### PR TITLE
ENH: convert tutorial_radolan_format.rst to notebook 

### DIFF
--- a/doc/source/notebooks.rst
+++ b/doc/source/notebooks.rst
@@ -10,7 +10,7 @@ also consider to have look at the code examples distributed with the source code
    
    wradlib_introduction.ipynb
    simple_plot.ipynb
-   radolan_showcase.ipynb
+   radolan.ipynb
 
 
 

--- a/notebooks/radolan.ipynb
+++ b/notebooks/radolan.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the wradlib documentation: http://wradlib.org/wradlib-docs.\n",
+    "\n",
+    "Copyright (c) 2016, wradlib developers.\n",
+    "Distributed under the MIT License. See LICENSE.txt for more info."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RADOLAN "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RADOLAN is abbreviated from the german **RA**dar-**O**n**L**ine-**AN**eichung, which means Radar-Online-Adjustment.\n",
+    "\n",
+    "Using it's [network of 17 weather radar](https://www.dwd.de/SharedDocs/broschueren/DE/presse/Wetterradar_PDF.pdf?__blob=publicationFile&v=5>) the German Weather Service provides many products for high resolution precipitation analysis and forecast. A comprehensive product list can be found in chapter [RADOLAN Product Showcase](radolan_showcase.ipynb).\n",
+    "\n",
+    "These composite products are distributed in the [RADOLAN Binary Data Format](radolan_format.ipynb) with an ASCII header. All composites are available in [Polar Stereographic Projection](radolan_grid.ipynb#Polar-Stereographic-Projection) which will be discussed in the chapter [RADOLAN Grid](radolan_grid.ipynb)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx-toctree": {
+     "maxdepth": 2
+    }
+   },
+   "source": [
+    "[RADOLAN Quick Start](radolan_quickstart.ipynb)\n",
+    "[RADOLAN Binary Data Format](radolan_format.ipynb)\n",
+    "[RADOLAN Product Showcase](radolan_showcase.ipynb)\n",
+    "[RADOLAN Grid](radolan_grid.ipynb)\n",
+    "[DWD Radar Network](radolan_network.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook tutorial was prepared with material from the [DWD RADOLAN/RADVOR-OP Kompositformat](http://www.dwd.de/DE/leistungen/radolan/radolan_info/radolan_radvor_op_komposit_format_pdf.pdf?__blob=publicationFile&v=5>).\n",
+    "We also wish to thank Elmar Weigl, German Weather Service, for providing the extensive set of example data and his valuable information about the RADOLAN products."
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/radolan_format.ipynb
+++ b/notebooks/radolan_format.ipynb
@@ -1,0 +1,163 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the wradlib documentation: http://wradlib.org/wradlib-docs.\n",
+    "\n",
+    "Copyright (c) 2016, wradlib developers.\n",
+    "Distributed under the MIT License. See LICENSE.txt for more info."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RADOLAN binary data format"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The RADOLAN binary data file format is described in the RADOLAN Kompositformat. The radolan composite files consists of an ascii header containing all needed information to decode the following binary data block. *wradlib* provides [wradlib.io.read_RADOLAN_composite()](generated/wradlib.io.read_RADOLAN_composite.rst) to read the data.\n",
+    "\n",
+    "The function `wradlib.io.parse_DWD_quant_composite_header()` takes care of correctly decoding the ascii header. All available header information is transferred into the metadata dictionary."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import wradlib as wrl\n",
+    "import matplotlib.pyplot as pl\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "try:\n",
+    "    get_ipython().magic(\"matplotlib inline\")\n",
+    "except:\n",
+    "    pl.ion()\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# load radolan files\n",
+    "rw_filename = wrl.util.get_wradlib_data_file('radolan/misc/raa01-rw_10000-1408102050-dwd---bin.gz')\n",
+    "filehandle = wrl.io.get_radolan_filehandle(rw_filename)\n",
+    "header = wrl.io.read_radolan_header(filehandle)\n",
+    "print(header)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "attrs = wrl.io.parse_DWD_quant_composite_header(header)\n",
+    "print(attrs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the following example, the header information of four different composites is extracted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# load radolan file\n",
+    "filename = 'radolan/showcase/raa01-rx_10000-1408102050-dwd---bin.gz'\n",
+    "rx_filename = wrl.util.get_wradlib_data_file(filename)\n",
+    "filename = 'radolan/showcase/raa01-ex_10000-1408102050-dwd---bin.gz'\n",
+    "ex_filename = wrl.util.get_wradlib_data_file(filename)\n",
+    "filename = 'radolan/showcase/raa01-rw_10000-1408102050-dwd---bin.gz'\n",
+    "rw_filename = wrl.util.get_wradlib_data_file(filename)\n",
+    "filename = 'radolan/showcase/raa01-sf_10000-1408102050-dwd---bin.gz'\n",
+    "sf_filename = wrl.util.get_wradlib_data_file(filename)\n",
+    "\n",
+    "rxdata, rxattrs = wrl.io.read_RADOLAN_composite(rx_filename)\n",
+    "exdata, exattrs = wrl.io.read_RADOLAN_composite(ex_filename)\n",
+    "rwdata, rwattrs = wrl.io.read_RADOLAN_composite(rw_filename)\n",
+    "sfdata, sfattrs = wrl.io.read_RADOLAN_composite(sf_filename)\n",
+    "\n",
+    "# print the available attributes\n",
+    "print(\"RX Attributes:\")\n",
+    "for key, value in rxattrs.items():\n",
+    "    print(key + ':', value)\n",
+    "print(\"----------------------------------------------------------------\")\n",
+    "# print the available attributes\n",
+    "print(\"EX Attributes:\")\n",
+    "for key, value in exattrs.items():\n",
+    "    print(key + ':', value)\n",
+    "print(\"----------------------------------------------------------------\")\n",
+    "\n",
+    "# print the available attributes\n",
+    "print(\"RW Attributes:\")\n",
+    "for key, value in rwattrs.items():\n",
+    "    print(key + ':', value)\n",
+    "print(\"----------------------------------------------------------------\")\n",
+    "\n",
+    "# print the available attributes\n",
+    "print(\"SF Attributes:\")\n",
+    "for key, value in sfattrs.items():\n",
+    "    print(key + ':', value)\n",
+    "print(\"----------------------------------------------------------------\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/radolan_grid.ipynb
+++ b/notebooks/radolan_grid.ipynb
@@ -1,0 +1,382 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the wradlib documentation: http://wradlib.org/wradlib-docs.\n",
+    "\n",
+    "Copyright (c) 2016, wradlib developers.\n",
+    "Distributed under the MIT License. See LICENSE.txt for more info."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RADOLAN Grid"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Polar Stereographic Projection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The projected composite raster is equidistant with a grid-spacing of 1.0 km in most cases. There are composites which have 2.0 km grid-spacing (e.g. PC).\n",
+    "\n",
+    "There are three different grid sizes, the well-known 900 rows by 900 columns (normal), 1500 rows by 1400 columns (extended, european) and 460 rows by 460 columns (small).\n",
+    "\n",
+    "Common to all is that the plane of projection intersects the earth sphere at $\\phi_0 = 60.0^{\\circ}N$. The cartesian co-ordinate system is aligned parallel to the $\\lambda_0 = 10.0^{\\circ}E$ meridian.\n",
+    "\n",
+    "The reference point ($\\lambda_m$, $\\phi_m$) is $9.0^{\\circ}E$ and $51.0^{\\circ}N$, which is the center of the two smaller grids. The extended grid has an offset in respect to this reference point of 350km by 150km.\n",
+    "\n",
+    "The earth as sphere with an radius of 6370.04 km is used for all calculations.\n",
+    "\n",
+    "With formulas (1), (2) and (3) the geographic reference points (lambda, phi) can be converted to projected cartesian coordinates. The calculated (x y) is the distance vector to the origign of the cartesian coordinate system (north pole).\n",
+    "\n",
+    "\\begin{equation}\n",
+    "x = R * M(\\phi) * cos(\\phi) * sin(\\lambda - \\lambda_0)\n",
+    "\\tag{1}\n",
+    "\\end{equation}\n",
+    "\n",
+    "\\begin{equation}\n",
+    "y = -R * M(\\phi) * cos(\\phi) * cos(\\lambda - \\lambda_0)\n",
+    "\\tag{2}\n",
+    "\\end{equation}\n",
+    "\n",
+    "\\begin{equation}\n",
+    "M(\\phi) =  \\frac {1 + sin(\\phi_0)} {1 + sin(\\phi)}\n",
+    "\\tag{3}\n",
+    "\\end{equation}\n",
+    "\n",
+    "Assumed the point ($10.0^{\\circ}E$, $90.0^{\\circ}N$) is defined as coordinate system origin. Then all ccordinates can be calculated with the known grid-spacing d as:\n",
+    "\n",
+    "\\begin{equation}\n",
+    "x = x_0 + d * (j - j_0)\n",
+    "\\tag{4}\n",
+    "\\end{equation}\n",
+    "\n",
+    "\\begin{equation}\n",
+    "y = y_0 + d * (i - i_0)\n",
+    "\\tag{5}\n",
+    "\\end{equation}\n",
+    "\n",
+    "with i, j as cartesian indices.\n",
+    "\n",
+    "*wradlib* provides the convenience function [wradlib.georef.get_radolan_grid()](generated/wradlib.georef.get_radolan_grid.rst) which returns the radolan grid for further processing. It takes `nrows` and `ncols` as parameters and returns the projected cartesian coordinates or the wgs84 coordinates (keyword arg wgs84=True) as numpy ndarray (nrows x ncols x 2)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import wradlib as wrl\n",
+    "import matplotlib.pyplot as pl\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "try:\n",
+    "    get_ipython().magic(\"matplotlib inline\")\n",
+    "except:\n",
+    "    pl.ion()\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "radolan_grid_xy = wrl.georef.get_radolan_grid(900,900)\n",
+    "print(\"{0}, ({1:.4f}, {2:.4f})\".format(radolan_grid_xy.shape, *radolan_grid_xy[0,0,:]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "radolan_grid_ll = wrl.georef.get_radolan_grid(900,900, wgs84=True)\n",
+    "print(\"{0}, ({1:.4f}, {2:.4f})\".format(radolan_grid_ll.shape, *radolan_grid_ll[0,0,:]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inverse Polar Stereographic Projection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The geographic coordinates of specific datapoints can be calculated by using the cartesian coordinates (x,y) and the following formulas:\n",
+    "\n",
+    "\\begin{equation}\n",
+    "\\lambda = \\arctan\\left(\\frac {-x} {y}\\right) + \\lambda_0\n",
+    "\\tag{6}\n",
+    "\\end{equation}\n",
+    "   \n",
+    "\\begin{equation}\n",
+    "\\phi = \\arcsin\\left(\\frac {R^2 * \\left(1 + \\sin\\phi_0\\right)^2 - \\left(x^2 + y^2\\right)} {R^2 * \\left(1 + \\sin\\phi_0\\right)^2 + \\left(x^2 + y^2\\right)}\\right)\n",
+    "\\tag{7}\n",
+    "\\end{equation}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Standard Formats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### WKT-String"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The German Weather Service provides a [WKT-string](https://kunden.dwd.de/geoserver/web/?wicket:bookmarkablePage=:org.geoserver.web.demo.SRSDescriptionPage&code=EPSG:1000001). This WKT (well known text) is used to create the osr-object representation of the radolan projection.\n",
+    "\n",
+    "For the scale_factor the intersection of the projection plane with the earth sphere at $60.0^{\\circ}N$ has to be taken into account:\n",
+    "\n",
+    "\\begin{equation}\n",
+    "scale\\_factor = \\frac {1 + \\sin\\left(60.^{\\circ}\\right)} {1 + \\sin\\left(90.^{\\circ}\\right)} = 0.93301270189\n",
+    "\\tag{8}\n",
+    "\\end{equation}\n",
+    "\n",
+    "Also, the `PROJECTION[\"Stereographic_North_Pole\"]` isn't known within GDAL/OSR. It has to be changed to the known `PROJECTION[\"polar_stereographic\"]`.\n",
+    "\n",
+    "With these adaptions we finally yield the Radolan Projection as WKT-string. This WKT-string is used within *wradlib* to create the osr-object by using the helper-function [wradlib.georef.create_osr()](generated/wradlib.georef.create_osr.rst)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "proj_stereo = wrl.georef.create_osr(\"dwd-radolan\")\n",
+    "print(proj_stereo)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### PROJ.4"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the above WKT-String the PROJ.4 representation can be derived as:\n",
+    "\n",
+    "```python\n",
+    "    +proj=stere +lat_0=90 +lat_ts=90 +lon_0=10 +k=0.93301270189\n",
+    "    +x_0=0 +y_0=0 +a=6370040 +b=6370040 +to_meter=1000 +no_defs\n",
+    "```\n",
+    "\n",
+    "This PROJ.4-string can also be used to create the osr-object by using the helper-function [wradlib.georef.proj4_to_osr()](generated/wradlib.georef.proj4_to_osr.rst):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# create radolan projection osr object\n",
+    "dwd_string = ('+proj=stere +lat_0=90 +lat_ts=90 +lon_0=10 +k=0.93301270189' \n",
+    "              '+x_0=0 +y_0=0 +a=6370040 +b=6370040 +to_meter=1000 +no_defs')\n",
+    "proj_stereo = wrl.georef.proj4_to_osr(dwd_string)\n",
+    "print(proj_stereo)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Grid Reprojection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Within *wradlib* the [wradlib.georef.reproject()](generated/wradlib.georef.reproject.rst) function can be used to convert the radolan grid data from xy-space to lonlat-space and back. First, we need to create the necessary Spatial Reference Objects for the RADOLAN-projection and wgs84."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from osgeo import osr\n",
+    "proj_stereo = wrl.georef.create_osr(\"dwd-radolan\")\n",
+    "proj_wgs = osr.SpatialReference()\n",
+    "proj_wgs.ImportFromEPSG(4326)\n",
+    "print(proj_wgs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then, we call `reproject` with the osr-objects as `projection_source` and `projection_target` parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "radolan_grid_ll = wrl.georef.reproject(radolan_grid_xy, projection_source=proj_stereo, projection_target=proj_wgs)\n",
+    "print(\"{0}, ({1:.4f}, {2:.4f})\".format(radolan_grid_ll.shape, *radolan_grid_ll[0,0,:]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And the other way round."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "radolan_grid_xy = wrl.georef.reproject(radolan_grid_ll, projection_source=proj_wgs, projection_target=proj_stereo)\n",
+    "print(\"{0}, ({1:.4f}, {2:.4f})\".format(radolan_grid_xy.shape, *radolan_grid_xy[0,0,:]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the following example the RADOLAN grid is projected to wgs84 and GaussKrüger Zone3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# create Gauss Krueger zone 3 projection osr object\n",
+    "proj_gk3 = osr.SpatialReference()\n",
+    "proj_gk3.ImportFromEPSG(31467)\n",
+    "\n",
+    "# transform radolan polar stereographic projection to wgs84 and then to gk3\n",
+    "radolan_grid_ll = wrl.georef.reproject(radolan_grid_xy,\n",
+    "                                       projection_source=proj_stereo,\n",
+    "                                       projection_target=proj_wgs)\n",
+    "radolan_grid_gk = wrl.georef.reproject(radolan_grid_ll,\n",
+    "                                       projection_source=proj_wgs,\n",
+    "                                       projection_target=proj_gk3)\n",
+    "\n",
+    "lon_wgs0 = radolan_grid_ll[:, :, 0]\n",
+    "lat_wgs0 = radolan_grid_ll[:, :, 1]\n",
+    "\n",
+    "x_gk3 = radolan_grid_gk[:, :, 0]\n",
+    "y_gk3 = radolan_grid_gk[:, :, 1]\n",
+    "\n",
+    "x_rad = radolan_grid_xy[:, :, 0]\n",
+    "y_rad = radolan_grid_xy[:, :, 1]\n",
+    "\n",
+    "print(\"\\n------------------------------\")\n",
+    "print(\"source radolan x,y-coordinates\")\n",
+    "print(u\"       {0}      {1} \".format('x [km]', 'y [km]'))\n",
+    "print(\"ll: {:10.4f} {:10.3f} \".format(x_rad[0, 0], y_rad[0, 0]))\n",
+    "print(\"lr: {:10.4f} {:10.3f} \".format(x_rad[0, -1], y_rad[0, -1]))\n",
+    "print(\"ur: {:10.4f} {:10.3f} \".format(x_rad[-1, -1], y_rad[-1, -1]))\n",
+    "print(\"ul: {:10.4f} {:10.3f} \".format(x_rad[-1, 0], y_rad[-1, 0]))\n",
+    "print(\"\\n--------------------------------------\")\n",
+    "print(\"transformed radolan lonlat-coordinates\")\n",
+    "print(u\"      {0}  {1} \".format('lon [degE]', 'lat [degN]'))\n",
+    "print(\"ll: {:10.4f}  {:10.4f} \".format(lon_wgs0[0, 0], lat_wgs0[0, 0]))\n",
+    "print(\"lr: {:10.4f}  {:10.4f} \".format(lon_wgs0[0, -1], lat_wgs0[0, -1]))\n",
+    "print(\"ur: {:10.4f}  {:10.4f} \".format(lon_wgs0[-1, -1], lat_wgs0[-1, -1]))\n",
+    "print(\"ul: {:10.4f}  {:10.4f} \".format(lon_wgs0[-1, 0], lat_wgs0[-1, 0]))\n",
+    "print(\"\\n-----------------------------------\")\n",
+    "print(\"transformed radolan gk3-coordinates\")\n",
+    "print(u\"     {0}   {1} \".format('easting [m]', 'northing [m]'))\n",
+    "print(\"ll: {:10.0f}   {:10.0f} \".format(x_gk3[0, 0], y_gk3[0, 0]))\n",
+    "print(\"lr: {:10.0f}   {:10.0f} \".format(x_gk3[0, -1], y_gk3[0, -1]))\n",
+    "print(\"ur: {:10.0f}   {:10.0f} \".format(x_gk3[-1, -1], y_gk3[-1, -1]))\n",
+    "print(\"ul: {:10.0f}   {:10.0f} \".format(x_gk3[-1, 0], y_gk3[-1, 0]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/notebooks/radolan_network.ipynb
+++ b/notebooks/radolan_network.ipynb
@@ -1,0 +1,355 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the wradlib documentation: http://wradlib.org/wradlib-docs.\n",
+    "\n",
+    "Copyright (c) 2016, wradlib developers.\n",
+    "Distributed under the MIT License. See LICENSE.txt for more info."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RADOLAN Radar Network"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this chapter the RW-product is shown in WGS84 and the RADOLAN [Polar Stereographic Projection](radolan_grid.ipynb#Polar-Stereographic-Projection). All for the compositing process used radars are extracted from the metadata and plotted with their respective maximum range rings and location information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import wradlib as wrl\n",
+    "import matplotlib.pyplot as pl\n",
+    "import matplotlib as mpl\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "try:\n",
+    "    get_ipython().magic(\"matplotlib inline\")\n",
+    "except:\n",
+    "    pl.ion()\n",
+    "import numpy as np\n",
+    "from osgeo import osr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def get_radar_locations():\n",
+    "    radars = {}\n",
+    "    radar = {'name': 'ASR Dresden', 'wmo': 10487, 'lon': 13.76347,\n",
+    "             'lat': 51.12404, 'alt': 261}\n",
+    "    radars['ASD'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Boostedt', 'wmo': 10132, 'lon': 10.04687,\n",
+    "             'lat': 54.00438, 'alt': 124.56}\n",
+    "    radars['BOO'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Dresden', 'wmo': 10488, 'lon': 13.76865, 'lat': 51.12465,\n",
+    "             'alt': 263.36}\n",
+    "    radars['DRS'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Eisberg', 'wmo': 10780, 'lon': 12.40278, 'lat': 49.54066,\n",
+    "             'alt': 798.79}\n",
+    "    radars['EIS'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Emden', 'wmo': 10204, 'lon': 7.02377, 'lat': 53.33872,\n",
+    "             'alt': 58}\n",
+    "    radars['EMD'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Essen', 'wmo': 10410, 'lon': 6.96712, 'lat': 51.40563,\n",
+    "             'alt': 185.10}\n",
+    "    radars['ESS'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Feldberg', 'wmo': 10908, 'lon': 8.00361, 'lat': 47.87361,\n",
+    "             'alt': 1516.10}\n",
+    "    radars['FBG'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Flechtdorf', 'wmo': 10440, 'lon': 8.802, 'lat': 51.3112,\n",
+    "             'alt': 627.88}\n",
+    "    radars['FLD'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Hannover', 'wmo': 10339, 'lon': 9.69452, 'lat': 52.46008,\n",
+    "             'alt': 97.66}\n",
+    "    radars['HNR'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Neuhaus', 'wmo': 10557, 'lon': 11.13504, 'lat': 50.50012,\n",
+    "             'alt': 878.04}\n",
+    "    radars['NEU'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Neuheilenbach', 'wmo': 10605, 'lon': 6.54853,\n",
+    "             'lat': 50.10965, 'alt': 585.84}\n",
+    "    radars['NHB'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Offenthal', 'wmo': 10629, 'lon': 8.71293, 'lat': 49.9847,\n",
+    "             'alt': 245.80}\n",
+    "    radars['OFT'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Proetzel', 'wmo': 10392, 'lon': 13.85821,\n",
+    "             'lat': 52.64867, 'alt': 193.92}\n",
+    "    radars['PRO'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Memmingen', 'wmo': 10950, 'lon': 10.21924,\n",
+    "             'lat': 48.04214, 'alt': 724.40}\n",
+    "    radars['MEM'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Rostock', 'wmo': 10169, 'lon': 12.05808, 'lat': 54.17566,\n",
+    "             'alt': 37}\n",
+    "    radars['ROS'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Isen', 'wmo': 10873, 'lon': 12.10177, 'lat': 48.1747,\n",
+    "             'alt': 677.77}\n",
+    "    radars['ISN'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Tuerkheim', 'wmo': 10832, 'lon': 9.78278,\n",
+    "             'lat': 48.58528, 'alt': 767.62}\n",
+    "    radars['TUR'] = radar\n",
+    "\n",
+    "    radar = {'name': 'Ummendorf', 'wmo': 10356, 'lon': 11.17609,\n",
+    "             'lat': 52.16009, 'alt': 183}\n",
+    "    radars['UMM'] = radar\n",
+    "\n",
+    "    return radars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# load radolan file\n",
+    "rw_filename = wrl.util.get_wradlib_data_file('radolan/showcase/raa01-rw_10000-1408102050-dwd---bin.gz')\n",
+    "rwdata, rwattrs = wrl.io.read_RADOLAN_composite(rw_filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# print the available attributes\n",
+    "print(\"RW Attributes:\", rwattrs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# mask data\n",
+    "sec = rwattrs['secondary']\n",
+    "rwdata.flat[sec] = -9999\n",
+    "rwdata = np.ma.masked_equal(rwdata, -9999)\n",
+    "\n",
+    "# create radolan projection object\n",
+    "proj_stereo = wrl.georef.create_osr(\"dwd-radolan\")\n",
+    "\n",
+    "# create wgs84 projection object\n",
+    "proj_wgs = osr.SpatialReference()\n",
+    "proj_wgs.ImportFromEPSG(4326)\n",
+    "\n",
+    "# get radolan grid\n",
+    "radolan_grid_xy = wrl.georef.get_radolan_grid(900, 900)\n",
+    "x1 = radolan_grid_xy[:, :, 0]\n",
+    "y1 = radolan_grid_xy[:, :, 1]\n",
+    "\n",
+    "# convert to lonlat\n",
+    "radolan_grid_ll = wrl.georef.reproject(radolan_grid_xy,\n",
+    "                                       projection_source=proj_stereo,\n",
+    "                                       projection_target=proj_wgs)\n",
+    "lon1 = radolan_grid_ll[:, :, 0]\n",
+    "lat1 = radolan_grid_ll[:, :, 1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# range array 150 km\n",
+    "print(\"Max Range: \", rwattrs['maxrange'])\n",
+    "r = np.arange(1, 151) * 1000\n",
+    "# azimuth array 1 degree spacing\n",
+    "az = np.linspace(0, 360, 361)[0:-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# get radar dict\n",
+    "radars = get_radar_locations()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "def plot_radar(radar, ax, reproject=False):\n",
+    "    \n",
+    "    x_loc, y_loc = (radar['lon'], radar['lat'])\n",
+    "    \n",
+    "    # build polygons for maxrange rangering\n",
+    "    polygons = wrl.georef.polar2polyvert(r, az,\n",
+    "                                         (x_loc, y_loc))\n",
+    "    polygons.shape = (len(az), len(r), 5, 2)\n",
+    "    polygons = polygons[:, -1, :, :]\n",
+    "    \n",
+    "    \n",
+    "    \n",
+    "    if reproject:\n",
+    "        # reproject to radolan polar stereographic projection\n",
+    "        polygons = wrl.georef.reproject(polygons,\n",
+    "                                        projection_source=proj_wgs,\n",
+    "                                        projection_target=proj_stereo)\n",
+    "        \n",
+    "        # reproject lonlat radar location coordinates to\n",
+    "        # polar stereographic projection\n",
+    "        x_loc, y_loc = wrl.georef.reproject(x_loc, y_loc,\n",
+    "                                            projection_source=proj_wgs,\n",
+    "                                            projection_target=proj_stereo)\n",
+    "        \n",
+    "\n",
+    "    # create PolyCollections and add to respective axes\n",
+    "    polycoll = mpl.collections.PolyCollection(polygons, closed=True,\n",
+    "                                              edgecolors='r',\n",
+    "                                              facecolors='r')\n",
+    "    ax.add_collection(polycoll, autolim=True)\n",
+    "    \n",
+    "    # plot radar location and information text\n",
+    "    ax.plot(x_loc, y_loc, 'r+')\n",
+    "    ax.text(x_loc, y_loc, radar['name'], color='r')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# plot two projections side by side\n",
+    "fig1 = pl.figure(figsize=(10,8))\n",
+    "ax1 = fig1.add_subplot(111, aspect='equal')\n",
+    "pm = ax1.pcolormesh(lon1, lat1, rwdata, cmap='spectral')\n",
+    "cb = fig1.colorbar(pm, shrink=0.75)\n",
+    "cb.set_label(\"mm/h\")\n",
+    "pl.xlabel(\"Longitude \")\n",
+    "pl.ylabel(\"Latitude\")\n",
+    "pl.title(\n",
+    "    'RADOLAN RW Product \\n' + rwattrs['datetime'].isoformat() + '\\n WGS84')\n",
+    "pl.xlim((lon1[0, 0], lon1[-1, -1]))\n",
+    "pl.ylim((lat1[0, 0], lat1[-1, -1]))\n",
+    "pl.grid(color='r')\n",
+    "for radar_id in rwattrs['radarlocations']:\n",
+    "    # get radar coords etc from dict\n",
+    "    # repair Ummendorf ID\n",
+    "    if radar_id == 'umd':\n",
+    "        radar_id = 'umm'\n",
+    "    radar = radars[radar_id.upper()]\n",
+    "    plot_radar(radar, ax1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fig2 = pl.figure(figsize=(10,8))\n",
+    "ax2 = fig2.add_subplot(111, aspect='equal')\n",
+    "pm = ax2.pcolormesh(x1, y1, rwdata, cmap='spectral')\n",
+    "cb = fig2.colorbar(pm, shrink=0.75)\n",
+    "cb.set_label(\"mm/h\")\n",
+    "pl.xlabel(\"x [km]\")\n",
+    "pl.ylabel(\"y [km]\")\n",
+    "pl.title('RADOLAN RW Product \\n' + rwattrs[\n",
+    "    'datetime'].isoformat() + '\\n Polar Stereographic Projection')\n",
+    "pl.xlim((x1[0, 0], x1[-1, -1]))\n",
+    "pl.ylim((y1[0, 0], y1[-1, -1]))\n",
+    "pl.grid(color='r')\n",
+    "for radar_id in rwattrs['radarlocations']:\n",
+    "    # get radar coords etc from dict\n",
+    "    # repair Ummendorf ID\n",
+    "    if radar_id == 'umd':\n",
+    "        radar_id = 'umm'\n",
+    "    radar = radars[radar_id.upper()]\n",
+    "    plot_radar(radar, ax2, reproject=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/radolan_quickstart.ipynb
+++ b/notebooks/radolan_quickstart.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the wradlib documentation: http://wradlib.org/wradlib-docs.\n",
+    "\n",
+    "Copyright (c) 2016, wradlib developers.\n",
+    "Distributed under the MIT License. See LICENSE.txt for more info."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# RADOLAN Quick Start"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All RADOLAN composite products can be read by the following function:\n",
+    "\n",
+    "```python\n",
+    "data, metadata = wradlib.io.read_RADOLAN_composite(\"mydrive:/path/to/my/file/filename\")\n",
+    "```\n",
+    "\n",
+    "Here, ``data`` is a two dimensional integer or float array of shape (number of rows, number of columns). ``metadata`` is a dictionary which provides metadata from the files header section, e.g. using the keys `producttype`, `datetime`, `intervalseconds`, `nodataflag`.\n",
+    "\n",
+    "The [RADOLAN Grid](radolan_grid.ipynb) coordinates can be calculated with [wradlib.georef.get_radolan_grid()](generated/wradlib.georef.get_radolan_grid.rst).\n",
+    "\n",
+    "With the following code snippet the RW-product is shown in the [Polar Stereographic Projection](radolan_grid.ipynb#Polar-Stereographic-Projection)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import modules, filter warnings to avoid cluttering output with DeprecationWarnings and use matplotlib inline or interactive mode if running in ipython or python respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import wradlib as wrl\n",
+    "import matplotlib.pyplot as pl\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "try:\n",
+    "    get_ipython().magic(\"matplotlib inline\")\n",
+    "except:\n",
+    "    pl.ion()\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# load radolan files\n",
+    "rw_filename = wrl.util.get_wradlib_data_file('radolan/misc/raa01-rw_10000-1408102050-dwd---bin.gz')\n",
+    "rwdata, rwattrs = wrl.io.read_RADOLAN_composite(rw_filename)\n",
+    "# print the available attributes\n",
+    "print(\"RW Attributes:\", rwattrs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# do some masking\n",
+    "sec = rwattrs['secondary']\n",
+    "rwdata.flat[sec] = -9999\n",
+    "rwdata = np.ma.masked_equal(rwdata, -9999)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Get coordinates\n",
+    "radolan_grid_xy = wrl.georef.get_radolan_grid(900,900)\n",
+    "x = radolan_grid_xy[:,:,0]\n",
+    "y = radolan_grid_xy[:,:,1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# plot function\n",
+    "pl.pcolormesh(x, y, rwdata, cmap=\"spectral\")\n",
+    "cb = pl.colorbar(shrink=0.75)\n",
+    "cb.set_label(\"mm/h\")\n",
+    "pl.title('RADOLAN RW Product Polar Stereo \\n' + rwattrs['datetime'].isoformat())\n",
+    "pl.grid(color='r')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A much more comprehensive section using several RADOLAN composites is shown in chapter [RADOLAN Product Showcase](radolan_showcase.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Edit Metadata",
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/notebooks/radolan_showcase.ipynb
+++ b/notebooks/radolan_showcase.ipynb
@@ -2,6 +2,18 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
+   "source": [
+    "This notebook is part of the wradlib documentation: http://wradlib.org/wradlib-docs.\n",
+    "\n",
+    "Copyright (c) 2016, wradlib developers.\n",
+    "Distributed under the MIT License. See LICENSE.txt for more info."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# RADOLAN Product Showcase"
@@ -18,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Preliminary Setup"
+    "## Setup Environment"
    ]
   },
   {
@@ -32,12 +44,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
     "import wradlib as wrl\n",
     "import matplotlib.pyplot as pl\n",
+    "import matplotlib as mpl\n",
     "import warnings\n",
     "warnings.filterwarnings('ignore')\n",
     "try:\n",
@@ -131,6 +144,48 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "A few products including RW and SF are available free of charge at this [DWD FTP Server](ftp://ftp-cdc.dwd.de/pub/CDC/grids_germany/). A full list of RADOLAN products can be found in the [DWD RADOLAN/RADVOR-OP Kompositformat](https://www.dwd.de/DE/leistungen/radolan/radolan_info/radolan_radvor_op_komposit_format_pdf.pdf?__blob=publicationFile&v=5).\n",
+    "\n",
+    "Currently, most of the RADOLAN composites have a spatial resolution of 1km x 1km, with the [National Composites](#National-Composites) (R-, S- and W-series) being 900 x 900 km grids, and the [European Composites](#Extended-RADOLAN-Composites) 1500 x 1400 km grids. The polar-stereographic projection is described in the chapter [RADOLAN Grid](radolan_grid.ipynb).\n",
+    "\n",
+    "Also the [PG/PC-Product](#RADOLAN-PG/PC-Product) with 460 x 460 km grid and runlength-coding is shortly described."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## National Composites"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    " ID  |  INT  | avail | Description                         \n",
+    "---- | ----: | ----- | -----------\n",
+    " RX | 5 min | 5 min | original radardata in qualitative RVP6-units (1 byte coded)\n",
+    " RZ | 5 min | 5 min | radardata after correction of PBB converted to rainrate <br>with improved Z-R-relation        \n",
+    " RY | 5 min | 5 min | radardata after correction with <br>Quality-composit (QY)\n",
+    " RH | 1 h | 5 min | 1 h summation of RZ-composit\n",
+    " RB | 1 h | hh:50 | 1 h summation with preadjustment\n",
+    " RW | 1 h | hh:50 | 1 h summation with standard <br>adjustment \"best of two\"\n",
+    " RL | 1 h | hh:50 | 1 h summation with adjustment by Merging\n",
+    " RU | 1 h | hh:50 | 1 h summation with standard and <br>merging adjustment \"best of three\"\n",
+    " SQ | 6 h | hh:50 | 6 h summation of RW\n",
+    " SH | 12 h | hh:50 | 12 h summation of RW\n",
+    " SF | 24 h | hh:50 | 24 h summation of RW\n",
+    " W1 | 7 d  | 05:50 | 7 d summation of RW\n",
+    " W2 | 14 d | 05:50 | 14 d summation of RW\n",
+    " W3 | 21 d | 05:50 | 21 d summation of RW\n",
+    " W4 | 30 d | 05:50 | 30 d summation of RW\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### RADOLAN RX Product"
    ]
   },
@@ -145,7 +200,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -175,7 +230,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -200,7 +255,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -229,8 +284,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "scrolled": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -255,7 +309,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -284,7 +338,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -309,7 +363,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -338,7 +392,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -363,7 +417,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -392,7 +446,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -417,7 +471,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -446,7 +500,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -471,7 +525,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -500,7 +554,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -525,7 +579,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -554,7 +608,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -579,7 +633,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -608,7 +662,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -633,7 +687,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -662,7 +716,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -687,7 +741,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -716,7 +770,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -741,7 +795,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -770,7 +824,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -795,7 +849,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -824,64 +878,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plot_radolan(data, attrs, radolan_grid_xy, clabel='mm * h-1')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### RADOLAN W3 Product"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Load data from data source"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "data, attrs = read_radolan('raa01-w3_10000-1408110550-dwd---bin.gz')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Mask data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
     "collapsed": true
    },
    "outputs": [],
    "source": [
-    "data = np.ma.masked_equal(data, -9999)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
     "plot_radolan(data, attrs, radolan_grid_xy, clabel='mm * h-1')"
    ]
   },
