### PR TITLE
ENH: render notebooks inside unittests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,9 @@ install:
 
 before_script:
     - flake8 .
-    # convert notebooks, render notebooks
     - export GDAL_DATA=$HOME/miniconda/envs/wradlib/share/gdal
     - export WRADLIB_DATA=$HOME/wradlib-data
-    - scripts/convert_notebooks.sh
+    - scripts/copy_notebooks.sh
 
 script:
     - xvfb-run -a -w 5 coverage run --source wradlib testrunner.py -u
@@ -45,8 +44,11 @@ script:
     - xvfb-run -a -w 5 coverage run -a --source wradlib testrunner.py -n
 
 after_success:
-    - scripts/render_notebooks.sh
+    # convert notebooks to python script for packaging
+    - scripts/convert_notebooks.sh
+    # report code coverage
     - if [[ "$COVERALLS" == "true" ]]; then coveralls || echo "failed"; fi
+    # build docs
     - if [[ "$DOC_BUILD" == "true" ]]; then cd $TRAVIS_BUILD_DIR; scripts/build_docs.sh; fi
 
 deploy:

--- a/scripts/convert_notebooks.sh
+++ b/scripts/convert_notebooks.sh
@@ -9,6 +9,4 @@ echo $notebooks
 # convert notebooks to python scripts
 for nb in $notebooks; do
     jupyter nbconvert --to script $nb
-    # this is for testrunner.py finding the notebook- tests
-    touch "${nb%/*}/__init__.py"
 done

--- a/scripts/copy_notebooks.sh
+++ b/scripts/copy_notebooks.sh
@@ -6,9 +6,8 @@
 notebooks=`find notebooks -path notebooks/.ipynb_checkpoints -prune -o -name *.ipynb -print`
 echo $notebooks
 
-# render notebooks to doc/sources
+# copy notebooks to doc/sources
 for nb in $notebooks; do
+    echo "cp --parents $nb doc/source/"
     cp --parents $nb doc/source/
-    echo "runipy --quiet --overwrite --matplotlib doc/source/$nb"
-    runipy --quiet --overwrite --matplotlib doc/source/$nb
 done


### PR DESCRIPTION
This changes the way the notebooks are rendered. We do this now as part of the unittest-process. This safes us from doing the rendering part twice. Should result in a significantly reduced build time on travis.