### PR TITLE
Fixes two issues with older gdal and matplotlib versions.

### DIFF
--- a/doc/source/jupyter.rst
+++ b/doc/source/jupyter.rst
@@ -24,8 +24,13 @@ Once these conditions are met, you can open a notebook: Launch a console or bash
 
 	> jupyter notebook
 	
-If you installed :math:`\omega radlib` into a virtual environment (as recommended :doc:`here <gettingstarted>`), 
-you need to find the path to that virtual environment, e.g. by:: 
+If you installed :math:`\omega radlib` into a conda environment (as recommended :doc:`here <gettingstarted>`), 
+you need to activate that environment first. Let's say you named the environment `wradlib`::
+	
+	> activate wradlib
+	> jupyter notebook
+	
+Did you forget the name of the environment that contains wradlib? This way, you get an overview over all environments:: 
 
 	> conda info --envs
 	
@@ -34,10 +39,6 @@ which will give you something like (example output under Windows)::
 	# conda environments
 	wradlib      C:\Anaconda2\envs\wradlib
 	root      *  C:\Anaconda2
-	
-Given this example, you would open a jupyter notebook server via::
-
-	> C:\Anaconda2\envs\wradlib\python C:\Anaconda2\envs\wradlib\Scripts\ipython-script.py notebook
 	
 In both cases, a browser window will open (typically at http://localhost:8888/tree) which will show the tree of the directory in which you started the jupyter notebook server. Just open any notebook by clicking. Code cells are executed by hitting ``Shift + Enter`` or by using the toolbar icons. It's pretty much self-explaining, and you'll soon get the hang of it.  
 

--- a/notebooks/visualisation/wradlib_overlay.ipynb
+++ b/notebooks/visualisation/wradlib_overlay.ipynb
@@ -632,11 +632,11 @@
    },
    "outputs": [],
    "source": [
-    "def plot_albers(ax):\n",
+    "def plot_mercator(ax):\n",
     "    from osgeo import osr\n",
-    "    india = osr.SpatialReference()\n",
-    "    # asia south albers equal area conic\n",
-    "    india.ImportFromEPSG(102028)\n",
+    "    proj = osr.SpatialReference()\n",
+    "    # \"Web Mercator\" projection (used by GoogleMaps, OSM, ...)\n",
+    "    proj.ImportFromEPSG(3857)\n",
     "\n",
     "    # add Bangladesh to countries\n",
     "    countries = ['India', 'Nepal', 'Bhutan', 'Myanmar', 'Bangladesh']\n",
@@ -657,7 +657,7 @@
     "        layer.SetAttributeFilter(fattr)\n",
     "        # get country patches and geotransform to destination srs\n",
     "        patches, keys = wrl.georef.get_shape_coordinates(layer,\n",
-    "                                                         dest_srs=india,\n",
+    "                                                         dest_srs=proj,\n",
     "                                                         key='name')\n",
     "        wrl.vis.add_patches(pl.gca(), patches, facecolor=colors[i])\n",
     "    \n",
@@ -666,7 +666,7 @@
     "    ax.set_xlabel('X - Coordinate')\n",
     "    ax.set_ylabel('Y - Coordinate')\n",
     "    ax.ticklabel_format(style='sci', scilimits=(0, 0))\n",
-    "    ax.set_title('South Asia - Albers Equal Area Conic ')"
+    "    ax.set_title('South Asia in Web Mercator Projection ')"
    ]
   },
   {
@@ -682,8 +682,17 @@
    "source": [
     "fig = pl.figure(figsize=(10,10))\n",
     "ax = fig.add_subplot(111, aspect='equal')\n",
-    "plot_albers(ax)"
+    "plot_mercator(ax)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/zonalstats/wradlib_zonalstats_quickstart.ipynb
+++ b/notebooks/zonalstats/wradlib_zonalstats_quickstart.ipynb
@@ -349,7 +349,7 @@
     "\n",
     "# Create discrete colormap\n",
     "levels=np.arange(0,30,2.5)\n",
-    "colors = pl.cm.magma(np.linspace(0, 1, len(levels)))\n",
+    "colors = pl.cm.gist_heat(np.linspace(0, 1, len(levels)))\n",
     "mycmap, mynorm = from_levels_and_colors(levels, colors, extend=\"max\")\n",
     "\n",
     "fig = pl.figure(figsize=(10, 10))\n",


### PR DESCRIPTION
Fixes an issue in wradlib_overlay.ipynb: the Albers projection is not available in gdal 1.10 which we are still using on the Open VM. Used Web Mercator instead.

Fixes an issue in wradlib_zonalstats_quickintro.ipynb: `magma` colormap is only availabel in the latest matplotlib releases. Used `gist_heat` instead.

Minor: Revised the tutorial on how to use jupyter notebooks with conda environments.