### PR TITLE
FIX: fix missing notebooks in docs - section

### DIFF
--- a/notebooks/basics.ipynb
+++ b/notebooks/basics.ipynb
@@ -38,7 +38,9 @@
     "\n",
     "- [Get wradlib version](basics/wradlib_introduction.ipynb)\n",
     "- [Typical Workflow for Radar-Based Rainfall Estimation](basics/wradlib_workflow.ipynb)\n",
-    "- [From Reflectivity to Rainfall](basics/wradlib_get_rainfall.ipynb)"
+    "- [From Reflectivity to Rainfall](basics/wradlib_get_rainfall.ipynb)",
+    "- [Plot Polar Data as PPI](visualisation/wradlib_plot_ppi_example.ipynb)",
+    "- [Plot Polar Data on Curvelinear Grids](visualisation/wradlib_plot_curvelinear_grids.ipynb)"
    ]
   }
  ],


### PR DESCRIPTION
This adds the missing plot notebooks into the basics section of the docs.