### PR TITLE
FIX: use OSR  IsSame function to evaluate SRS equality

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ CLASSIFIERS = filter(None, CLASSIFIERS.split('\n'))
 PLATFORMS = ["Linux", "Mac OS-X", "Unix", "Windows"]
 MAJOR = 0
 MINOR = 9
-MICRO = 0
+MICRO = 1
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 

--- a/wradlib/georef.py
+++ b/wradlib/georef.py
@@ -1689,11 +1689,8 @@ def transform_geometry(geom, dest_srs):
         Transformed Geometry
     """
 
-    src_srs = geom.GetSpatialReference()
-    # needed to get EPSG code
-    src_srs.AutoIdentifyEPSG()
     # transform if not the same spatial reference system
-    if src_srs.GetAuthorityCode(None) != dest_srs.GetAuthorityCode(None):
+    if not geom.GetSpatialReference().IsSame(dest_srs):
         geom.TransformTo(dest_srs)
 
     return geom


### PR DESCRIPTION
The old approach using `AutoIdentifyEPSG` and `GetAuthorityCode` doesn't work for some reason. Using OGR `IsSame` works fine so far. 