### PR TITLE
ENH: copy notebook scripts to examples folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ after_success:
     - scripts/render_notebooks.sh
     - if [[ "$COVERALLS" == "true" ]]; then coveralls || echo "failed"; fi
     - if [[ "$DOC_BUILD" == "true" ]]; then cd $TRAVIS_BUILD_DIR; scripts/build_docs.sh; fi
+    - cp notebooks/*.py examples/
 
 deploy:
   provider: pypi

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,6 @@ include requirements.txt
 include testrunner.py
 recursive-include examples *.py
 recursive-exclude examples *.pyc
+recursive-include notebooks *.ipynb
 recursive-include wradlib/tests *.py
 recursive-exclude wradlib/tests *.pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,6 @@ include testrunner.py
 recursive-include examples *.py
 recursive-exclude examples *.pyc
 recursive-include notebooks *.ipynb
+prune */.ipynb_checkpoints
 recursive-include wradlib/tests *.py
 recursive-exclude wradlib/tests *.pyc

--- a/scripts/convert_notebooks.sh
+++ b/scripts/convert_notebooks.sh
@@ -6,7 +6,3 @@
 cd notebooks
 jupyter nbconvert --to script *.ipynb
 cd ..
-cp notebooks/*.py examples/
-
-
-

--- a/scripts/convert_notebooks.sh
+++ b/scripts/convert_notebooks.sh
@@ -6,6 +6,7 @@
 cd notebooks
 jupyter nbconvert --to script *.ipynb
 cd ..
+cp notebooks/*.py examples/
 
 
 


### PR DESCRIPTION
add notebooks to distribution.

This adds notebooks and the converted python scripts to the `source distribution` (PyPi).