### PR TITLE
FIX: Addresses issue 86 introduces by scipy 0_18_0.

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -18,7 +18,7 @@ source activate wradlib
 conda config --add channels conda-forge
 
 # Install wradlib dependencies
-conda install --yes gdal numpy scipy=0.17.1 matplotlib netcdf4 h5py
+conda install --yes gdal numpy scipy matplotlib netcdf4 h5py
 ls -lart $HOME/miniconda/envs/wradlib/share/gdal
 
 # install wradlib-data

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -713,7 +713,7 @@ class ExternalDriftKriging(IpolBase):
         self.trg_drift = trg_drift
         # remember some things
         self.numtargets = len(trg)
-        if self.numtargets==0:
+        if self.numtargets == 0:
             raise MissingTargetsError
         self.numsources = len(src)
         if self.numsources == 0:

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -75,6 +75,8 @@ class IpolBase():
     def __init__(self, src, trg):
         src = self._make_coord_arrays(src)
         trg = self._make_coord_arrays(trg)
+        self.numsources = len(src)
+        self.numtargets = len(trg)
 
     def __call__(self, vals):
         """

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -43,15 +43,18 @@ import numpy as np
 import wradlib.util as util
 import warnings
 
+
 class MissingSourcesError(Exception):
     """Is raised in case no source coordinates are available for interpolation.
     """
     pass
 
+
 class MissingTargetsError(Exception):
     """Is raised in case no interpolation targets are available.
     """
     pass
+
 
 class IpolBase():
     """
@@ -181,7 +184,7 @@ class Nearest(IpolBase):
         trg = self._make_coord_arrays(trg)
         # remember some things
         self.numtargets = len(trg)
-        if self.numtargets==0:
+        if self.numtargets == 0:
             raise MissingTargetsError
         self.numsources = len(src)
         if self.numsources == 0:
@@ -245,15 +248,16 @@ class Idw(IpolBase):
         trg = self._make_coord_arrays(trg)
         # remember some things
         self.numtargets = len(trg)
-        if self.numtargets==0:
+        if self.numtargets == 0:
             raise MissingTargetsError
         self.numsources = len(src)
         if self.numsources == 0:
             raise MissingSourcesError
         if nnearest > self.numsources:
             warnings.warn(
-                "wradlib.ipol.Idw: <nnearest> is larger than number of source points and " \
-                "is set to %d corresponding to the number of source points." % self.numsources,
+                "wradlib.ipol.Idw: <nnearest> is larger than number of "
+                "source points and is set to %d corresponding to the "
+                "number of source points." % self.numsources,
                 UserWarning
             )
             self.nnearest = self.numsources
@@ -348,7 +352,7 @@ class Linear(IpolBase):
         self.trg = self._make_coord_arrays(trg)
         # remember some things
         self.numtargets = len(trg)
-        if self.numtargets==0:
+        if self.numtargets == 0:
             raise MissingTargetsError
         self.numsources = len(src)
         if self.numsources == 0:
@@ -568,15 +572,17 @@ class OrdinaryKriging(IpolBase):
         self.trg = self._make_coord_arrays(trg)
         # remember some things
         self.numtargets = len(trg)
-        if self.numtargets==0:
+        if self.numtargets == 0:
             raise MissingTargetsError
         self.numsources = len(src)
         if self.numsources == 0:
             raise MissingSourcesError
         if nnearest > self.numsources:
             warnings.warn(
-                "wradlib.ipol.OrdinaryKriging: <nnearest> is larger than number of source points and " \
-                "is set to %d corresponding to the number of source points." % self.numsources,
+                "wradlib.ipol.OrdinaryKriging: <nnearest> is "
+                "larger than number of source points and is "
+                "set to %d corresponding to the "
+                "number of source points." % self.numsources,
                 UserWarning
             )
             self.nnearest = self.numsources
