### PR TITLE
ENH: add reading capability of new radolan FZ product

### DIFF
--- a/wradlib/georef.py
+++ b/wradlib/georef.py
@@ -1449,10 +1449,12 @@ def get_radolan_grid(nrows=None, ncols=None, trig=False, wgs84=False):
     """
 
     # setup default parameters in dicts
+    tiny = {'j_0': 450, 'i_0': 450, 'res': 2}
     small = {'j_0': 460, 'i_0': 460, 'res': 2}
     normal = {'j_0': 450, 'i_0': 450, 'res': 1}
     extended = {'j_0': 600, 'i_0': 800, 'res': 1}
-    griddefs = {(460, 460): small, (900, 900): normal, (1500, 1400): extended}
+    griddefs = {(450, 450): tiny, (460, 460): small,
+                (900, 900): normal, (1500, 1400): extended}
 
     # type and value checking
     if nrows and ncols:
@@ -1467,7 +1469,7 @@ def get_radolan_grid(nrows=None, ncols=None, trig=False, wgs84=False):
         nrows = 900
         ncols = 900
 
-    # small, normal or extended grid check
+    # tiny, small, normal or extended grid check
     # reference point changes according to radolan composit format
     j_0 = griddefs[(nrows, ncols)]['j_0']
     i_0 = griddefs[(nrows, ncols)]['i_0']

--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -874,7 +874,6 @@ def read_RADOLAN_composite(fname, missing=-9999, loaddata=True):
         # this promotes arr to float if precision is float
         arr = arr * attrs["precision"]
         # this applies correction for new "FZ" product
-        print(attrs["producttype"])
         if attrs['producttype'] == 'FZ':
             arr /= 12.
         # set nodata value

--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -470,7 +470,8 @@ def get_radolan_header_token():
     """
     head = {'BY': None, 'VS': None, 'SW': None, 'PR': None,
             'INT': None, 'GP': None, 'MS': None, 'LV': None,
-            'CS': None, 'MX': None, 'BG': None, 'ST': None}
+            'CS': None, 'MX': None, 'BG': None, 'ST': None,
+            'VV': None, 'MF': None}
     return head
 
 
@@ -585,6 +586,10 @@ def parse_DWD_quant_composite_header(header):
                                     2: "tops"}.get(int(header[v[0]:v[1]]))
             if k == 'MX':
                 out['imagecount'] = int(header[v[0]:v[1]])
+            if k == 'VV':
+                out['vv'] = int(header[v[0]:v[1]])
+            if k == 'MF':
+                out['mf'] = int(header[v[0]:v[1]])
     return out
 
 
@@ -868,6 +873,10 @@ def read_RADOLAN_composite(fname, missing=-9999, loaddata=True):
         # apply precision factor
         # this promotes arr to float if precision is float
         arr = arr * attrs["precision"]
+        # this applies correction for new "FZ" product
+        print(attrs["producttype"])
+        if attrs['producttype'] == 'FZ':
+            arr /= 12.
         # set nodata value
         arr[nodata] = NODATA
 


### PR DESCRIPTION
This adds the FZ product to the radolan composit reader.

This is actually very preliminary. Means the two new header keys will probably be renamed in a future version, when their correct dwd-name is figured out.

This also adds a new grid specification (450 by 450), which wasn't defined before.

