### PR TITLE
Define range_res as a float.

### DIFF
--- a/notebooks/beamblockage/wradlib_beamblock.ipynb
+++ b/notebooks/beamblockage/wradlib_beamblock.ipynb
@@ -113,7 +113,7 @@
     "nbins = 1000 # number of range bins\n",
     "el = 1.0 # vertical antenna pointing angle (deg)\n",
     "bw = 1.0 # half power beam width (deg)\n",
-    "range_res = 100 # range resolution (meters)"
+    "range_res = 100. # range resolution (meters)"
    ]
   },
   {


### PR DESCRIPTION
Otherwise - for some systems such as 32-bit - fantastic problems occur in the final plot of the notebook.