@@ -714,8 +720,10 @@ class ExternalDriftKriging(IpolBase):
             raise MissingSourcesError
         if nnearest > self.numsources:
             warnings.warn(
-                "wradlib.ipol.ExternalDriftKriging: <nnearest> is larger than number of source points and " \
-                "is set to %d corresponding to the number of source points." % self.numsources,
+                "wradlib.ipol.ExternalDriftKriging: <nnearest> is larger "
+                "than number of source points and is set to %d "
+                "corresponding to the number of source "
+                "points." % self.numsources,
                 UserWarning
             )
             self.nnearest = self.numsources

--- a/wradlib/tests/test_ipol.py
+++ b/wradlib/tests/test_ipol.py
@@ -134,6 +134,12 @@ class InterpolationTest(unittest.TestCase):
                                                 [5., 2., -1.],
                                                 [7., 2., -3.]])))
 
+    def test_MissingErrors(self):
+        self.assertRaises(ipol.MissingSourcesError,
+                          ipol.Idw, np.array([]), self.trg)
+        self.assertRaises(ipol.MissingTargetsError,
+                          ipol.Idw, self.src, np.array([]))
+
 
 class Regular2IrregularTest(unittest.TestCase):
     def setUp(self):

--- a/wradlib/tests/test_ipol.py
+++ b/wradlib/tests/test_ipol.py
@@ -7,6 +7,7 @@ import numpy as np
 import wradlib.ipol as ipol
 import wradlib.georef as georef
 import unittest
+import warnings
 
 
 class InterpolationTest(unittest.TestCase):
@@ -134,11 +135,79 @@ class InterpolationTest(unittest.TestCase):
                                                 [5., 2., -1.],
                                                 [7., 2., -3.]])))
 
+    def test_ExternalDriftKriging_3(self):
+        """testing the basic behaviour of the ExternalDriftKriging class
+        with missing drift terms"""
+        ip = ipol.ExternalDriftKriging(self.src, self.trg, '1.0 Lin(2.0)',
+                                       src_drift=None,
+                                       trg_drift=None)
+
+        self.assertRaises(ValueError, ip, self.vals)
+
     def test_MissingErrors(self):
+        self.assertRaises(ipol.MissingSourcesError,
+                          ipol.Nearest, np.array([]), self.trg)
+        self.assertRaises(ipol.MissingTargetsError,
+                          ipol.Nearest, self.src, np.array([]))
         self.assertRaises(ipol.MissingSourcesError,
                           ipol.Idw, np.array([]), self.trg)
         self.assertRaises(ipol.MissingTargetsError,
                           ipol.Idw, self.src, np.array([]))
