### PR TITLE
Small change so that read_RADOLAN_composite also accepts a file handle

### DIFF
--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -796,7 +796,7 @@ def read_radolan_header(fid):
     return header
 
 
-def read_RADOLAN_composite(fname, missing=-9999, loaddata=True):
+def read_RADOLAN_composite(f, missing=-9999, loaddata=True):
     """Read quantitative radar composite format of the German Weather Service
 
     The quantitative composite format of the DWD (German Weather Service) was
@@ -820,8 +820,8 @@ def read_RADOLAN_composite(fname, missing=-9999, loaddata=True):
 
     Parameters
     ----------
-    fname : string
-        path to the composite file
+    f : string or file handle
+        path to the composite file or file handle
     missing : int
         value assigned to no-data cells
     loaddata : bool
@@ -846,7 +846,9 @@ def read_RADOLAN_composite(fname, missing=-9999, loaddata=True):
     NODATA = missing
     mask = 0xFFF  # max value integer
 
-    f = get_radolan_filehandle(fname)
+    # If a file name is supplied, get a file handle
+    if type(f) == str:
+        f = get_radolan_filehandle(f)
 
     header = read_radolan_header(f)
 

--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -847,10 +847,11 @@ def read_RADOLAN_composite(f, missing=-9999, loaddata=True):
     mask = 0xFFF  # max value integer
 
     # If a file name is supplied, get a file handle
-    if type(f) == str:
+    try:
+        header = read_radolan_header(f)
+    except AttributeError:
         f = get_radolan_filehandle(f)
-
-    header = read_radolan_header(f)
+        header = read_radolan_header(f)
 
     attrs = parse_DWD_quant_composite_header(header)
 

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -367,8 +367,12 @@ class GetGridsTest(unittest.TestCase):
 
     def test_radolan_coords(self):
         x, y = georef.get_radolan_coords(7.0, 53.0)
-        self.assertEqual(x, -208.15159184860158)
-        self.assertEqual(y, -3971.7689758313813)
+        self.assertAlmostEqual(x, -208.15159184860158)
+        self.assertAlmostEqual(y, -3971.7689758313813)
+        # Also test with trigonometric approach
+        x, y = georef.get_radolan_coords(7.0, 53.0, trig=True)
+        self.assertEqual(x, -208.15159184860175)
+        self.assertEqual(y, -3971.7689758313832)
 
 
 if __name__ == '__main__':

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -5,6 +5,7 @@ import unittest
 import wradlib as wrl
 import numpy as np
 import zlib
+import gzip
 import tempfile
 import os
 import datetime
@@ -274,6 +275,18 @@ class RadolanTest(unittest.TestCase):
         # test for complete file
         data, attrs = wrl.io.read_RADOLAN_composite(rw_file)
         self.assertEqual(data.shape, (900, 900))
+
+        for key, value in attrs.items():
+            if type(value) == np.ndarray:
+                self.assertIn(value.dtype, [np.int32, np.int64])
+            else:
+                self.assertEqual(value, test_attrs[key])
+
+        # Do the same for the case where a file handle is passed
+        # instead of a file name
+        with gzip.open(rw_file) as fh:
+            data, attrs = wrl.io.read_RADOLAN_composite(fh)
+            self.assertEqual(data.shape, (900, 900))
 
         for key, value in attrs.items():
             if type(value) == np.ndarray:


### PR DESCRIPTION
Not sure if this could be useful for others.

But since I want to work with the different archived RADOLAN files more easily (current `bin.gz` files and historic `tar.gz` files) I added the possibility to pass a file handle to `read_RADOLAN_composite`. This makes it possible to untar and unzip the historic RADOLAN files on the fly and avoids storing uncompressed data or creating temporary files from the tar.gz files. I tried the approach with the temporary files, but this small change to `read_RADOLAN_composite` is much more elegant.

I can however understand that this is just a edge-case and of no use to most other users so that a merge does not make sense.
