### PR TITLE
ENH: added option to read rainbow files from file handle

### DIFF
--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -1542,15 +1542,15 @@ def get_RB_blob_from_string(datastring, blobdict):
     return data
 
 
-def get_RB_blob_from_file(fid, blobdict):
+def get_RB_blob_from_file(f, blobdict):
     """
     Read BLOB data from file and return it with correct
     dataWidth and shape
 
     Parameters
     ----------
-    fid : file handle
-        File handle of Data File
+    f : string or file handle
+        File handle of or path to Rainbow file
     blobdict : dict
         Blob Dict
 
@@ -1560,10 +1560,21 @@ def get_RB_blob_from_file(fid, blobdict):
         Content of blob as numpy array
     """
 
+    # Try to read the data from a file handle
     try:
+        f.seek(0, 0)
+        fid = f
         datastring = fid.read()
-    except:
-        raise IOError('Could not read from file handle')
+    except AttributeError:
+        # If we did not get a file handle, assume that we got a filename,
+        # get a file handle and read the data
+        try:
+            fid = open(f, "rb")
+            datastring = fid.read()
+            fid.close()
+        except IOError:
+            print("WRADLIB: Error opening Rainbow file ", f)
+            raise IOError
 
     data = get_RB_blob_from_string(datastring, blobdict)
 
@@ -1653,7 +1664,6 @@ def get_RB_header(fid):
     return xmltodict.parse(header)
 
 
-@util.apichange_kwarg('0.9.2', par='filename', typ=str, expar='f')
 def read_Rainbow(f, loaddata=True):
     """Reads Rainbow files files according to their structure
 
@@ -1684,6 +1694,9 @@ def read_Rainbow(f, loaddata=True):
     --------
 
     See :ref:`notebooks/fileio/wradlib_load_rainbow_example.ipynb`.
+
+    .. versionchanged 0.10.0
+       Added reading from file handles.
 
     """
 

--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -1639,8 +1639,6 @@ def get_RB_header(fid):
         if len(line) == 0:
             break
 
-    #fid.close()
-
     xmltodict = util.import_optional('xmltodict')
 
     return xmltodict.parse(header)

--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -1559,8 +1559,10 @@ def get_RB_blob_from_file(fid, blobdict):
         Content of blob as numpy array
     """
 
-    datastring = fid.read()
-    fid.close()
+    try:
+        datastring = fid.read()
+    except:
+        raise IOError('Could not read from file handle')
 
     data = get_RB_blob_from_string(datastring, blobdict)
 
@@ -1581,8 +1583,10 @@ def get_RB_file_as_string(fid):
         File Contents as dataString
     """
 
-    dataString = fid.read()
-    fid.close()
+    try:
+        dataString = fid.read()
+    except:
+        raise IOError('Could not read from file handle')
 
     return dataString
 
@@ -1633,11 +1637,15 @@ def get_RB_header(fid):
     endXMLmarker = b"<!-- END XML -->"
     header = b""
     line = b""
-    while not line.startswith(endXMLmarker):
-        header += line[:-1]
-        line = fid.readline()
-        if len(line) == 0:
-            break
+
+    try:
+        while not line.startswith(endXMLmarker):
+            header += line[:-1]
+            line = fid.readline()
+            if len(line) == 0:
+                break
+    except:
+        raise IOError('Could not read from file handle')
 
     xmltodict = util.import_optional('xmltodict')
 

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -404,10 +404,10 @@ class RainbowTest(unittest.TestCase):
         rbblob = rbdict['volume']['scan']['slice']['slicedata']['rawdata']
         with open(rb_file) as rb_fh:
             data = wrl.io.get_RB_blob_from_file(rb_fh, rbblob)
