### PR TITLE
ENH: Raster handling

### DIFF
--- a/notebooks/beamblockage/wradlib_beamblock.ipynb
+++ b/notebooks/beamblockage/wradlib_beamblock.ipynb
@@ -283,7 +283,7 @@
     "rastervalues, rastercoords, proj = wrl.georef.extract_raster_dataset(ds, nodata=-32768.)\n",
     "\n",
     "# Clip the region inside our bounding box \n",
-    "ind = wrl.georef.find_bbox_indices(rastercoords, rlimits)\n",
+    "ind = wrl.util.find_bbox_indices(rastercoords, rlimits)\n",
     "rastercoords = rastercoords_u[ind[1]:ind[3], ind[0]:ind[2], ...]\n",
     "rastervalues = rastervalues_u[ind[1]:ind[3], ind[0]:ind[2]]\n",
     "\n",

--- a/notebooks/beamblockage/wradlib_beamblock.ipynb
+++ b/notebooks/beamblockage/wradlib_beamblock.ipynb
@@ -272,7 +272,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -284,8 +286,8 @@
     "\n",
     "# Clip the region inside our bounding box \n",
     "ind = wrl.util.find_bbox_indices(rastercoords, rlimits)\n",
-    "rastercoords = rastercoords_u[ind[1]:ind[3], ind[0]:ind[2], ...]\n",
-    "rastervalues = rastervalues_u[ind[1]:ind[3], ind[0]:ind[2]]\n",
+    "rastercoords = rastercoords[ind[1]:ind[3], ind[0]:ind[2], ...]\n",
+    "rastervalues = rastervalues[ind[1]:ind[3], ind[0]:ind[2]]\n",
     "\n",
     "# Map rastervalues to polar grid points\n",
     "polarvalues = wrl.ipol.cart2irregular_spline(rastercoords, rastervalues,\n",

--- a/notebooks/beamblockage/wradlib_beamblock.ipynb
+++ b/notebooks/beamblockage/wradlib_beamblock.ipynb
@@ -3,6 +3,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "nbsphinx": "hidden",
     "slideshow": {
      "slide_type": "skip"
@@ -18,6 +20,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -29,6 +33,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -40,6 +46,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -56,7 +64,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "scrolled": false,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -78,6 +89,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -89,6 +102,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -102,6 +117,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -119,6 +136,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -132,6 +151,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -145,6 +166,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -163,6 +186,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -180,6 +205,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -195,6 +222,9 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "scrolled": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -209,6 +239,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -220,6 +252,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -231,40 +265,39 @@
     "\n",
     "*Note*: You can choose between the coarser resolution `bonn_gtopo.tif` (from GTOPO30) and the finer resolution `bonn_new.tif` (from the SRTM mission).\n",
     "\n",
-    "The DEM raster data is read via [wradlib.io.read_raster_data](http://wradlib.org/wradlib-docs/latest/generated/wradlib.io.read_raster_data.html)."
+    "The DEM raster data is opened via [wradlib.io.open_raster](http://wradlib.org/wradlib-docs/latest/generated/wradlib.io.open_raster.html) and extracted via [wradlib.georef.extract_raster_dataset](http://wradlib.org/wradlib-docs/latest/generated/wradlib.georef.extract_raster_dataset.html)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false,
-    "slideshow": {
-     "slide_type": "fragment"
-    }
+    "collapsed": false
    },
    "outputs": [],
    "source": [
     "#rasterfile = wrl.util.get_wradlib_data_file('geo/bonn_gtopo.tif')\n",
     "rasterfile = wrl.util.get_wradlib_data_file('geo/bonn_new.tif')\n",
-    "rastercoords, rastervalues = wrl.io.read_raster_data(rasterfile)\n",
+    "\n",
+    "ds = wrl.io.open_raster(rasterfile)\n",
+    "rastervalues, rastercoords, proj = wrl.georef.extract_raster_dataset(ds, nodata=-32768.)\n",
     "\n",
     "# Clip the region inside our bounding box \n",
-    "ind = wrl.util.find_bbox_indices(rastercoords, rlimits)\n",
-    "rastercoords = rastercoords[ind[1]:ind[3], ind[0]:ind[2], ...]\n",
-    "rastervalues = rastervalues[ind[1]:ind[3], ind[0]:ind[2]]\n",
+    "ind = wrl.georef.find_bbox_indices(rastercoords, rlimits)\n",
+    "rastercoords = rastercoords_u[ind[1]:ind[3], ind[0]:ind[2], ...]\n",
+    "rastervalues = rastervalues_u[ind[1]:ind[3], ind[0]:ind[2]]\n",
     "\n",
     "# Map rastervalues to polar grid points\n",
     "polarvalues = wrl.ipol.cart2irregular_spline(rastercoords, rastervalues,\n",
     "                                             polcoords, order=3,\n",
-    "                                             prefilter=False)\n",
-    "\n",
-    "print(polarvalues.shape)"
+    "                                             prefilter=False)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -276,6 +309,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -289,6 +324,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -303,6 +340,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -317,7 +356,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -331,6 +372,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -342,6 +385,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -358,6 +403,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -384,6 +431,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -447,6 +496,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -458,6 +509,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -474,6 +527,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -494,6 +549,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -509,6 +566,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -576,6 +635,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "skip"
     }
@@ -602,7 +663,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   },
   "livereveal": {
    "scroll": true

--- a/notebooks/fileio/wradlib_gis_export_example.ipynb
+++ b/notebooks/fileio/wradlib_gis_export_example.ipynb
@@ -144,8 +144,10 @@
    },
    "outputs": [],
    "source": [
+    "# create 3 bands\n",
+    "data = np.stack((data, data+100, data+1000))\n",
     "ds = wrl.georef.create_raster_dataset(data, xy, projection=proj_osr)\n",
-    "wrl.io.write_raster_data(wdir + \"geotiff.tif\", ds, 'GTiff')"
+    "wrl.io.write_raster_dataset(wdir + \"geotiff.tif\", ds, 'GTiff')"
    ]
   },
   {
@@ -171,15 +173,19 @@
     "# Export to Arc/Info ASCII Grid format (aka ESRI grid)\n",
     "#     It should be possible to import this to most conventional\n",
     "# GIS software.\n",
+    "# only use first band\n",
     "proj_esri = proj_osr.Clone()\n",
     "proj_esri.MorphToESRI()\n",
-    "ds = wrl.georef.create_raster_dataset(data, xy, projection=proj_esri)\n",
-    "wrl.io.write_raster_data(wdir + \"aaigrid.asc\", ds, 'AAIGrid', options=['DECIMAL_PRECISION=2'])"
+    "ds = wrl.georef.create_raster_dataset(data[0], xy, projection=proj_esri)\n",
+    "wrl.io.write_raster_dataset(wdir + \"aaigrid.asc\", ds, 'AAIGrid', options=['DECIMAL_PRECISION=2'])"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Step 5a: Read from GeoTIFF"
    ]
@@ -188,7 +194,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -200,7 +208,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Step 5b: Read from ESRI ASCII file (aka Arc/Info ASCII Grid)"
    ]
@@ -209,13 +220,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
     "ds2 = wrl.io.open_raster(wdir + \"aaigrid.asc\")\n",
     "data2, xy2, proj2 = wrl.georef.extract_raster_dataset(ds2, nodata=-9999.)\n",
