### PR TITLE
Fix GDAL issue on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install: source scripts/install.sh
 
 script:
     - export GDAL_DATA=/home/travis/miniconda2/envs/wradlib/share/gdal
-    - xvfb-run coverage run --source wradlib testrunner.py -u
+    - xvfb-run coverage run --source wradlib testrunner.py -a
 
 after_success:
     - if [[ "$COVERALLS" == "true" ]]; then coveralls || echo "failed"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install: source scripts/install.sh
 
 script:
     - export GDAL_DATA=/home/travis/miniconda2/envs/wradlib/share/gdal
-    - xvfb-run coverage run --source wradlib testrunner.py -a
+    - xvfb-run coverage run --source wradlib testrunner.py -u
 
 after_success:
     - if [[ "$COVERALLS" == "true" ]]; then coveralls || echo "failed"; fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,7 +15,10 @@ source activate wradlib
 # Install wradlib dependencies
 conda install -c https://conda.anaconda.org/anaconda --yes numpy scipy matplotlib netcdf4 proj4
 
-conda install -c https://conda.anaconda.org/anaconda --yes sphinx gdal numpydoc h5py geos
+conda install -c https://conda.anaconda.org/anaconda --yes sphinx numpydoc h5py
+# Installing libgdal is required to get the lastest build.
+# The build installed by default  2.0.0_0 is broken.
+conda install -c https://conda.anaconda.org/anaconda --yes gdal geos libgdal
 # install krb5 for gdal
 conda install -c https://conda.anaconda.org/anaconda --yes krb5
 ls -lart /home/travis/miniconda2/envs/wradlib/share/gdal


### PR DESCRIPTION
Explicitly conda install libgdal on Travis CI to insure the latest version of libgdal is install in the conda environment.

closes #26