-        self.assertEqual(data.shape[0], int(rbblob['@rays']))
-        self.assertEqual(data.shape[1], int(rbblob['@bins']))
-        self.assertRaises(IOError,
-                          lambda: wrl.io.get_RB_blob_from_file('rb_file',
+            self.assertEqual(data.shape[0], int(rbblob['@rays']))
+            self.assertEqual(data.shape[1], int(rbblob['@bins']))
+            self.assertRaises(IOError,
+                              lambda: wrl.io.get_RB_blob_from_file('rb_fh',
                                                                rbblob))
 
     def test_get_RB_file_as_string(self):
@@ -415,18 +415,18 @@ class RainbowTest(unittest.TestCase):
         rb_file = wrl.util.get_wradlib_data_file(filename)
         with open(rb_file) as rb_fh:
             rb_string = wrl.io.get_RB_file_as_string(rb_fh)
-        self.assertTrue(rb_string)
-        self.assertRaises(IOError,
-                          lambda: wrl.io.get_RB_file_as_string('rb_file'))
+            self.assertTrue(rb_string)
+            self.assertRaises(IOError,
+                              lambda: wrl.io.get_RB_file_as_string('rb_fh'))
 
     def test_get_RB_header(self):
         filename = 'rainbow/2013070308340000dBuZ.azi'
         rb_file = wrl.util.get_wradlib_data_file(filename)
         with open(rb_file) as rb_fh:
             rb_header = wrl.io.get_RB_header(rb_fh)
-        self.assertEqual(rb_header['volume']['@version'], '5.34.16')
-        self.assertRaises(IOError,
-                          lambda: wrl.io.get_RB_header('rb_file'))
+            self.assertEqual(rb_header['volume']['@version'], '5.34.16')
+            self.assertRaises(IOError,
+                              lambda: wrl.io.get_RB_header('rb_fh'))
 
 
 if __name__ == '__main__':

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -307,7 +307,17 @@ class RadolanTest(unittest.TestCase):
 
 class RainbowTest(unittest.TestCase):
     def test_read_rainbow(self):
-        pass
+        filename = 'rainbow/2013070308340000dBuZ.azi'
+        rb_file = wrl.util.get_wradlib_data_file(filename)
+        # Test reading from file name
+        rb_dict = wrl.io.read_Rainbow(rb_file)
+        self.assertEqual(rb_dict[u'volume'][u'@datetime'],
+                         u'2013-07-03T08:33:55')
+        # Test reading from file handle
+        with open(rb_file, 'rb') as rb_fh:
+            rb_dict = wrl.io.read_Rainbow(rb_fh)
+            self.assertEqual(rb_dict[u'volume'][u'@datetime'],
+                             u'2013-07-03T08:33:55')
 
     def test_find_key(self):
         indict = {'A': {'AA': {'AAA': 0, 'X': 1},

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -430,7 +430,6 @@ class RainbowTest(unittest.TestCase):
                           lambda: wrl.io.get_RB_blob_from_file('rb_fh',
                                                                rbblob))
 
-
     def test_get_RB_file_as_string(self):
         filename = 'rainbow/2013070308340000dBuZ.azi'
         rb_file = wrl.util.get_wradlib_data_file(filename)

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -402,7 +402,8 @@ class RainbowTest(unittest.TestCase):
         rb_file = wrl.util.get_wradlib_data_file(filename)
         rbdict = wrl.io.read_Rainbow(rb_file, loaddata=False)
         rbblob = rbdict['volume']['scan']['slice']['slicedata']['rawdata']
-        data = wrl.io.get_RB_blob_from_file(rb_file, rbblob)
+        with open(rb_file) as rb_fh:
+            data = wrl.io.get_RB_blob_from_file(rb_fh, rbblob)
         self.assertEqual(data.shape[0], int(rbblob['@rays']))
         self.assertEqual(data.shape[1], int(rbblob['@bins']))
         self.assertRaises(IOError,
@@ -412,7 +413,8 @@ class RainbowTest(unittest.TestCase):
     def test_get_RB_file_as_string(self):
         filename = 'rainbow/2013070308340000dBuZ.azi'
         rb_file = wrl.util.get_wradlib_data_file(filename)
-        rb_string = wrl.io.get_RB_file_as_string(rb_file)
+        with open(rb_file) as rb_fh:
+            rb_string = wrl.io.get_RB_file_as_string(rb_fh)
         self.assertTrue(rb_string)
         self.assertRaises(IOError,
                           lambda: wrl.io.get_RB_file_as_string('rb_file'))
@@ -420,7 +422,8 @@ class RainbowTest(unittest.TestCase):
     def test_get_RB_header(self):
         filename = 'rainbow/2013070308340000dBuZ.azi'
         rb_file = wrl.util.get_wradlib_data_file(filename)
-        rb_header = wrl.io.get_RB_header(rb_file)
+        with open(rb_file) as rb_fh:
+            rb_header = wrl.io.get_RB_header(rb_fh)
         self.assertEqual(rb_header['volume']['@version'], '5.34.16')
         self.assertRaises(IOError,
                           lambda: wrl.io.get_RB_header('rb_file'))

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -408,7 +408,7 @@ class RainbowTest(unittest.TestCase):
             self.assertEqual(data.shape[1], int(rbblob['@bins']))
             self.assertRaises(IOError,
                               lambda: wrl.io.get_RB_blob_from_file('rb_fh',
-                                                               rbblob))
+                                                                   rbblob))
 
     def test_get_RB_file_as_string(self):
         filename = 'rainbow/2013070308340000dBuZ.azi'

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -414,6 +414,7 @@ class RainbowTest(unittest.TestCase):
         rb_file = wrl.util.get_wradlib_data_file(filename)
         rbdict = wrl.io.read_Rainbow(rb_file, loaddata=False)
         rbblob = rbdict['volume']['scan']['slice']['slicedata']['rawdata']
+        # Check reading from file handle
         with open(rb_file, 'rb') as rb_fh:
             data = wrl.io.get_RB_blob_from_file(rb_fh, rbblob)
             self.assertEqual(data.shape[0], int(rbblob['@rays']))
@@ -421,6 +422,14 @@ class RainbowTest(unittest.TestCase):
             self.assertRaises(IOError,
                               lambda: wrl.io.get_RB_blob_from_file('rb_fh',
                                                                    rbblob))
+        # Check reading from file path
+        data = wrl.io.get_RB_blob_from_file(rb_file, rbblob)
+        self.assertEqual(data.shape[0], int(rbblob['@rays']))
+        self.assertEqual(data.shape[1], int(rbblob['@bins']))
+        self.assertRaises(IOError,
+                          lambda: wrl.io.get_RB_blob_from_file('rb_fh',
+                                                               rbblob))
+
 
     def test_get_RB_file_as_string(self):
         filename = 'rainbow/2013070308340000dBuZ.azi'

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -402,7 +402,7 @@ class RainbowTest(unittest.TestCase):
         rb_file = wrl.util.get_wradlib_data_file(filename)
         rbdict = wrl.io.read_Rainbow(rb_file, loaddata=False)
         rbblob = rbdict['volume']['scan']['slice']['slicedata']['rawdata']
-        with open(rb_file) as rb_fh:
+        with open(rb_file, 'rb') as rb_fh:
             data = wrl.io.get_RB_blob_from_file(rb_fh, rbblob)
             self.assertEqual(data.shape[0], int(rbblob['@rays']))
             self.assertEqual(data.shape[1], int(rbblob['@bins']))
@@ -413,7 +413,7 @@ class RainbowTest(unittest.TestCase):
     def test_get_RB_file_as_string(self):
         filename = 'rainbow/2013070308340000dBuZ.azi'
         rb_file = wrl.util.get_wradlib_data_file(filename)
-        with open(rb_file) as rb_fh:
+        with open(rb_file, 'rb') as rb_fh:
             rb_string = wrl.io.get_RB_file_as_string(rb_fh)
             self.assertTrue(rb_string)
             self.assertRaises(IOError,
@@ -422,7 +422,7 @@ class RainbowTest(unittest.TestCase):
     def test_get_RB_header(self):
         filename = 'rainbow/2013070308340000dBuZ.azi'
         rb_file = wrl.util.get_wradlib_data_file(filename)
-        with open(rb_file) as rb_fh:
+        with open(rb_file, 'rb') as rb_fh:
             rb_header = wrl.io.get_RB_header(rb_fh)
             self.assertEqual(rb_header['volume']['@version'], '5.34.16')
             self.assertRaises(IOError,


### PR DESCRIPTION
As discussed, [here](https://github.com/cchwala/wradlib/commit/d55678fda5afc9945844f258586d6a47da68e4f3#commitcomment-21557664), this is now the PR to make it possible to read Rainbow files from a file handle, e.g. when reading from a zipped archive.

I assumed that the low level functions do not need the `apichange_kwarg` since nobody ever uses them directly and they only get called by `read_Rainbow`. It would be hard (or impossible without writing to a temp file) to transform the `fid` file handles into the now deprecated `filename` strings because in many cases (or at least in my application) there is no path to the files which e.g. may belong to a zipped archive.

After rebasing on master I cannot run the tests. They fail with "The process has forked and you cannot use this CoreFoundation functionality safely. You MUST exec().". Hence, I hope that the CI runs will complete.
