### PR TITLE
MNT: remove *.pyc artefacts from sdist, bump build number

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,8 +4,8 @@ include requirements.txt
 include testrunner.py
 recursive-include notebooks *.ipynb
 recursive-include notebooks *.py
-recursive-include notebooks *.pyc
 recursive-exclude notebooks __init__.py
+recursive-exclude notebooks *.pyc
 prune */.ipynb_checkpoints
 recursive-include wradlib/tests *.py
 recursive-exclude wradlib/tests *.pyc

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ CLASSIFIERS = filter(None, CLASSIFIERS.split('\n'))
 PLATFORMS = ["Linux", "Mac OS-X", "Unix", "Windows"]
 MAJOR = 0
 MINOR = 8
-MICRO = 2
+MICRO = 3
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
This is another example of a devel release.

We have some changes (adapting MANIFEST.in) and we bumb the MICRO-part of the build number. This will create a devel release on testpypi  after merge.