@@ -889,61 +889,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### RADOLAN W4 Product"
+    "## Extended RADOLAN Composites"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Load data from data source"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "data, attrs = read_radolan('raa01-w4_10000-1408110550-dwd---bin.gz')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Mask data"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "data = np.ma.masked_equal(data, -9999)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "plot_radolan(data, attrs, radolan_grid_xy, clabel='mm * h-1')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Extended RADOLAN Composite"
+    "The common central european products with a range of 1500 km by 1400 km are presented in the following table:\n",
+    "\n",
+    " ID |  INT  | avail | Description\n",
+    "--- | ----: | ----- | ----------- \n",
+    " EX | 5 min | 5 min | analogue RX\n",
+    " EZ | 5 min | 5 min | analogue RZ\n",
+    " EY | 5 min | 5 min | analogue EY after correction <br>with Quality-composit\n",
+    " EH |  1 h  | hh:50 | analogue RH (no preadjustment) <br>1 h summation of EY-composite\n",
+    " EB |  1 h  | hh:50 | analogue RB (with preadjustment) <br>1 h summation\n",
+    " EW |  1 h  | hh:50 | analogue RW (full adjustment) <br>1 h summation\n"
    ]
   },
   {
@@ -964,7 +926,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -993,7 +955,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1018,7 +980,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1047,7 +1009,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1072,7 +1034,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1101,7 +1063,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1126,7 +1088,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1155,7 +1117,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1180,7 +1142,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -1209,15 +1171,106 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
     "plot_radolan(data, attrs, radolan_egrid_xy, clabel='mm * h-1')"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## RADOLAN PG/PC Product"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The PG/PC product is a bit different from the normal RADOLAN formats. The header is actually the same, but the data is runlength encoded. Also the RADOLAN grid cells have 2km edge length (460x460 cells)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load data from data source"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "radfile = 'raa00-pc_10015-1408030905-dwd---bin.gz'\n",
+    "radfile = wrl.util.get_wradlib_data_file('radolan/misc/' + radfile)\n",
+    "data, attrs = wrl.io.read_RADOLAN_composite(radfile, missing=255)\n",
+    "radolan_grid_pc = wrl.georef.get_radolan_grid(460,460)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Mask data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "data = np.ma.masked_equal(data, 255)\n",
+    "print(data.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# plot the images side by side\n",
+    "pl.figure(figsize=(10, 8))\n",
+    "pl.subplot(111, aspect='equal')\n",
+    "X = radolan_grid_pc[:,:,0]\n",
+    "Y = radolan_grid_pc[:,:,1]\n",
+    "# color-scheme taken from DWD \"legend_radar_products_pc.pdf\"\n",
+    "colors = ['lightgrey', 'yellow', 'lightblue', 'magenta', 'green',\n",
+    "          'red', 'darkblue', 'darkred']\n",
+    "cmap = mpl.colors.ListedColormap(colors, name=u'DWD-pc-scheme')\n",
+    "bounds = np.arange(len(colors) + 1)\n",
+    "norm = mpl.colors.BoundaryNorm(bounds, cmap.N)\n",
+    "pl.pcolormesh(X, Y, data, cmap=cmap, norm=norm)\n",
+    "pl.xlim((X[0,0], X[-1,-1]))\n",
+    "pl.ylim((Y[0,0], Y[-1,-1]))\n",
+    "\n",
+    "# add colorbar and do some magic for proper visualisation\n",
+    "cb = pl.colorbar(shrink=0.75, norm=norm, boundaries=bounds)\n",
+    "loc = bounds + .5\n",
+    "cb.set_ticks(loc)\n",
+    "labels = bounds[:-1]\n",
+    "cb.set_ticklabels(labels)\n",
+    "cl = cb.ax.get_yticklabels()\n",
+    "cl[-1].set_text('9')\n",
+    "cb.ax.set_yticklabels([elem.get_text() for elem in cl])\n",
+    "pl.title('RADOLAN PG Product \\n' + attrs['datetime'].isoformat())\n",
+    "pl.grid(color='r')"
+   ]
   }
  ],
  "metadata": {
+  "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 2",
    "language": "python",

--- a/notebooks/simple_plot.ipynb
+++ b/notebooks/simple_plot.ipynb
@@ -19,9 +19,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# import section\n",
@@ -57,9 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# mask invalid values\n",
@@ -85,11 +81,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    ""
+   ]
   }
  ],
  "metadata": {
@@ -101,7 +97,7 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",


### PR DESCRIPTION
This PR adds the former tutorial_radolan_format.rst within the new notebook-section.

It consist of 6 notebooks and shows how the notebooks can be used:

- referencing (also between notebooks and links to api-functions)
- tables
- creation of tocs
- hiding cells
- math, equations