-    "np.testing.assert_array_almost_equal(data2, data, decimal=2)\n",
+    "np.testing.assert_array_almost_equal(data2, data[0], decimal=2)\n",
     "np.testing.assert_array_almost_equal(xy2[:-1,:-1,:], xy)"
    ]
   }

--- a/notebooks/fileio/wradlib_gis_export_example.ipynb
+++ b/notebooks/fileio/wradlib_gis_export_example.ipynb
@@ -105,7 +105,7 @@
    "source": [
     "### Step 3: Check Origin and Row/Column Order\n",
     "\n",
-    "We know, that `wrl.read_RADOLAN_composite` returns a 2D-array (rows, cols) with the origin in the lower left corner. Same applies to `wrl.georef.get_radolan_grid`. For the next step, we need to flip the data and the coords up-down. The coordinate corner points also need to be adjusted from lower left corner to upper right corner. This is achieved by adding [0, y-spacing] to the array."
+    "We know, that `wrl.read_RADOLAN_composite` returns a 2D-array (rows, cols) with the origin in the lower left corner. Same applies to `wrl.georef.get_radolan_grid`. For the next step, we need to flip the data and the coords up-down. The coordinate corner points also need to be adjusted from lower left corner to upper right corner."
    ]
   },
   {
@@ -118,16 +118,7 @@
    },
    "outputs": [],
    "source": [
-    "x_sp, y_sp = xy[1, 1] - xy[0, 0]\n",
-    "\n",
-    "if y_sp > 0:\n",
-    "    origin='lower'\n",
-    "else:\n",
-    "    origin='upper'\n",
-    "\n",
-    "if origin is 'lower':\n",
-    "    data = np.flipud(data)\n",
-    "    xy = np.flipud(xy) + [0, y_sp]"
+    "data, xy = wrl.georef.set_raster_origin(data, xy, 'upper')"
    ]
   },
   {

--- a/notebooks/fileio/wradlib_gis_export_example.ipynb
+++ b/notebooks/fileio/wradlib_gis_export_example.ipynb
@@ -3,6 +3,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "nbsphinx": "hidden"
    },
    "source": [
@@ -14,7 +16,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Export a dataset in GIS-compatible format\n",
     "\n",
@@ -25,18 +30,24 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
-    "import wradlib\n",
+    "import wradlib as wrl\n",
+    "import numpy as np\n",
     "import warnings\n",
     "warnings.filterwarnings('ignore')"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Step 1: Read the original data"
    ]
@@ -45,20 +56,25 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
     "# We will export this RADOLAN dataset to a GIS compatible format\n",
-    "wdir = wradlib.util.get_wradlib_data_path() + '/radolan/grid/'\n",
+    "wdir = wrl.util.get_wradlib_data_path() + '/radolan/grid/'\n",
     "filename = 'radolan/misc/raa01-sf_10000-1408102050-dwd---bin.gz'\n",
-    "filename = wradlib.util.get_wradlib_data_file(filename)\n",
-    "data, meta = wradlib.io.read_RADOLAN_composite(filename)"
+    "filename = wrl.util.get_wradlib_data_file(filename)\n",
+    "data, meta = wrl.io.read_RADOLAN_composite(filename)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Step 2: Get the projected coordinates of the RADOLAN grid"
    ]
@@ -67,68 +83,112 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
     "# This is the RADOLAN projection\n",
-    "proj_osr = wradlib.georef.create_osr(\"dwd-radolan\")\n",
+    "proj_osr = wrl.georef.create_osr(\"dwd-radolan\")\n",
     "\n",
     "# Get projected RADOLAN coordinates for corner definition\n",
-    "xy = wradlib.georef.get_radolan_grid(900, 900)"
+    "xy = wrl.georef.get_radolan_grid(900, 900)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
-    "### Step 3a: Export as GeoTIFF\n",
+    "### Step 3: Check Origin and Row/Column Order\n",
     "\n",
-    "For RADOLAN grids, this projection wi#ll probably not be recognized by\n",
-    "ESRI ArcGIS.\n",
-    "Please note that that the geotransform for creating GeoTIFF files\n",
-    "requires the top-left corner of the bounding box. See help for\n",
-    "io.to_GeoTIFF for further instructions, particularly on how to define\n",
-    "the geotransform.\n"
+    "We know, that `wrl.read_RADOLAN_composite` returns a 2D-array (rows, cols) with the origin in the lower left corner. Same applies to `wrl.georef.get_radolan_grid`. For the next step, we need to flip the data and the coords up-down. The coordinate corner points also need to be adjusted from lower left corner to upper right corner. This is achieved by adding [0, y-spacing] to the array."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
-    "geotransform = [xy[0, 0, 0], 1., 0, xy[-1, -1, 1] + 1., 0, -1.]\n",
-    "wradlib.io.to_GeoTIFF(wdir + \"geotiff.tif\", data, geotransform,\n",
-    "                      proj=proj_osr)"
+    "x_sp, y_sp = xy[1, 1] - xy[0, 0]\n",
+    "\n",
+    "if y_sp > 0:\n",
+    "    origin='lower'\n",
+    "else:\n",
+    "    origin='upper'\n",
+    "\n",
+    "if origin is 'lower':\n",
+    "    data = np.flipud(data)\n",
+    "    xy = np.flipud(xy) + [0, y_sp]"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
-    "### Step 3b: Export as ESRI ASCII file (aka Arc/Info ASCII Grid)"
+    "### Step 4a: Export as GeoTIFF\n",
+    "\n",
+    "For RADOLAN grids, this projection will probably not be recognized by\n",
+    "ESRI ArcGIS."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "ds = wrl.georef.create_raster_dataset(data, xy, projection=proj_osr)\n",
+    "wrl.io.write_raster_data(wdir + \"geotiff.tif\", ds, 'GTiff')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "### Step 4b: Export as ESRI ASCII file (aka Arc/Info ASCII Grid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
     "# Export to Arc/Info ASCII Grid format (aka ESRI grid)\n",
     "#     It should be possible to import this to most conventional\n",
     "# GIS software.\n",