+        self.assertRaises(ipol.MissingSourcesError,
+                          ipol.Linear, np.array([]), self.trg)
+        self.assertRaises(ipol.MissingTargetsError,
+                          ipol.Linear, self.src, np.array([]))
+        self.assertRaises(ipol.MissingSourcesError,
+                          ipol.OrdinaryKriging, np.array([]), self.trg)
+        self.assertRaises(ipol.MissingTargetsError,
+                          ipol.OrdinaryKriging, self.src, np.array([]))
+        self.assertRaises(ipol.MissingSourcesError,
+                          ipol.ExternalDriftKriging, np.array([]), self.trg)
+        self.assertRaises(ipol.MissingTargetsError,
+                          ipol.ExternalDriftKriging, self.src, np.array([]))
+
+
+    def test_nnearest_warning(self):
+            with warnings.catch_warnings(record=True) as w:
+                # Cause all warnings to always be triggered.
+                warnings.simplefilter("always")
+                # Trigger a warning.
+                ipol.Idw(self.src, self.trg, nnearest=len(self.src)+1)
+                # Verify some things
+                self.assertTrue(len(w) == 1)
+                self.assertTrue(issubclass(w[-1].category, UserWarning))
+                self.assertTrue("nnearest" in str(w[-1].message))
+                ipol.OrdinaryKriging(self.src, self.trg,
+                                     nnearest=len(self.src) + 1)
+                # Verify some things
+                self.assertTrue(len(w) == 1)
+                self.assertTrue(issubclass(w[-1].category, UserWarning))
+                self.assertTrue("nnearest" in str(w[-1].message))
+                ipol.ExternalDriftKriging(self.src, self.trg,
+                                          nnearest=len(self.src) + 1)
+                # Verify some things
+                self.assertTrue(len(w) == 1)
+                self.assertTrue(issubclass(w[-1].category, UserWarning))
+                self.assertTrue("nnearest" in str(w[-1].message))
+
+    def test_IpolBase(self):
+        """testing the basic behaviour of the base class"""
+
+        ip = ipol.IpolBase(self.src, self.trg)
+        res = ip(self.vals)
+        self.assertEqual(res, None)
+
+        # Check behaviour if args are passed as lists
+        src = [self.src[:,0], self.src[:,1]]
+        trg = [self.trg[:,0], self.trg[:,1]]
+        ip = ipol.IpolBase(src, trg)
+        self.assertEqual(len(self.src), ip.numsources)
+
+        # Check behaviour if dimension is > 2
+        ip = ipol.IpolBase(self.src, self.trg)
+        self.assertRaises(Exception, ipol.IpolBase,
+                          np.arange(12).reshape((2,3,2)),
+                          np.arange(20).reshape((2, 2, 5)))
 
 
 class Regular2IrregularTest(unittest.TestCase):

--- a/wradlib/tests/test_ipol.py
+++ b/wradlib/tests/test_ipol.py
@@ -168,26 +168,15 @@ class InterpolationTest(unittest.TestCase):
 
     def test_nnearest_warning(self):
         with warnings.catch_warnings(record=True) as w:
-            # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
-            # Trigger a warning.
             ipol.Idw(self.src, self.trg, nnearest=len(self.src) + 1)
-            # Verify some things
-            self.assertTrue(len(w) == 1)
-            self.assertTrue(issubclass(w[-1].category, UserWarning))
-            self.assertTrue("nnearest" in str(w[-1].message))
             ipol.OrdinaryKriging(self.src, self.trg,
                                  nnearest=len(self.src) + 1)
-            # Verify some things
-            self.assertTrue(len(w) == 1)
-            self.assertTrue(issubclass(w[-1].category, UserWarning))
-            self.assertTrue("nnearest" in str(w[-1].message))
             ipol.ExternalDriftKriging(self.src, self.trg,
                                       nnearest=len(self.src) + 1)
-            # Verify some things
-            self.assertTrue(len(w) == 1)
-            self.assertTrue(issubclass(w[-1].category, UserWarning))
-            self.assertTrue("nnearest" in str(w[-1].message))
+            for item in w:
+                self.assertTrue(issubclass(item.category, UserWarning))
+                self.assertTrue("nnearest" in str(item.message))
 
     def test_IpolBase(self):
         """testing the basic behaviour of the base class"""

--- a/wradlib/tests/test_ipol.py
+++ b/wradlib/tests/test_ipol.py
@@ -166,29 +166,28 @@ class InterpolationTest(unittest.TestCase):
         self.assertRaises(ipol.MissingTargetsError,
                           ipol.ExternalDriftKriging, self.src, np.array([]))
 
-
     def test_nnearest_warning(self):
