### PR TITLE
Prepare PR for v0.8.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ after_success:
 
 deploy:
   provider: pypi
-  server: https://testpypi.python.org/pypi
+  server: https://pypi.python.org/pypi
   user: wradlib
   password:
     secure: rKiAS61oDiuV2uJvkP2aiXt8hb7boU2p35RWiTLS8b5pSo/BWysThOIf1jmz5GQIpI8uYU+5GajlgtGVq8GmOxprexDgwTfMFF2bsblfUuZwYM3R1tPQuo2poAZ1/m0jPCul60vJJ31B2wEzsneo4tvbM4a7mAoBMMA5auli5o3eVo4P8xnXziMbw/l53bnl+ZYv7qocbt9RIsrgckAdfjLkZy8gAgDxcYXGGybg6K8VN/twSZGMIJfOvjkONhOtRfsiUc8fEu2hF6+HjQfSC07jue4KDPzo3s9hrAS6+fB0v8MV4UsB710VsrqoPuIfhBRo+xj8tW7Y2MPzJq/6kPBrVoQwV7gLTxZ7IWy5y4/Si78rxhXZIKDzo2VS4tNq1wo6xfGXv8pbzal7TOljqzK+ekXJBsXgdVUiGisZJLHTnPr0rkjwY7qzW+mqPqnpLLTCoHYWQE9AlrEQI3jP1FejGB5iyv/A3kDhjaerFkXlu5TXfkE44EpoKp8uURCNdzNiFoACv/68w3BJmWI0IkQR+YWZEBQm0xySMj8zLd5qrhqX/0u2crEC2uUPEQnkwNF1X8fOz3KFozY68KYsvSmIqKPlJFWSpzXYzMzqFnpvSumgb+g8FK/UppmMpukeQXTVSMGHY9k0Hi6I/WoGgmlDMksRB4fMUG0nZXdOqyM=

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -11,8 +11,31 @@ Bleeding Edge
 
 **Highlights**
 
-wradlib goes python3. The whole package was made python3-ready. The package is ready to run under python2.7.X and python3.5. All needed dependencies are also python3 ready.
-While doing the transformation not only code was adapted. Docstrings, tests and examples as well as the documentation were reviewed. All tests are performing good on python27 and python3.5
+nothing so far
+
+
+Version 0.8.0
+-------------
+
+**Highlights**
+
+* As of now wradlib is python3 compatible.
+* Docstrings, tests and examples as well as the documentation have been reviewed and fixed.
+* main wradlib repository is now hosted `here on github <https://github.com/wradlib/wradlib>`_.
+* wradlib docs are now hosted `on github, but with custom domain <http://wradlib.org/wradlib-docs/>`_.
+
+**New features**
+
+wradlib is constantly tested on `travis-ci wradlib <https://travis-ci.org/wradlib/wradlib>`_ within a miniconda python environment with the latest python27, python34 and python35 interpreters on linux OS.
+We also check code coverage for all pull requests and additions with `coveralls <https://coveralls.io/github/wradlib/wradlib>`_.
+
+**Deprecated features**
+
+*None.*
+
+**Removed functions**
+
+* `georef.create_projstr`, also removed deprecated decorators
 
 
 Version 0.7.0
@@ -22,7 +45,7 @@ Version 0.7.0
 
 New *experimental* module ``zonalstats``: it supports computation of zonal statistics (so far mean and variance) for target polygons. 
 Typical applications would be the computation of average catchment rainfall from polar or cartesian grids. Check out the 
-`module documentation <http://wradlib.github.io/wradlib-docs/zonalstats.html>`_ and the new examples.
+`module documentation <http://wradlib.github.io/wradlib-docs/latest/zonalstats.html>`_ and the new examples.
 
 
 Version 0.6.0
@@ -111,7 +134,7 @@ Version 0.4.0
 
 **New features**
 
-- comprehensive RADOLAN tutorial, examples, and example data: http://wradlib.github.io/wradlib-docs/tutorial_radolan_format.html
+- comprehensive RADOLAN tutorial, examples, and example data: http://wradlib.github.io/wradlib-docs/latest/tutorial_radolan_format.html
 - enhanced :doc:`generated/wradlib.io.read_RADOLAN_composite` to read EX product
 - :doc:`generated/wradlib.georef.get_radolan_grid`
 