-    "wradlib.io.to_AAIGrid(wdir + \"aaigrid.asc\", data, xy[0, 0, 0], xy[0, 0, 1],\n",
-    "                      1., proj=proj_osr, to_esri=False)"
+    "proj_esri = proj_osr.Clone()\n",
+    "proj_esri.MorphToESRI()\n",
+    "ds = wrl.georef.create_raster_dataset(data, xy, projection=proj_esri)\n",
+    "wrl.io.write_raster_data(wdir + \"aaigrid.asc\", ds, 'AAIGrid', options=['DECIMAL_PRECISION=2'])"
    ]
   }
  ],
  "metadata": {
+  "celltoolbar": "Edit Metadata",
   "kernelspec": {
    "display_name": "Python 2",
    "language": "python",
@@ -144,7 +204,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/fileio/wradlib_gis_export_example.ipynb
+++ b/notebooks/fileio/wradlib_gis_export_example.ipynb
@@ -66,7 +66,7 @@
     "wdir = wrl.util.get_wradlib_data_path() + '/radolan/grid/'\n",
     "filename = 'radolan/misc/raa01-sf_10000-1408102050-dwd---bin.gz'\n",
     "filename = wrl.util.get_wradlib_data_file(filename)\n",
-    "data, meta = wrl.io.read_RADOLAN_composite(filename)"
+    "data_raw, meta = wrl.io.read_RADOLAN_composite(filename)"
    ]
   },
   {
@@ -93,7 +93,7 @@
     "proj_osr = wrl.georef.create_osr(\"dwd-radolan\")\n",
     "\n",
     "# Get projected RADOLAN coordinates for corner definition\n",
-    "xy = wrl.georef.get_radolan_grid(900, 900)"
+    "xy_raw = wrl.georef.get_radolan_grid(900, 900)"
    ]
   },
   {
@@ -118,7 +118,7 @@
    },
    "outputs": [],
    "source": [
-    "data, xy = wrl.georef.set_raster_origin(data, xy, 'upper')"
+    "data, xy = wrl.georef.set_raster_origin(data_raw, xy_raw, 'upper')"
    ]
   },
   {
@@ -147,7 +147,11 @@
     "# create 3 bands\n",
     "data = np.stack((data, data+100, data+1000))\n",
     "ds = wrl.georef.create_raster_dataset(data, xy, projection=proj_osr)\n",
-    "wrl.io.write_raster_dataset(wdir + \"geotiff.tif\", ds, 'GTiff')"
+    "wrl.io.write_raster_dataset(wdir + \"geotiff.tif\", ds, 'GTiff')\n",
+    "\n",
+    "# now deprecated\n",
+    "geotransform = [xy_raw[0, 0, 0], 1., 0, xy_raw[-1, -1, 1] + 1., 0, -1.]\n",
+    "wrl.io.to_GeoTIFF(wdir + \"geotiff1.tif\", data_raw[0], geotransform, proj=proj_osr)"
    ]
   },
   {
@@ -177,7 +181,11 @@
     "proj_esri = proj_osr.Clone()\n",
     "proj_esri.MorphToESRI()\n",
     "ds = wrl.georef.create_raster_dataset(data[0], xy, projection=proj_esri)\n",
-    "wrl.io.write_raster_dataset(wdir + \"aaigrid.asc\", ds, 'AAIGrid', options=['DECIMAL_PRECISION=2'])"
+    "wrl.io.write_raster_dataset(wdir + \"aaigrid.asc\", ds, 'AAIGrid', options=['DECIMAL_PRECISION=2'])\n",
+    "\n",
+    "# now deprecated\n",
+    "wrl.io.to_AAIGrid(wdir + \"aaigrid1.asc\", data_raw[0], xy_raw[0, 0, 0], xy_raw[0, 0, 1],\n",
+    "                  1., proj=proj_osr, to_esri=False)"
    ]
   },
   {
@@ -250,7 +258,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/fileio/wradlib_gis_export_example.ipynb
+++ b/notebooks/fileio/wradlib_gis_export_example.ipynb
@@ -151,7 +151,7 @@
     "\n",
     "# now deprecated\n",
     "geotransform = [xy_raw[0, 0, 0], 1., 0, xy_raw[-1, -1, 1] + 1., 0, -1.]\n",
-    "wrl.io.to_GeoTIFF(wdir + \"geotiff1.tif\", data_raw[0], geotransform, proj=proj_osr)"
+    "wrl.io.to_GeoTIFF(wdir + \"geotiff1.tif\", data_raw, geotransform, proj=proj_osr)"
    ]
   },
   {
@@ -184,7 +184,7 @@
     "wrl.io.write_raster_dataset(wdir + \"aaigrid.asc\", ds, 'AAIGrid', options=['DECIMAL_PRECISION=2'])\n",
     "\n",
     "# now deprecated\n",
-    "wrl.io.to_AAIGrid(wdir + \"aaigrid1.asc\", data_raw[0], xy_raw[0, 0, 0], xy_raw[0, 0, 1],\n",
+    "wrl.io.to_AAIGrid(wdir + \"aaigrid1.asc\", data_raw, xy_raw[0, 0, 0], xy_raw[0, 0, 1],\n",
     "                  1., proj=proj_osr, to_esri=False)"
    ]
   },

--- a/notebooks/fileio/wradlib_gis_export_example.ipynb
+++ b/notebooks/fileio/wradlib_gis_export_example.ipynb
@@ -176,6 +176,48 @@
     "ds = wrl.georef.create_raster_dataset(data, xy, projection=proj_esri)\n",
     "wrl.io.write_raster_data(wdir + \"aaigrid.asc\", ds, 'AAIGrid', options=['DECIMAL_PRECISION=2'])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 5a: Read from GeoTIFF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ds1 = wrl.io.open_raster(wdir + \"geotiff.tif\")\n",