-            with warnings.catch_warnings(record=True) as w:
-                # Cause all warnings to always be triggered.
-                warnings.simplefilter("always")
-                # Trigger a warning.
-                ipol.Idw(self.src, self.trg, nnearest=len(self.src)+1)
-                # Verify some things
-                self.assertTrue(len(w) == 1)
-                self.assertTrue(issubclass(w[-1].category, UserWarning))
-                self.assertTrue("nnearest" in str(w[-1].message))
-                ipol.OrdinaryKriging(self.src, self.trg,
-                                     nnearest=len(self.src) + 1)
-                # Verify some things
-                self.assertTrue(len(w) == 1)
-                self.assertTrue(issubclass(w[-1].category, UserWarning))
-                self.assertTrue("nnearest" in str(w[-1].message))
-                ipol.ExternalDriftKriging(self.src, self.trg,
-                                          nnearest=len(self.src) + 1)
-                # Verify some things
-                self.assertTrue(len(w) == 1)
-                self.assertTrue(issubclass(w[-1].category, UserWarning))
-                self.assertTrue("nnearest" in str(w[-1].message))
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            # Trigger a warning.
+            ipol.Idw(self.src, self.trg, nnearest=len(self.src) + 1)
+            # Verify some things
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, UserWarning))
+            self.assertTrue("nnearest" in str(w[-1].message))
+            ipol.OrdinaryKriging(self.src, self.trg,
+                                 nnearest=len(self.src) + 1)
+            # Verify some things
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, UserWarning))
+            self.assertTrue("nnearest" in str(w[-1].message))
+            ipol.ExternalDriftKriging(self.src, self.trg,
+                                      nnearest=len(self.src) + 1)
+            # Verify some things
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[-1].category, UserWarning))
+            self.assertTrue("nnearest" in str(w[-1].message))
 
     def test_IpolBase(self):
         """testing the basic behaviour of the base class"""
@@ -198,15 +197,15 @@ class InterpolationTest(unittest.TestCase):
         self.assertEqual(res, None)
 
         # Check behaviour if args are passed as lists
-        src = [self.src[:,0], self.src[:,1]]
-        trg = [self.trg[:,0], self.trg[:,1]]
+        src = [self.src[:, 0], self.src[:, 1]]
+        trg = [self.trg[:, 0], self.trg[:, 1]]
         ip = ipol.IpolBase(src, trg)
         self.assertEqual(len(self.src), ip.numsources)
 
         # Check behaviour if dimension is > 2
         ip = ipol.IpolBase(self.src, self.trg)
         self.assertRaises(Exception, ipol.IpolBase,
-                          np.arange(12).reshape((2,3,2)),
+                          np.arange(12).reshape((2, 3, 2)),
                           np.arange(20).reshape((2, 2, 5)))
 
 

--- a/wradlib/tests/test_util.py
+++ b/wradlib/tests/test_util.py
@@ -81,7 +81,8 @@ class HelperFunctionsTest(unittest.TestCase):
         out = util.from_to("2000-01-01 00:00:00",
                            "2000-01-02 00:00:00",
                            86400)
-        shouldbe = [dt.datetime(2000, 1, 1, 0, 0), dt.datetime(2000, 1, 2, 0, 0)]
+        shouldbe = [dt.datetime(2000, 1, 1, 0, 0),
+                    dt.datetime(2000, 1, 2, 0, 0)]
         self.assertEqual(out, shouldbe)
 
 

--- a/wradlib/tests/test_util.py
+++ b/wradlib/tests/test_util.py
@@ -77,6 +77,13 @@ class HelperFunctionsTest(unittest.TestCase):
         self.assertRaises(EnvironmentError,
                           lambda: util.get_wradlib_data_file(filename))
 
+    def test_from_to(self):
+        out = util.from_to("2000-01-01 00:00:00",
+                           "2000-01-02 00:00:00",
+                           86400)
+        shouldbe = [dt.datetime(2000, 1, 1, 0, 0), dt.datetime(2000, 1, 2, 0, 0)]
+        self.assertEqual(out, shouldbe)
+
 
 # -------------------------------------------------------------------------------
 # testing the filter helper function


### PR DESCRIPTION
Issue #86 was apparently introduced by a change in behaviour of cKDTree (see also scipy/scipy#6515).

Maximum number of neigbours (nnearest) is now set to maximum number of
source points during runtime. A warning is released in this case.

This change affects ipol.Idw, ipol.OrdinaryKriging and ipol.ExternalDriftKriging.

Akso introduced exceptions in case sources or targets are missing.