@@ -135,13 +158,13 @@ However, the most important change introduced with this release was to remove a 
 
 In addition, we removed three outdated tutorial (on clutter detection, convertion and rainfall accumulation) and replaced the two latter by a more concise tutorial "Converting reflectivity to rainfall".
 
-Finally, we use one "central" bibliography for literature cross-referencing now (see http://wradlib.github.io/wradlib-docs/zreferences.html).
+Finally, we use one "central" bibliography for literature cross-referencing now (see http://wradlib.github.io/wradlib-docs/latest/zreferences.html).
 
 **New features**
 
 - New style of online docs (http://wradlib.github.io/wradlib-docs), using sphinx_rtd_theme
-- Added Tutorial http://wradlib.github.io/wradlib-docs/tutorial_get_rainfall.html
-- New organisation of bibliography: http://wradlib.github.io/wradlib-docs/zreferences.html
+- Added Tutorial http://wradlib.github.io/wradlib-docs/latest/tutorial_get_rainfall.html
+- New organisation of bibliography: http://wradlib.github.io/wradlib-docs/latest/zreferences.html
 
 **Deprecated features**
 

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,9 @@ LICENSE = 'MIT'
 CLASSIFIERS = filter(None, CLASSIFIERS.split('\n'))
 PLATFORMS = ["Linux", "Mac OS-X", "Unix"]
 MAJOR = 0
-MINOR = 7
-MICRO = 7
-ISRELEASED = False
+MINOR = 8
+MICRO = 0
+ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 

--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -1843,7 +1843,7 @@ def to_AAIGrid(fpath, data, xllcorner, yllcorner, cellsize,
     the function will also try to write an accompanying projection (``.prj``) 
     file that has the same file name, but a different extension.
     
-    Please refer to http://wradlib.github.io/wradlib-docs/georef.html to see how to
+    Please refer to http://wradlib.github.io/wradlib-docs/latest/georef.html to see how to
     create SpatialReference objects from e.g. :doc:`EPSG codes <wradlib.georef.epsg_to_osr>`,
     :doc:`proj4 strings <wradlib.georef.proj4_to_osr>`,
     or :doc:`WKT strings <wradlib.georef.wkt_to_osr>`. Other projections
@@ -1947,7 +1947,7 @@ def to_GeoTIFF(fpath, data, geotransform, nodata=-9999, proj=None):
     stereographic projections between GDAL and ESRI ArcGIS.
     
     The projection information (argument ``proj``) needs to be passed as a GDAL 
-    SpatialReference object. Refer to https://wradlib.github.io/wradlib-docs/georef.html
+    SpatialReference object. Refer to https://wradlib.github.io/wradlib-docs/latest/georef.html
     to see how to create SpatialReference objects from e.g. 
     :doc:`EPSG codes <wradlib.georef.epsg_to_osr>`,
     :doc:`proj4 strings <wradlib.georef.proj4_to_osr>`,

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -168,7 +168,7 @@ class OptionalModuleStub(object):
         self.name = name
 
     def __getattr__(self, name):
-        link = 'https://wradlib.github.io/wradlib-docs/gettingstarted.html#optional-dependencies'
+        link = 'https://wradlib.github.io/wradlib-docs/latest/gettingstarted.html#optional-dependencies'
         raise AttributeError('Module "' + self.name +
                              '" is not installed.\n\n' +
                              'You tried to access function/module/attribute "' +
@@ -219,7 +219,7 @@ def import_optional(module):
     from module "nonexistentmodule".
     This module is optional right now in wradlib.
     You need to separately install this dependency.
-    Please refer to https://wradlib.github.io/wradlib-docs/gettingstarted.html#optional-dependencies
+    Please refer to https://wradlib.github.io/wradlib-docs/latest/gettingstarted.html#optional-dependencies
     for further instructions.
     """
     try:


### PR DESCRIPTION
This is the last PR before release of v0.8.0

* checked version, ISRELEASED in setup.py
* fixed some links to wradlib-docs (need to point to latest)
* updated release_notes

closes #6 