### PR TITLE
FIX: Correct error in calculation of pulse volume.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ def git_version():
 
     return GIT_REVISION
 
+
 # BEFORE importing distutils, remove MANIFEST. distutils doesn't properly
 # update it when the contents of directories change.
 if os.path.exists('MANIFEST'):

--- a/testrunner.py
+++ b/testrunner.py
@@ -250,5 +250,6 @@ def err_exit(message, rc=2):
     sys.stderr.write("\n%s\n" % message)
     sys.exit(rc)
 
+
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/wradlib/qual.py
+++ b/wradlib/qual.py
@@ -127,7 +127,7 @@ def pulse_volume(ranges, h, theta):
     :math:`R=r= \tan ( 0.5 \cdot \theta \cdot \pi/180 ) \cdot range`
     with theta being the aperture angle (beam width).
     Thus, the pulse volume simply becomes the volume of a cylinder with
-    :math:`V=\pi \cdot h \cdot range^2 \cdot \tan( 
+    :math:`V=\pi \cdot h \cdot range^2 \cdot \tan(
     0.5 \cdot \theta \cdot \pi/180)^2`
 
     Parameters

--- a/wradlib/qual.py
+++ b/wradlib/qual.py
@@ -124,9 +124,10 @@ def pulse_volume(ranges, h, theta):
     :math:`V=(\pi/3) \cdot h \cdot (R^2 + R \cdot r + r^2)`.
     R and r are the radii of the two frustum surface circles. Assuming that the
     pulse width is small compared to the range, we get
-    :math:`R=r= \tan ( \theta \cdot \pi/180 ) \cdot range`.
+    :math:`R=r= \tan ( 0.5 \cdot \theta \cdot \pi/180 ) \cdot range`
+    with theta being the aperture angle (beam width).
     Thus, the pulse volume simply becomes the volume of a cylinder with
-    :math:`V=\pi \cdot h \cdot range^2 \cdot \tan(\theta \cdot \pi/180)^2`
+    :math:`V=\pi \cdot h \cdot range^2 \cdot \tan( 0.5 \cdot \theta \cdot \pi/180)^2`
 
     Parameters
     ----------
@@ -148,7 +149,7 @@ def pulse_volume(ranges, h, theta):
     See :ref:`notebooks/workflow/recipe1.ipynb`.
 
     """
-    return np.pi * h * (ranges ** 2) * (np.tan(np.radians(theta))) ** 2
+    return np.pi * h * (ranges ** 2) * (np.tan(np.radians(theta/2.))) ** 2
 
 
 def beam_block_frac(Th, Bh, a):

--- a/wradlib/qual.py
+++ b/wradlib/qual.py
@@ -127,7 +127,8 @@ def pulse_volume(ranges, h, theta):
     :math:`R=r= \tan ( 0.5 \cdot \theta \cdot \pi/180 ) \cdot range`
     with theta being the aperture angle (beam width).
     Thus, the pulse volume simply becomes the volume of a cylinder with
-    :math:`V=\pi \cdot h \cdot range^2 \cdot \tan( 0.5 \cdot \theta \cdot \pi/180)^2`
+    :math:`V=\pi \cdot h \cdot range^2 \cdot \tan( 
+    0.5 \cdot \theta \cdot \pi/180)^2`
 
     Parameters
     ----------

--- a/wradlib/tests/test_dp.py
+++ b/wradlib/tests/test_dp.py
@@ -43,5 +43,6 @@ class TextureTest(unittest.TestCase):
     def test_texture(self):
         pass
 
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We need to take half of the beam width in order to compute the base radius of our cone.