+    "data1, xy1, proj1 = wrl.georef.extract_raster_dataset(ds1, nodata=-9999.)\n",
+    "np.testing.assert_array_equal(data1, data)\n",
+    "np.testing.assert_array_equal(xy1[:-1,:-1,:], xy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Step 5b: Read from ESRI ASCII file (aka Arc/Info ASCII Grid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "ds2 = wrl.io.open_raster(wdir + \"aaigrid.asc\")\n",
+    "data2, xy2, proj2 = wrl.georef.extract_raster_dataset(ds2, nodata=-9999.)\n",
+    "np.testing.assert_array_almost_equal(data2, data, decimal=2)\n",
+    "np.testing.assert_array_almost_equal(xy2[:-1,:-1,:], xy)"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/visualisation/wradlib_overlay.ipynb
+++ b/notebooks/visualisation/wradlib_overlay.ipynb
@@ -3,6 +3,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "nbsphinx": "hidden",
     "slideshow": {
      "slide_type": "skip"
@@ -18,6 +20,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -29,6 +33,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -41,6 +47,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -54,6 +62,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -78,6 +88,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -89,6 +101,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -104,19 +118,23 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
    },
    "source": [
     "Here we\n",
-    "- read the DEM via [wradlib.io.read_raster_data()](http://wradlib.org/wradlib-docs/latest/generated/wradlib.io.read_raster_data.html);\n",
+    "- read the DEM via [wradlib.io.open_raster](http://wradlib.org/wradlib-docs/latest/generated/wradlib.io.open_raster.html) and extracted via [wradlib.georef.extract_raster_dataset](http://wradlib.org/wradlib-docs/latest/generated/wradlib.georef.extract_raster_dataset.html).;\n",
     "- resample the data to a (lon/lat) grid with `spacing=0.005`."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -130,6 +148,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -138,9 +158,10 @@
    "source": [
     "def plot_dem(ax):\n",
     "    filename = wrl.util.get_wradlib_data_file('geo/bangladesh.tif')\n",
+    "    ds = wrl.io.open_raster(filename)\n",
     "    # pixel_spacing is in output units (lonlat)\n",
-    "    rastercoords, rastervalues = wrl.io.read_raster_data(filename,\n",
-    "                                                         spacing=0.005)\n",
+    "    ds = wrl.georef.reproject_raster_dataset(ds, spacing=0.005)\n",
+    "    rastervalues, rastercoords, proj = wrl.georef.extract_raster_dataset(ds)\n",
     "    # specify kwargs for plotting, using terrain colormap and LogNorm\n",
     "    dem = ax.pcolormesh(rastercoords[..., 0], rastercoords[..., 1],\n",
     "                        rastervalues, cmap=pl.cm.terrain, norm=LogNorm(),\n",
@@ -160,6 +181,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -174,6 +197,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -185,6 +210,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -196,6 +223,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -213,6 +242,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -242,6 +273,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -259,6 +292,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -270,6 +305,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -281,6 +318,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -298,6 +337,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -325,6 +366,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -345,6 +388,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -368,6 +413,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -387,6 +434,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -398,6 +447,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -411,6 +462,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -433,6 +486,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -458,6 +513,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -469,6 +526,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -480,6 +539,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -491,6 +552,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -504,6 +567,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -517,6 +582,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -564,7 +631,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -576,6 +645,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -587,6 +658,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -598,6 +671,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -611,6 +686,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -626,6 +703,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -674,6 +753,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -684,15 +765,6 @@
     "ax = fig.add_subplot(111, aspect='equal')\n",
     "plot_mercator(ax)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -712,7 +784,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   },
   "livereveal": {
    "scroll": true

--- a/wradlib/georef.py
+++ b/wradlib/georef.py
@@ -2014,25 +2014,47 @@ def set_raster_origin(data, coords, direction):
     same = (origin == direction)
     if not same:
         data = np.flipud(data)
+        # TODO: this assumes that the edge of
+        # the last row/column is missing
+        # but this may not be the case
         coords = np.flipud(coords) + [0, y_sp]
     return data, coords
 
 
 def extract_raster_dataset(dataset, nodata=None):
-    #data, coords, projection = None, nodata = -9999
+    """ Extract data, coordinates and projection information
+
+    Parameters
+    ----------
+    dataset : gdal.Dataset
+        raster dataset
+    nodata : scalar
+        Value to which the dataset nodata values are mapped.
+
+    Returns
+    -------
+    data : :class:`numpy:numpy.ndarray`
+        Array of shape (rows, cols) or (rows, cols, bands) containing
+        the data values.
+    coords : :class:`numpy:numpy.ndarray`
+        Array of shape (rows, cols, 2) containing xy-coordinates.
+    projection : osr object
+        Spatial reference system of the used coordinates.
+    """
 
     # data values
     data = read_gdal_values(dataset, nodata=nodata)
 
     # coords
-    coordinates_pixel = pixel_coordinates(dataset.RasterXSize,
-                                          dataset.RasterYSize,
-                                          'edges')
-    coordinates = pixel_to_map(dataset.GetGeoTransform(),
-                               coordinates_pixel)
+    coords_pixel = pixel_coordinates(dataset.RasterXSize,
+                                     dataset.RasterYSize,
+                                     'edges')
+    coords = pixel_to_map(dataset.GetGeoTransform(),
+                          coords_pixel)
+
     projection = read_gdal_projection(dataset)
 
-    return data, coordinates, projection
+    return data, coords, projection
 
 
 

--- a/wradlib/georef.py
+++ b/wradlib/georef.py
@@ -2059,7 +2059,6 @@ def extract_raster_dataset(dataset, nodata=None):
     return data, coords, projection
 
 
-
 def _doctest_():
     import doctest
     print('doctesting')

--- a/wradlib/georef.py
+++ b/wradlib/georef.py
@@ -34,11 +34,15 @@ Georeferencing
    pixel_coordinates
    get_earth_radius
    get_radolan_grid
+   reproject_raster_dataset
    resample_raster_dataset
    get_shape_coordinates
    correct_parallax
    sat2pol
    dist_from_orbit
+   create_raster_dataset
+   set_raster_origin
+   extract_raster_dataset
 
 
 """
@@ -60,6 +64,8 @@ from osgeo import gdal, osr, gdal_array
 import numpy as np
 from sys import exit
 import warnings
+
+from . import util as util
 
 
 def hor2aeq(a, h, phi):
@@ -1160,7 +1166,8 @@ def read_gdal_values(dataset=None, nodata=None):
     Returns
     -------
     values : :class:`numpy:numpy.ndarray`
-        2d array with values
+        Array of shape (rows, cols) or (bands, rows, cols) containing
+        the data values.
 
     Examples
     --------
@@ -1177,11 +1184,10 @@ def read_gdal_values(dataset=None, nodata=None):
         nd = band.GetNoDataValue()
         data = band.ReadAsArray()
         if nodata is not None:
-            nodata = band.GetNoDataValue()
             data[data == nd] = nodata
         bands.append(data)
 
-    return np.squeeze(np.dstack(bands))
+    return np.squeeze(np.stack(bands))
 
 
 def reproject(*args, **kwargs):
@@ -1590,6 +1596,141 @@ def get_radolan_grid(nrows=None, ncols=None, trig=False, wgs84=False):
     return radolan_grid
 
 
+def reproject_raster_dataset(src_ds, **kwargs):
+    """Reproject/Resample given dataset according to keyword arguments
+
+    .. versionadded:: 0.10.0
+
+    # function inspired from github project
+    # https://github.com/profLewis/geogg122
+
+    Parameters
+    ----------
+    src_ds : gdal.Dataset
+        raster image with georeferencing (GeoTransform at least)
+    spacing : float
+        float or tuple of two floats
+        pixel spacing of destination dataset, same unit as pixel coordinates
+    size : int
+        tuple of two ints
+        X/YRasterSize of destination dataset
+    resample : GDALResampleAlg
+        defaults to GRA_Bilinear
+        GRA_NearestNeighbour = 0, GRA_Bilinear = 1, GRA_Cubic = 2,
+        GRA_CubicSpline = 3, GRA_Lanczos = 4, GRA_Average = 5, GRA_Mode = 6,
+        GRA_Max = 8, GRA_Min = 9, GRA_Med = 10, GRA_Q1 = 11, GRA_Q3 = 12
+    projection_target : osr object
+        destination dataset projection, defaults to None
+    align : bool or Point
+        If False, there is no destination grid aligment.
+        If True, aligns the destination grid to the next integer multiple of
+        destination grid.
+        If Point (tuple, list of upper-left x,y-coordinate), the destination
+        grid is aligned to this point.
+
+    Returns
+    -------
+    dst_ds : gdal.Dataset
+        reprojected/resampled raster dataset
+    """
+
+    # checking kwargs
+    spacing = kwargs.pop('spacing', None)
+    size = kwargs.pop('size', None)
+    resample = kwargs.pop('resample', gdal.GRA_Bilinear)
+    src_srs = kwargs.pop('projection_source', None)
+    dst_srs = kwargs.pop('projection_target', None)
+    align = kwargs.pop('align', False)
+
+    # Get the GeoTransform vector
+    src_geo = src_ds.GetGeoTransform()
+    x_size = src_ds.RasterXSize
+    y_size = src_ds.RasterYSize
+
+    # get extent
+    ulx = src_geo[0]
+    uly = src_geo[3]
+    lrx = src_geo[0] + src_geo[1] * x_size
+    lry = src_geo[3] + src_geo[5] * y_size
+
+    extent = np.array([[[ulx, uly],
+                        [lrx, uly]],
+                       [[ulx, lry],
+                        [lrx, lry]]])
+
+    if dst_srs:
+        print("dest_src available")
+        src_srs = osr.SpatialReference()
+        src_srs.ImportFromWkt(src_ds.GetProjection())
+
+        # Transformation
+        extent = reproject(extent, projection_source=src_srs,
+                           projection_target=dst_srs)
+
+        # wkt needed
+        src_srs = src_srs.ExportToWkt()
+        dst_srs = dst_srs.ExportToWkt()
+
+    (ulx, uly, urx, ury,
+     llx, lly, lrx, lry) = tuple(list(extent.flatten().tolist()))
+
+    # align grid to destination raster or UL-corner point
+    if align:
+        try:
+            ulx, uly = align
+        except TypeError:
+            pass
+
+        ulx = int(max(np.floor(ulx), np.floor(llx)))
+        uly = int(min(np.ceil(uly), np.ceil(ury)))
+        lrx = int(min(np.ceil(lrx), np.ceil(urx)))
+        lry = int(max(np.floor(lry), np.floor(lly)))
+
+    # calculate cols/rows or xspacing/yspacing
+    if spacing:
+        try:
+            x_ps, y_ps = spacing
+        except TypeError:
+            x_ps = spacing
+            y_ps = spacing
+
+        cols = int(abs(lrx - ulx) / x_ps)
+        rows = int(abs(uly - lry) / y_ps)
+    elif size:
+        cols, rows = size
+        x_ps = x_size * src_geo[1] / cols
+        y_ps = y_size * abs(src_geo[5]) / rows
+    else:
+        raise NameError("Whether keyword 'spacing' or 'size' must be given")
+
+    # create destination in-memory raster
+    mem_drv = gdal.GetDriverByName('MEM')
+
+    print(rows, cols)
+    # and set RasterSize according ro cols/rows
+    dst_ds = mem_drv.Create('', cols, rows, 1, gdal.GDT_Float32)
+
+    # Create the destination GeoTransform with changed x/y spacing
+    dst_geo = (ulx, x_ps, src_geo[2], uly, src_geo[4], -y_ps)
+
+    # apply GeoTransform to destination dataset
+    dst_ds.SetGeoTransform(dst_geo)
+
+    # nodata handling, need to initialize dst_ds with nodata
+    src_band = src_ds.GetRasterBand(1)
+    nodata = src_band.GetNoDataValue()
+    dst_band = dst_ds.GetRasterBand(1)
+    dst_band.SetNoDataValue(nodata)
+    dst_band.WriteArray(np.ones((rows, cols)) * nodata)
+    dst_band.FlushCache()
+
+    # resample and reproject dataset
+    gdal.ReprojectImage(src_ds, dst_ds, src_srs, dst_srs, resample)
+
+    return dst_ds
+
+
+@util.deprecated(reproject_raster_dataset)
 def resample_raster_dataset(src_ds, **kwargs):
     """Resample given dataset according to keyword arguments
 
@@ -1649,7 +1790,7 @@ def resample_raster_dataset(src_ds, **kwargs):
 
     # create destination in-memory raster
     mem_drv = gdal.GetDriverByName('MEM')
-    # and set RasterSize according ro cols/rows
+    # and set RasterSize according cols/rows
     dst_ds = mem_drv.Create('', cols, rows, 1, gdal.GDT_Float32)
 
     # Create the destination GeoTransform with changed x/y spacing
@@ -1942,7 +2083,7 @@ def create_raster_dataset(data, coords, projection=None, nodata=-9999):
     Parameters
     ----------
     data : :class:`numpy:numpy.ndarray`
-        Array of shape (rows, cols) or (rows, cols, bands) containing
+        Array of shape (rows, cols) or (bands, rows, cols) containing
         the data values.
     coords : :class:`numpy:numpy.ndarray`
         Array of shape (rows, cols, 2) containing xy-coordinates.
@@ -1962,8 +2103,8 @@ def create_raster_dataset(data, coords, projection=None, nodata=-9999):
     # align data
     data = data.copy()
     if data.ndim == 2:
-        data = data[..., np.newaxis]
-    rows, cols, bands = data.shape
+        data = data[np.newaxis, ...]
+    bands, rows, cols = data.shape
 
     # create In-Memory Raster with correct dtype
     mem_drv = gdal.GetDriverByName('MEM')
@@ -1978,9 +2119,11 @@ def create_raster_dataset(data, coords, projection=None, nodata=-9999):
     if projection:
         dataset.SetProjection(projection.ExportToWkt())
 
+    # set np.nan to nodata
     dataset.GetRasterBand(1).SetNoDataValue(nodata)
-    for i in range(bands):
-        dataset.GetRasterBand(i + 1).WriteArray(data[..., i])
+
+    for i, band in enumerate(data, start=1):
+        dataset.GetRasterBand(i).WriteArray(band)
 
     return dataset
 
@@ -1993,7 +2136,7 @@ def set_raster_origin(data, coords, direction):
     Parameters
     ----------
     data : :class:`numpy:numpy.ndarray`
-        Array of shape (rows, cols) or (rows, cols, bands) containing
+        Array of shape (rows, cols) or (bands, rows, cols) containing
         the data values.
     coords : :class:`numpy:numpy.ndarray`
         Array of shape (rows, cols, 2) containing xy-coordinates.
@@ -2003,7 +2146,7 @@ def set_raster_origin(data, coords, direction):
     Returns
     -------
     data : :class:`numpy:numpy.ndarray`
-        Array of shape (rows, cols) or (rows, cols, bands) containing
+        Array of shape (rows, cols) or (bands, rows, cols) containing
         the data values.
     coords : :class:`numpy:numpy.ndarray`
         Array of shape (rows, cols, 2) containing xy-coordinates.
@@ -2012,11 +2155,11 @@ def set_raster_origin(data, coords, direction):
     origin = ('lower' if y_sp > 0 else 'upper')
     same = (origin == direction)
     if not same:
-        data = np.flipud(data)
-        coords = np.flipud(coords)
+        data = np.flip(data, axis=-2)
+        coords = np.flip(coords, axis=-2)
         # we need to shift y-coordinate if data and coordinates have the same
         # number of rows and cols
-        if data.shape[:2] == coords.shape[:2]:
+        if data.shape[1:] == coords.shape[:2]:
             coords += [0, y_sp]
 
     return data, coords
@@ -2035,7 +2178,7 @@ def extract_raster_dataset(dataset, nodata=None):
     Returns
     -------
     data : :class:`numpy:numpy.ndarray`
-        Array of shape (rows, cols) or (rows, cols, bands) containing
+        Array of shape (rows, cols) or (bands, rows, cols) containing
         the data values.
     coords : :class:`numpy:numpy.ndarray`
         Array of shape (rows, cols, 2) containing xy-coordinates.

--- a/wradlib/georef.py
+++ b/wradlib/georef.py
@@ -1178,7 +1178,7 @@ def read_gdal_values(dataset=None, nodata=None):
         data = band.ReadAsArray()
         if nodata is not None:
             nodata = band.GetNoDataValue()
-            data[data == nodata] = nodata
+            data[data == nd] = nodata
         bands.append(data)
 
     return np.squeeze(np.dstack(bands))

--- a/wradlib/georef.py
+++ b/wradlib/georef.py
@@ -1176,7 +1176,6 @@ def read_gdal_values(dataset=None, nodata=None):
         band = dataset.GetRasterBand(i + 1)
         nd = band.GetNoDataValue()
         data = band.ReadAsArray()
-        data[data == nd] = nodata
         if nodata is not None:
             nodata = band.GetNoDataValue()
             data[data == nodata] = nodata

--- a/wradlib/georef.py
+++ b/wradlib/georef.py
@@ -1931,6 +1931,8 @@ def dist_from_orbit(pr_alt, alpha, r_pr_inv):
 def create_raster_dataset(data, coords, projection=None, nodata=-9999):
     """ Create In-Memory Raster Dataset
 
+    .. versionadded 0.10.0
+
     Parameters
     ----------
     data : :class:`numpy:numpy.ndarray`

--- a/wradlib/georef.py
+++ b/wradlib/georef.py
@@ -2156,10 +2156,10 @@ def set_raster_origin(data, coords, direction):
     same = (origin == direction)
     if not same:
         data = np.flip(data, axis=-2)
-        coords = np.flip(coords, axis=-2)
+        coords = np.flip(coords, axis=-3)
         # we need to shift y-coordinate if data and coordinates have the same
         # number of rows and cols
-        if data.shape[1:] == coords.shape[:2]:
+        if data.shape[-2:] == coords.shape[:2]:
             coords += [0, y_sp]
 
     return data, coords

--- a/wradlib/georef.py
+++ b/wradlib/georef.py
@@ -2014,10 +2014,12 @@ def set_raster_origin(data, coords, direction):
     same = (origin == direction)
     if not same:
         data = np.flipud(data)
-        # TODO: this assumes that the edge of
-        # the last row/column is missing
-        # but this may not be the case
-        coords = np.flipud(coords) + [0, y_sp]
+        coords = np.flipud(coords)
+        # we need to shift y-coordinate if data and coordinates have the same
+        # number of rows and cols
+        if data.shape[:2] == coords.shape[:2]:
+            coords += [0, y_sp]
+
     return data, coords
 
 

--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -2262,6 +2262,37 @@ def read_raster_data(filename, driver=None, **kwargs):
     return coords, values
 
 
+def write_raster_data(fpath, dataset, format, options=None):
+    """ Write raster dataset to file format
+
+    Parameters
+    ----------
+    fpath : string
+        A file path - should have file extension corresponding to format.
+    dataset : gdal.Dataset
+        gdal raster dataset
+    format : string
+        gdal raster format string
+        see `formats_list <http://www.gdal.org/formats_list.html>`_.
+    options : list
+        list of option strings for the corresponding format
+    """
+    # check for option list
+    if options is None:
+        options = []
+
+    driver = gdal.GetDriverByName(format)
+
+    metadata = driver.GetMetadata()
+
+    # check driver capability
+    if 'DCAP_CREATECOPY' in metadata and metadata['DCAP_CREATECOPY'] != 'YES':
+        assert "Driver %s doesn't support CreateCopy() method.".format(format)
+
+    target = driver.CreateCopy(fpath, dataset, 0, options)
+    del target
+
+
 def open_shape(filename, driver=None):
     """
     Open shapefile, return ogr dataset and layer

--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -24,6 +24,7 @@ for an introduction on how to deal with different file formats.
    read_RADOLAN_composite
    read_Rainbow
    read_safnwc
+   write_raster_dataset
    to_AAIGrid
    to_GeoTIFF
    to_hdf5
@@ -1963,7 +1964,7 @@ def _check_arguments(fpath, data):
                         os.path.dirname(fpath))
 
 
-def write_raster_data(fpath, dataset, format, options=None):
+def write_raster_dataset(fpath, dataset, format, options=None, remove=False):
     """ Write raster dataset to file format
 
     .. versionadded 0.10.0
@@ -1978,6 +1979,9 @@ def write_raster_data(fpath, dataset, format, options=None):
         gdal raster format string
     options : list
         List of option strings for the corresponding format.
+    remove : bool
+        if True, existing OGR.DataSource will be
+        removed before creation
 
     Note
     ----
@@ -1993,18 +1997,21 @@ def write_raster_data(fpath, dataset, format, options=None):
         options = []
 
     driver = gdal.GetDriverByName(format)
-
     metadata = driver.GetMetadata()
 
     # check driver capability
     if 'DCAP_CREATECOPY' in metadata and metadata['DCAP_CREATECOPY'] != 'YES':
         assert "Driver %s doesn't support CreateCopy() method.".format(format)
 
+    if remove:
+        if os.path.exists(fpath):
+            driver.Delete(fpath)
+
     target = driver.CreateCopy(fpath, dataset, 0, options)
     del target
 
 
-@util.deprecated(write_raster_data)
+@util.deprecated(write_raster_dataset)
 def to_AAIGrid(fpath, data, xllcorner, yllcorner, cellsize,
                nodata=-9999, proj=None, fmt="%.2f", to_esri=True):
     """Write a cartesian grid to an Arc/Info ASCII grid file.
@@ -2110,7 +2117,7 @@ def to_AAIGrid(fpath, data, xllcorner, yllcorner, cellsize,
     return 0
 
 
-@util.deprecated(write_raster_data)
+@util.deprecated(write_raster_dataset)
 def to_GeoTIFF(fpath, data, geotransform, nodata=-9999, proj=None):
     """Write a cartesian grid to a GeoTIFF file.
 
@@ -2239,6 +2246,7 @@ def to_GeoTIFF(fpath, data, geotransform, nodata=-9999, proj=None):
     ds = None
 
 
+@util.deprecated(georef.extract_raster_dataset)
 def read_raster_data(filename, driver=None, **kwargs):
     """Read raster data
 

--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -1798,13 +1798,14 @@ def read_safnwc(filename):
 
     # name = os.path.basename(filename)[7:11]
     try:
-        proj = root.GetMetadata()["PROJECTION"]
+        proj = osr.SpatialReference()
+        proj.ImportFromProj4(ds.GetMetadata()["PROJECTION"])
     except Exception:
         raise NameError("No metadata for satellite file %s" % filename)
     geotransform = root.GetMetadata()["GEOTRANSFORM_GDAL_TABLE"].split(",")
     geotransform[0] = root.GetMetadata()["XGEO_UP_LEFT"]
     geotransform[3] = root.GetMetadata()["YGEO_UP_LEFT"]
-    ds.SetProjection(proj)
+    ds.SetProjection(proj.ExportToWkt())
     ds.SetGeoTransform([float(x) for x in geotransform])
     return ds
 

--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -1962,6 +1962,48 @@ def _check_arguments(fpath, data):
                         os.path.dirname(fpath))
 
 
+def write_raster_data(fpath, dataset, format, options=None):
+    """ Write raster dataset to file format
+
+    .. versionadded 0.10.0
+
+    Parameters
+    ----------
+    fpath : string
+        A file path - should have file extension corresponding to format.
+    dataset : gdal.Dataset
+        gdal raster dataset
+    format : string
+        gdal raster format string
+    options : list
+        List of option strings for the corresponding format.
+
+    Note
+    ----
+    For format and options refer to
+    `formats_list <http://www.gdal.org/formats_list.html>`_.
+
+    Examples
+    --------
+    See :ref:`notebooks/fileio/wradlib_gis_export_example.ipynb`.
+    """
+    # check for option list
+    if options is None:
+        options = []
+
+    driver = gdal.GetDriverByName(format)
+
+    metadata = driver.GetMetadata()
+
+    # check driver capability
+    if 'DCAP_CREATECOPY' in metadata and metadata['DCAP_CREATECOPY'] != 'YES':
+        assert "Driver %s doesn't support CreateCopy() method.".format(format)
+
+    target = driver.CreateCopy(fpath, dataset, 0, options)
+    del target
+
+
+@util.deprecated(write_raster_data)
 def to_AAIGrid(fpath, data, xllcorner, yllcorner, cellsize,
                nodata=-9999, proj=None, fmt="%.2f", to_esri=True):
     """Write a cartesian grid to an Arc/Info ASCII grid file.
@@ -2067,6 +2109,7 @@ def to_AAIGrid(fpath, data, xllcorner, yllcorner, cellsize,
     return 0
 
 
+@util.deprecated(write_raster_data)
 def to_GeoTIFF(fpath, data, geotransform, nodata=-9999, proj=None):
     """Write a cartesian grid to a GeoTIFF file.
 
@@ -2260,37 +2303,6 @@ def read_raster_data(filename, driver=None, **kwargs):
     dataset1 = None
 
     return coords, values
-
-
-def write_raster_data(fpath, dataset, format, options=None):
-    """ Write raster dataset to file format
-
-    Parameters
-    ----------
-    fpath : string
-        A file path - should have file extension corresponding to format.
-    dataset : gdal.Dataset
-        gdal raster dataset
-    format : string
-        gdal raster format string
-        see `formats_list <http://www.gdal.org/formats_list.html>`_.
-    options : list
-        list of option strings for the corresponding format
-    """
-    # check for option list
-    if options is None:
-        options = []
-
-    driver = gdal.GetDriverByName(format)
-
-    metadata = driver.GetMetadata()
-
-    # check driver capability
-    if 'DCAP_CREATECOPY' in metadata and metadata['DCAP_CREATECOPY'] != 'YES':
-        assert "Driver %s doesn't support CreateCopy() method.".format(format)
-
-    target = driver.CreateCopy(fpath, dataset, 0, options)
-    del target
 
 
 def open_shape(filename, driver=None):

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -40,8 +40,9 @@ from scipy.interpolate import LinearNDInterpolator
 from scipy.ndimage.interpolation import map_coordinates
 from scipy.interpolate import griddata
 import numpy as np
-import wradlib.util as util
 import warnings
+
+from . import util as util
 
 
 class MissingSourcesError(Exception):
@@ -1099,6 +1100,9 @@ def cart2irregular_spline(cartgrid, values, newgrid, **kwargs):
 
     .. versionadded:: 0.6.0
 
+    .. versionchanged:: 0.10.0
+       Accept data/coords with origin 'lower' or 'upper'.
+
     Keyword arguments are fed through to
     :func:`scipy:scipy.ndimage.map_coordinates`
 
@@ -1142,7 +1146,12 @@ Read-DEM-Raster-Data`.
     # can be transferred into separate function
     # if necessary
     xi = (nx - 1) * (xi - cxmin) / (cxmax - cxmin)
-    yi = (ny - 1) * (yi - cymin) / (cymax - cymin)
+
+    # check origin to calculate y index
+    if util.get_raster_origin(cartgrid) is 'lower':
+        yi = (ny - 1) * (yi - cymin) / (cymax - cymin)
+    else:
+        yi = ny - (ny - 1) * (yi - cymin) / (cymax - cymin)
 
     # interpolation by map_coordinates
     interp = map_coordinates(values, [yi, xi], **kwargs)

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -352,7 +352,7 @@ class GdalTests(unittest.TestCase):
         data, coords = georef.set_raster_origin(self.data.copy(),
                                                 self.coords.copy(), 'lower')
         np.testing.assert_array_equal(data, np.flip(self.data, axis=-2))
-        np.testing.assert_array_equal(coords, np.flip(self.coords, axis=-2))
+        np.testing.assert_array_equal(coords, np.flip(self.coords, axis=-3))
 
     def test_extract_raster_dataset(self):
         data, coords, proj = georef.extract_raster_dataset(self.ds)

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -6,9 +6,9 @@ import sys
 import unittest
 import wradlib.georef as georef
 import wradlib.util as util
-from wradlib.io import read_generic_hdf5
+from wradlib.io import read_generic_hdf5, open_raster
 import numpy as np
-from osgeo import osr
+from osgeo import gdal, ogr, osr
 
 
 class CoordinateTransformTest(unittest.TestCase):
@@ -305,16 +305,30 @@ class PixMapTest(unittest.TestCase):
 
 
 class GdalTests(unittest.TestCase):
+    def setUp(self):
+        filename = 'geo/bonn_new.tif'
+        geofile = util.get_wradlib_data_file(filename)
+        self.ds = open_raster(geofile)
+        (self.data,
+         self.coords,
+         self.proj) = georef.extract_raster_dataset(self.ds)
+
     def test_read_gdal_coordinates(self):
-        pass
+        coords = georef.read_gdal_coordinates(self.ds)
 
     def test_read_gdal_projection(self):
-        pass
+        proj = georef.read_gdal_projection(self.ds)
 
     def test_read_gdal_values(self):
-        pass
+        values = georef.read_gdal_values(self.ds)
+
+    def test_reproject_raster_dataset(self):
+        ds1 = georef.reproject_raster_dataset(self.ds, spacing=0.005,
+                                              resample=gdal.GRA_Bilinear,
+                                              align=True)
 
     def test_resample_raster_dataset(self):
+        ds1 = georef.resample_raster_dataset(self.ds, spacing=0.005)
         pass
 
     def test_get_shape_points(self):
@@ -324,6 +338,34 @@ class GdalTests(unittest.TestCase):
         pass
 
     def test_get_shape_coordinates(self):
+        pass
+
+    def test_create_raster_dataset(self):
+        data, coords = georef.set_raster_origin(self.data.copy(),
+                                                self.coords.copy(),
+                                                'upper')
+        ds = georef.create_raster_dataset(data,
+                                          coords,
+                                          projection=self.proj,
+                                          nodata=-32768)
+
+        data, coords, proj = georef.extract_raster_dataset(ds)
+        np.testing.assert_array_equal(data, self.data)
+        np.testing.assert_array_almost_equal(coords, self.coords)
+        self.assertEqual(proj.ExportToWkt(), self.proj.ExportToWkt())
+
+    def test_set_raster_origin(self):
+        data, coords = georef.set_raster_origin(self.data.copy(),
+                                                self.coords.copy(), 'upper')
+        np.testing.assert_array_equal(data, self.data)
+        np.testing.assert_array_equal(coords, self.coords)
+        data, coords = georef.set_raster_origin(self.data.copy(),
+                                                self.coords.copy(), 'lower')
+        np.testing.assert_array_equal(data, np.flip(self.data, axis=-2))
+        np.testing.assert_array_equal(coords, np.flip(self.coords, axis=-2))
+
+    def test_extract_raster_dataset(self):
+        data, coords, proj = georef.extract_raster_dataset(self.ds)
         pass
 
 

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -8,7 +8,7 @@ import wradlib.georef as georef
 import wradlib.util as util
 from wradlib.io import read_generic_hdf5, open_raster
 import numpy as np
-from osgeo import gdal, ogr, osr
+from osgeo import gdal, osr
 
 
 class CoordinateTransformTest(unittest.TestCase):
@@ -314,31 +314,21 @@ class GdalTests(unittest.TestCase):
          self.proj) = georef.extract_raster_dataset(self.ds)
 
     def test_read_gdal_coordinates(self):
-        coords = georef.read_gdal_coordinates(self.ds)
+        georef.read_gdal_coordinates(self.ds)
 
     def test_read_gdal_projection(self):
-        proj = georef.read_gdal_projection(self.ds)
+        georef.read_gdal_projection(self.ds)
 
     def test_read_gdal_values(self):
-        values = georef.read_gdal_values(self.ds)
+        georef.read_gdal_values(self.ds)
 
     def test_reproject_raster_dataset(self):
-        ds1 = georef.reproject_raster_dataset(self.ds, spacing=0.005,
-                                              resample=gdal.GRA_Bilinear,
-                                              align=True)
+        georef.reproject_raster_dataset(self.ds, spacing=0.005,
+                                        resample=gdal.GRA_Bilinear,
+                                        align=True)
 
     def test_resample_raster_dataset(self):
-        ds1 = georef.resample_raster_dataset(self.ds, spacing=0.005)
-        pass
-
-    def test_get_shape_points(self):
-        pass
-
-    def test_transform_geometry(self):
-        pass
-
-    def test_get_shape_coordinates(self):
-        pass
+        georef.resample_raster_dataset(self.ds, spacing=0.005)
 
     def test_create_raster_dataset(self):
         data, coords = georef.set_raster_origin(self.data.copy(),
@@ -366,7 +356,6 @@ class GdalTests(unittest.TestCase):
 
     def test_extract_raster_dataset(self):
         data, coords, proj = georef.extract_raster_dataset(self.ds)
-        pass
 
 
 class GetGridsTest(unittest.TestCase):

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -12,7 +12,7 @@ import datetime
 import io
 
 
-class IOTest(unittest.TestCase):
+class DXTest(unittest.TestCase):
     # testing functions related to readDX
     def test__getTimestampFromFilename(self):
         filename = 'raa00-dx_10488-200608050000-drs---bin'
@@ -36,6 +36,8 @@ class IOTest(unittest.TestCase):
     def test_readDX(self):
         pass
 
+
+class IOTest(unittest.TestCase):
     def test_writePolygon2Text(self):
         poly1 = [[0., 0., 0., 0.], [0., 1., 0., 1.], [1., 1., 0., 2.],
                  [0., 0., 0., 0.]]
@@ -425,6 +427,18 @@ class RainbowTest(unittest.TestCase):
         self.assertRaises(IOError,
                           lambda: wrl.io.get_RB_header('rb_file'))
 
+
+class RasterTest(unittest.TestCase):
+    def test_write_raster_dataset(self):
+        filename = 'geo/bonn_new.tif'
+        geofile = wrl.util.get_wradlib_data_file(filename)
+        ds = wrl.io.open_raster(geofile)
+        wrl.io.write_raster_dataset(geofile + 'asc', ds, 'AAIGrid')
+
+    def test_open_raster(self):
+        filename = 'geo/bonn_new.tif'
+        geofile = wrl.util.get_wradlib_data_file(filename)
+        ds = wrl.io.open_raster(geofile)
 
 if __name__ == '__main__':
     unittest.main()

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -438,7 +438,8 @@ class RasterTest(unittest.TestCase):
     def test_open_raster(self):
         filename = 'geo/bonn_new.tif'
         geofile = wrl.util.get_wradlib_data_file(filename)
-        ds = wrl.io.open_raster(geofile)
+        wrl.io.open_raster(geofile)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/wradlib/tests/test_util.py
+++ b/wradlib/tests/test_util.py
@@ -218,8 +218,7 @@ class FindBboxIndicesTest(unittest.TestCase):
                                                self.grid.shape[0]]))
 
         bbind = util.find_bbox_indices(self.grid, self.inside1)
-        self.assertTrue(np.array_equal(bbind, [0, 0, self.grid.shape[1],
-                                               self.grid.shape[0]]))
+        self.assertTrue(np.array_equal(bbind, [0, 0, 5, 8]))
 
         bbind = util.find_bbox_indices(self.grid, self.inside2)
-        self.assertTrue(np.array_equal(bbind, [1, 1, 5, 8]))
+        self.assertTrue(np.array_equal(bbind, [1, 1, 4, 7]))

--- a/wradlib/zonalstats.py
+++ b/wradlib/zonalstats.py
@@ -262,9 +262,9 @@ DataSource`.
         cols = int((x_max - x_min) / pixel_size)
         rows = int((y_max - y_min) / pixel_size)
 
+        mem_drv = gdal.GetDriverByName('MEM')
         # Todo: at the moment, always writing floats
-        ds_out = gdal_create_dataset(driver, filename, cols, rows,
-                                     gdal.GDT_Float32, remove=remove)
+        ds_out = mem_drv.Create('', cols, rows, 1, gdal.GDT_Float32)
         ds_out.SetGeoTransform((x_min, pixel_size, 0, y_max, 0, -pixel_size))
         proj = layer.GetSpatialRef()
         if proj is None:
@@ -273,7 +273,7 @@ DataSource`.
 
         band = ds_out.GetRasterBand(1)
         band.FlushCache()
-        print("Rasterizing Layer")
+        print("Rasterize layers")
         if attr is not None:
             gdal.RasterizeLayer(ds_out, [1], layer, burn_values=[0],
                                 options=["ATTRIBUTE={0}".format(attr),
@@ -283,6 +283,8 @@ DataSource`.
             gdal.RasterizeLayer(ds_out, [1], layer, burn_values=[1],
                                 options=["ALL_TOUCHED=TRUE"],
                                 callback=gdal.TermProgress)
+
+        io.write_raster_dataset(filename, ds_out, driver, remove=remove)
 
         del ds_out
 


### PR DESCRIPTION
This PR handles the issues outline in #135 

new functions
- [x] `georef.create_raster_dataset` (data, coords, proj -> dataset)
- [x] `georef.extract_raster_dataset` (dataset -> data, coords, proj)
- [x] `georef.set_raster_origin` (flip data and coords, if necessary)
- [x] `georef.reproject_raster_dataset` (and resampling)
- [x] `io.write_raster_dataset` (write to disc)
- [x] `util.get_raster_origin` (returns `upper` or `lower`)
- [x] add unit-tests

deprecated functions
- [x] deprecate `io.to_AAIGrid` and `to_GeoTIFF`
- [x] deprecate `io.read_raster_dataset` (the magic needed in this function isn't worth the work)
- [x] deprecate `georef.resample_raster_dataset`

other fixes
- [x] fix `zonalstats.DataSource.dump_raster` to use new functionality
- [x] fixed `io.read_safnwc` (proj4/wkt-handling)
- [x] update `notebooks/fileio/wradlib_gis_export_example.ipynb`
- [x] update `georef.read_gdal_values` to read multi band data
- [x] fix `util.find_bbox_indices` to account for `lower` or `upper` origin data/coords
- [x] fix `ipol.cart2irregular_spline` to account for data/coords origin
