### PR TITLE
MNT: fix deploying converted notebooks, bump build number

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ deploy:
   - provider: pypi
     server: https://testpypi.python.org/pypi
     distributions: sdist
+    skip_cleanup: true
     user: wradlib
     password:
       secure: rKiAS61oDiuV2uJvkP2aiXt8hb7boU2p35RWiTLS8b5pSo/BWysThOIf1jmz5GQIpI8uYU+5GajlgtGVq8GmOxprexDgwTfMFF2bsblfUuZwYM3R1tPQuo2poAZ1/m0jPCul60vJJ31B2wEzsneo4tvbM4a7mAoBMMA5auli5o3eVo4P8xnXziMbw/l53bnl+ZYv7qocbt9RIsrgckAdfjLkZy8gAgDxcYXGGybg6K8VN/twSZGMIJfOvjkONhOtRfsiUc8fEu2hF6+HjQfSC07jue4KDPzo3s9hrAS6+fB0v8MV4UsB710VsrqoPuIfhBRo+xj8tW7Y2MPzJq/6kPBrVoQwV7gLTxZ7IWy5y4/Si78rxhXZIKDzo2VS4tNq1wo6xfGXv8pbzal7TOljqzK+ekXJBsXgdVUiGisZJLHTnPr0rkjwY7qzW+mqPqnpLLTCoHYWQE9AlrEQI3jP1FejGB5iyv/A3kDhjaerFkXlu5TXfkE44EpoKp8uURCNdzNiFoACv/68w3BJmWI0IkQR+YWZEBQm0xySMj8zLd5qrhqX/0u2crEC2uUPEQnkwNF1X8fOz3KFozY68KYsvSmIqKPlJFWSpzXYzMzqFnpvSumgb+g8FK/UppmMpukeQXTVSMGHY9k0Hi6I/WoGgmlDMksRB4fMUG0nZXdOqyM=
@@ -67,6 +68,7 @@ deploy:
   - provider: pypi
     server: https://testpypi.python.org/pypi
     distributions: sdist
+    skip_cleanup: true
     user: wradlib
     password:
       secure: rKiAS61oDiuV2uJvkP2aiXt8hb7boU2p35RWiTLS8b5pSo/BWysThOIf1jmz5GQIpI8uYU+5GajlgtGVq8GmOxprexDgwTfMFF2bsblfUuZwYM3R1tPQuo2poAZ1/m0jPCul60vJJ31B2wEzsneo4tvbM4a7mAoBMMA5auli5o3eVo4P8xnXziMbw/l53bnl+ZYv7qocbt9RIsrgckAdfjLkZy8gAgDxcYXGGybg6K8VN/twSZGMIJfOvjkONhOtRfsiUc8fEu2hF6+HjQfSC07jue4KDPzo3s9hrAS6+fB0v8MV4UsB710VsrqoPuIfhBRo+xj8tW7Y2MPzJq/6kPBrVoQwV7gLTxZ7IWy5y4/Si78rxhXZIKDzo2VS4tNq1wo6xfGXv8pbzal7TOljqzK+ekXJBsXgdVUiGisZJLHTnPr0rkjwY7qzW+mqPqnpLLTCoHYWQE9AlrEQI3jP1FejGB5iyv/A3kDhjaerFkXlu5TXfkE44EpoKp8uURCNdzNiFoACv/68w3BJmWI0IkQR+YWZEBQm0xySMj8zLd5qrhqX/0u2crEC2uUPEQnkwNF1X8fOz3KFozY68KYsvSmIqKPlJFWSpzXYzMzqFnpvSumgb+g8FK/UppmMpukeQXTVSMGHY9k0Hi6I/WoGgmlDMksRB4fMUG0nZXdOqyM=

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include requirements.txt
 include testrunner.py
 recursive-include notebooks *.ipynb
 recursive-include notebooks *.py
+recursive-include notebooks *.pyc
 recursive-exclude notebooks __init__.py
 prune */.ipynb_checkpoints
 recursive-include wradlib/tests *.py

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ CLASSIFIERS = filter(None, CLASSIFIERS.split('\n'))
 PLATFORMS = ["Linux", "Mac OS-X", "Unix", "Windows"]
 MAJOR = 0
 MINOR = 8
-MICRO = 1
+MICRO = 2
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
This fixes the deployment of the converted notebook-scripts alongside the notebooks (`skip_cleanup` needed). Also bumbing build number to actually upload to testpypi.