### PR TITLE
WIP: testrunner fixup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,6 @@
 [run]
+concurrency = multiprocessing
+parallel = true
 source = wradlib
 omit =
     */setup.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,9 @@ before_script:
     - export GDAL_DATA=$HOME/miniconda/envs/wradlib/share/gdal
     - export WRADLIB_DATA=$HOME/wradlib-data
     - scripts/convert_notebooks.sh
+    - export DISPLAY=:99
+    - sh -e /etc/init.d/xvfb start
+    - sleep 3
 
 script:
     - scripts/run_tests.sh

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -2,14 +2,23 @@
 # Copyright (c) 2017, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
+exit_status=0
+
 if [[ "$COVERAGE" == "true" ]]; then
-    xvfb-run -a -w 5 coverage run --source wradlib testrunner.py -u
-    xvfb-run -a -w 5 coverage run -a --source wradlib testrunner.py -d
-    xvfb-run -a -w 5 coverage run -a --source wradlib testrunner.py -e
-    xvfb-run -a -w 5 coverage run -a --source wradlib testrunner.py -n
+    #export COVERAGE_PROCESS_START=".coveragerc"
+    coverage run --source wradlib testrunner.py -u
+    (( exit_status = ($? || $exit_status) ))
+    coverage run --source wradlib testrunner.py -d
+    (( exit_status = ($? || $exit_status) ))
+    coverage run --source wradlib testrunner.py -e
+    (( exit_status = ($? || $exit_status) ))
+    coverage run --source wradlib testrunner.py -n
+    (( exit_status = ($? || $exit_status) ))
+    coverage combine
+
 else
-    xvfb-run -a -w 5 python testrunner.py -u
-    xvfb-run -a -w 5 python testrunner.py -d
-    xvfb-run -a -w 5 python testrunner.py -e
-    xvfb-run -a -w 5 python testrunner.py -n
+    python testrunner.py -u
+    python testrunner.py -d
+    python testrunner.py -e
+    python testrunner.py -n
 fi

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -22,3 +22,5 @@ else
     python testrunner.py -e
     python testrunner.py -n
 fi
+
+exit $exit_status

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -1,7 +1,8 @@
 # !/usr/bin/env python
-# Copyright (c) 2016, wradlib developers.
+# Copyright (c) 2016-2017, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
+import sys
 import unittest
 import wradlib.georef as georef
 import wradlib.util as util
@@ -183,11 +184,13 @@ class CoordinateHelperTest(unittest.TestCase):
         self.assertRaises(ValueError,
                           lambda: georef._check_polar_coords(r, az))
 
-        # only py3k
-        # r = np.array([50., 100., 150., 200.])
-        # az = np.array([10., 45., 90., 135., 180., 225., 270., 315.])
-        # self.assertWarns(UserWarning,
-        #                  lambda: georef._check_polar_coords(r, az))
+    @unittest.skipIf(sys.version_info < (3, 5),
+                     "not supported in this python version")
+    def test__check_polar_coords_py3k(self):
+        r = np.array([50., 100., 150., 200.])
+        az = np.array([10., 45., 90., 135., 180., 225., 270., 315.])
+        self.assertWarns(UserWarning,
+                         lambda: georef._check_polar_coords(r, az))
 
 
 class ProjectionsTest(unittest.TestCase):

--- a/wradlib/tests/test_vis.py
+++ b/wradlib/tests/test_vis.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
-# Copyright (c) 2016, wradlib developers.
+# Copyright (c) 2016-2017, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
+import sys
 import unittest
 
 import wradlib.vis as vis
@@ -57,6 +58,10 @@ class PolarPlotTest(unittest.TestCase):
         cgax, pm = vis.plot_ppi(self.img, refrac=False, cg=True)
         cgax, pm = vis.plot_ppi(self.img, func='contour', cg=True)
         cgax, pm = vis.plot_ppi(self.img, func='contourf', cg=True)
+
+    @unittest.skipIf(sys.version_info < (3, 5),
+                     "not supported in this python version")
+    def test_plot_cg_ppi_py3k(self):
         with self.assertWarns(UserWarning):
             cgax, pm = vis.plot_ppi(self.img, func='contourf',
                                     proj=self.proj, cg=True)


### PR DESCRIPTION
Testing how to make single-notebook-test testsuites running in separate processes with Xvfb on Travis-Ci.

1. With this change, every `unittest.TestSuite` is started in a separate subprocess. 

2. But for the memory consuming notebooks (because of the sheer amount of notebooks) this also breaks the memory limit of travis-ci (all notebooks are run in the same `unittest.TestSuite` / subprocess). So every notebook is started as single `unittest.TestSuite` in a separate process.

3. To get the headless mode with `xvfb` in the subprocesses, we need to export the `DISPLAY` and start `xvfb` before starting the tests.

4. To get `coverage` working with subprocesses, we need to state this in the `.coveragerc`. 

5. To get the correct `exit_status` from `run_test.sh`, we need to retrieve it from the `coverage`-calls.

This is working now, finally!