### PR TITLE
MAINT: replace `runipy` workflow by `execute`-API workflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
     - flake8 .
     - export GDAL_DATA=$HOME/miniconda/envs/wradlib/share/gdal
     - export WRADLIB_DATA=$HOME/wradlib-data
-    - export WRADLIB_NOTEBOOKS=$HOME/notebooks-render
+    - export WRADLIB_NOTEBOOKS=$TRAVIS_BUILD_DIR/notebooks-render
     # duplicate notebooks folder
     - mkdir $WRADLIB_NOTEBOOKS && cp -R notebooks $WRADLIB_NOTEBOOKS/
     # convert notebooks

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,12 @@ install:
 
 before_script:
     - flake8 .
-    # convert notebooks, render notebooks
     - export GDAL_DATA=$HOME/miniconda/envs/wradlib/share/gdal
     - export WRADLIB_DATA=$HOME/wradlib-data
+    - export WRADLIB_NOTEBOOKS=$HOME/notebooks-render
+    # duplicate notebooks folder
+    - mkdir $WRADLIB_NOTEBOOKS && cp -R notebooks $WRADLIB_NOTEBOOKS/
+    # convert notebooks
     - scripts/convert_notebooks.sh
     - export DISPLAY=:99
     - sh -e /etc/init.d/xvfb start
@@ -48,7 +51,7 @@ script:
 
 after_success:
     - if [[ "$COVERAGE" == "true" ]]; then codecov || echo "failed"; fi
-    - if [[ "$DOC_BUILD" == "true" ]]; then scripts/render_notebooks.sh; fi
+    - if [[ "$DOC_BUILD" == "true" ]]; then scripts/copy_notebooks.sh; fi
     - if [[ "$DOC_BUILD" == "true" ]]; then cd $TRAVIS_BUILD_DIR; scripts/build_docs.sh; fi
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   global:
     # wradlib-docs
     - secure: "CjaL6vDvKqTaKClp6pqAlS7nyCN5WenEH0OS+zGvb2P7FF0bl5VU3xVZJl60OG0c7/ft/wsYSpFT9VzXZTuLo7+FOpiIuECOujYyAcFDU+NWS1YtRLYXj7z/8DV6VIl2BjQc/sOczF0Jv556UdNLOQP6b5KTxhx4xCCTHHQ1s1Lg14RVnUT+HiJGC8C5y0Fsh1GPTQywZ0aLAPWU7CQeRtsqH3PuBznRvmmfwkFKJhXAxdIj1lv9jBgwwpDgzPgPT7dMiGOkN0k8B5alMBRLB0SmEtabn1SHCSTExocze6SduxlGt1iPRJTY+VO9PxCmqDDiO8rD+Qya/TxnAU8Zgzxeq77ckG3er0dS4M6fsF/vre7E93VYRqI+e5XJCVsUzhlIoSrgq0OEa6UeRAJzahVXTFGhb/t4dpYjiW3yMwDUzK+gLYdClutBy7zIEu68h/4dwQDy9POEaL/8Zfwa0J64vJscOqTFj/9E4EjjQKVG8qT0QoIezTue6RMTK3BcBVRHSsACzemGKyIOzVjIbdxi9gLGf3wxRTiuzRzZ3SjC1LVaxzw982c/1xfrnJVhgU9pL+xb0yPvGNW8clZhVVEceuYRU+9zL77abDgBIxoUAzHB2LjDMCr2f3w89RQYQxDvmDsmLPXGyMQuLtIP1rIwC5+mydj9hP29KsIkgwQ="
+    - WRADLIB_BUILD_DIR=$TRAVIS_BUILD_DIR
 
 matrix:
     include:
@@ -37,7 +38,7 @@ before_script:
     - flake8 .
     - export GDAL_DATA=$HOME/miniconda/envs/wradlib/share/gdal
     - export WRADLIB_DATA=$HOME/wradlib-data
-    - export WRADLIB_NOTEBOOKS=$TRAVIS_BUILD_DIR/notebooks-render
+    - export WRADLIB_NOTEBOOKS=$WRADLIB_BUILD_DIR/notebooks-render
     # duplicate notebooks folder
     - mkdir $WRADLIB_NOTEBOOKS && cp -R notebooks $WRADLIB_NOTEBOOKS/
     # convert notebooks
@@ -52,7 +53,7 @@ script:
 after_success:
     - if [[ "$COVERAGE" == "true" ]]; then codecov || echo "failed"; fi
     - if [[ "$DOC_BUILD" == "true" ]]; then scripts/copy_notebooks.sh; fi
-    - if [[ "$DOC_BUILD" == "true" ]]; then cd $TRAVIS_BUILD_DIR; scripts/build_docs.sh; fi
+    - if [[ "$DOC_BUILD" == "true" ]]; then cd $WRADLIB_BUILD_DIR; scripts/build_docs.sh; fi
 
 deploy:
   # devel

--- a/scripts/build_docs.sh
+++ b/scripts/build_docs.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-cd "$TRAVIS_BUILD_DIR"
+cd "$WRADLIB_BUILD_DIR"
 
 # print the vars
 echo "TRAVIS_PULL_REQUEST " $TRAVIS_PULL_REQUEST

--- a/scripts/convert_notebooks.sh
+++ b/scripts/convert_notebooks.sh
@@ -9,6 +9,4 @@ echo $notebooks
 # convert notebooks to python scripts
 for nb in $notebooks; do
     jupyter nbconvert --to script $nb
-    # this is for testrunner.py finding the notebook- tests
-    touch "${nb%/*}/__init__.py"
 done

--- a/scripts/copy_notebooks.sh
+++ b/scripts/copy_notebooks.sh
@@ -2,25 +2,19 @@
 # Copyright (c) 2016, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
-# duplicate folder
-mkdir notebooks-render
-cp -R notebooks notebooks-render/
-
-cd notebooks-render
+cd $WRADLIB_NOTEBOOKS
 # get notebooks list
 notebooks=`find notebooks -path notebooks/*.ipynb_checkpoints -prune -o -name *.ipynb -print`
 echo $notebooks
 
-# render notebooks to doc/sources
+# copy notebooks to doc/sources
 for nb in $notebooks; do
-    echo "runipy --quiet --overwrite --matplotlib $nb"
-    runipy --quiet --overwrite --matplotlib $nb
-    cp --parents $nb ../doc/source/
+    cp --parents $nb $TRAVIS_BUILD_DIR/doc/source/
 done
 
 # copy images to docs too
 images=`find notebooks -path notebooks/*.ipynb_checkpoints -prune -o -name *.png -print`
 echo $images
 for im in $images; do
-    cp --parents $im ../doc/source/
+    cp --parents $im $TRAVIS_BUILD_DIR/doc/source/
 done

--- a/scripts/copy_notebooks.sh
+++ b/scripts/copy_notebooks.sh
@@ -9,12 +9,12 @@ echo $notebooks
 
 # copy notebooks to doc/sources
 for nb in $notebooks; do
-    cp --parents $nb $TRAVIS_BUILD_DIR/doc/source/
+    cp --parents $nb $WRADLIB_BUILD_DIR/doc/source/
 done
 
 # copy images to docs too
 images=`find notebooks -path notebooks/*.ipynb_checkpoints -prune -o -name *.png -print`
 echo $images
 for im in $images; do
-    cp --parents $im $TRAVIS_BUILD_DIR/doc/source/
+    cp --parents $im $WRADLIB_BUILD_DIR/doc/source/
 done

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -4,23 +4,41 @@
 
 exit_status=0
 
+# export location of .coveragerc
 if [[ "$COVERAGE" == "true" ]]; then
-    #export COVERAGE_PROCESS_START=".coveragerc"
-    coverage run --source wradlib testrunner.py -u -s
+    export COVERAGE_PROCESS_START=$WRADLIB_BUILD_DIR/.coveragerc
+    # run tests, retrieve exit status
+    ./testrunner.py -u -c -s
     (( exit_status = ($? || $exit_status) ))
-    coverage run --source wradlib testrunner.py -d -s
+    ./testrunner.py -d -c -s
     (( exit_status = ($? || $exit_status) ))
-    coverage run --source wradlib testrunner.py -e -s
+    ./testrunner.py -e -c -s
     (( exit_status = ($? || $exit_status) ))
-    coverage run --source wradlib testrunner.py -n -s
+    ./testrunner.py -n -c -s
     (( exit_status = ($? || $exit_status) ))
-    coverage combine
+
+    # copy .coverage files to cov-folder
+    cov=`find . -name *.coverage.* -print`
+    echo $cov
+    mkdir -p cov
+    for cv in $cov; do
+        mv $cv cov/.
+    done
+
+    # combine coverage, remove cov-folder
+    coverage combine cov
+    rm -rf cov
 
 else
-    python testrunner.py -u -s
-    python testrunner.py -d -s
-    python testrunner.py -e -s
-    python testrunner.py -n -s
+    # run tests, retrieve exit status
+    ./testrunner.py -u -s
+    (( exit_status = ($? || $exit_status) ))
+    ./testrunner.py -d -s
+    (( exit_status = ($? || $exit_status) ))
+    ./testrunner.py -e -s
+    (( exit_status = ($? || $exit_status) ))
+    ./testrunner.py -n -s
+    (( exit_status = ($? || $exit_status) ))
 fi
 
 exit $exit_status

--- a/testrunner.py
+++ b/testrunner.py
@@ -1,13 +1,7 @@
-# ------------------------------------------------------------------------------
-# Name:        testrunner.py
-# Purpose:     testrunner for unittest, doctest, examples and notebook tests
-#
-# Author:      Kai Muehlbauer
-#
-# Created:     03.03.2014
-# Copyright:   (c) wradlib developers 2017
-# Licence:     The MIT License
-# ------------------------------------------------------------------------------
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+# Copyright (c) 2017, wradlib developers.
+# Distributed under the MIT License. See LICENSE.txt for more info.
 
 import sys
 import os
@@ -20,6 +14,7 @@ from multiprocessing import Process, Queue
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError
+import coverage
 
 VERBOSE = 2
 
@@ -57,9 +52,10 @@ def create_examples_testsuite():
 
 
 class NotebookTest(unittest.TestCase):
-    def __init__(self, nbfile):
+    def __init__(self, nbfile, cov):
         super(NotebookTest, self).__init__()
         self.nbfile = nbfile
+        self.cov = cov
 
     def runTest(self):
         print(self.nbfile)
@@ -68,6 +64,14 @@ class NotebookTest(unittest.TestCase):
 
         with open(self.nbfile) as f:
             nb = nbformat.read(f, as_version=4)
+            if self.cov:
+                covdict = {'cell_type': 'code', 'execution_count': 1,
+                           'metadata': {'collapsed': True}, 'outputs': [],
+                           'nbsphinx': 'hidden',
+                           'source': 'import coverage\n'
+                                     'coverage.process_startup()\n'}
+                nb['cells'].insert(0, nbformat.from_dict(covdict))
+
             exproc = ExecutePreprocessor(kernel_name=kernel, timeout=500)
 
             try:
@@ -75,18 +79,22 @@ class NotebookTest(unittest.TestCase):
             except CellExecutionError as e:
                 raise e
 
+        if self.cov:
+            nb['cells'].pop(0)
+
         with io.open(self.nbfile, 'wt') as f:
             nbformat.write(nb, f)
 
         self.assertTrue(True)
 
 
-def create_notebooks_testsuite():
+def create_notebooks_testsuite(**kwargs):
     # gather information on notebooks
     # all notebooks in the notebooks folder
     # are considered as tests
     # find notebook files in notebooks directory
-    root_dir = os.getenv('WRADLIB_NOTEBOOKS', 'notebooks/')
+    cov = kwargs.pop('cov')
+    root_dir = os.getenv('WRADLIB_NOTEBOOKS', 'notebooks')
     files = []
     skip = []
     for root, _, filenames in os.walk(root_dir):
@@ -104,7 +112,7 @@ def create_notebooks_testsuite():
     suites = []
     for file in files:
         suite = unittest.TestSuite()
-        suite.addTest(NotebookTest(file))
+        suite.addTest(NotebookTest(file, cov))
         suites.append(suite)
 
     return suites
@@ -152,8 +160,16 @@ def create_unittest_testsuite():
     return suite
 
 
-def single_suite_process(queue, test, verbosity):
+def single_suite_process(queue, test, verbosity, **kwargs):
+    test_cov = kwargs.pop('coverage', 0)
+    test_nb = kwargs.pop('notebooks', 0)
+    if test_cov and not test_nb:
+        cov = coverage.coverage()
+        cov.start()
     res = unittest.TextTestRunner(verbosity=verbosity).run(test)
+    if test_cov and not test_nb:
+        cov.stop()
+        cov.save()
     queue.put(res.wasSuccessful())
 
 
@@ -186,10 +202,18 @@ def main(args):
         -u
         --unit
             Run only unit test
+        
+        -n
+        --notebook
+            Run only notebook test
 
         -s
         --use-subprocess
             Run every testsuite in a subprocess.
+        
+        -c
+        --coverage
+            Run notebook tests with code coverage
 
         -v level
             Set the level of verbosity.
@@ -209,13 +233,14 @@ def main(args):
     test_notebooks = 0
     test_units = 0
     test_subprocess = 0
+    test_cov = 0
     verbosity = VERBOSE
 
     try:
-        options, arg = getopt.getopt(args, 'aednushv:',
+        options, arg = getopt.getopt(args, 'aednuschv:',
                                      ['all', 'example', 'doc',
                                       'notebook', 'unit', 'use-subprocess',
-                                      'help'])
+                                      'coverage', 'help'])
     except getopt.GetoptError as e:
         err_exit(e.msg)
 
@@ -234,6 +259,8 @@ def main(args):
             test_units = 1
         elif name in ('-s', '--use-subprocess'):
             test_subprocess = 1
+        elif name in ('-c', '--coverage'):
+            test_cov = 1
         elif name in ('-h', '--help'):
             err_exit(usage_message, 0)
         elif name == '-v':
@@ -254,13 +281,15 @@ def main(args):
 
     if test_all:
         testSuite.append(unittest.TestSuite(create_examples_testsuite()))
-        testSuite.append(unittest.TestSuite(create_notebooks_testsuite()))
+        testSuite.append(unittest.
+                         TestSuite(create_notebooks_testsuite(cov=test_cov)))
         testSuite.append(unittest.TestSuite(create_doctest_testsuite()))
         testSuite.append(unittest.TestSuite(create_unittest_testsuite()))
     elif test_examples:
         testSuite.append(unittest.TestSuite(create_examples_testsuite()))
     elif test_notebooks:
-        testSuite.extend(unittest.TestSuite(create_notebooks_testsuite()))
+        testSuite.extend(unittest.
+                         TestSuite(create_notebooks_testsuite(cov=test_cov)))
     elif test_docs:
         testSuite.append(unittest.TestSuite(create_doctest_testsuite()))
     elif test_units:
@@ -270,23 +299,31 @@ def main(args):
     if test_subprocess:
         for test in testSuite:
             queue = Queue()
-            proc = Process(target=single_suite_process, args=(queue, test,
-                                                              verbosity))
+            keywords = {'coverage': test_cov, 'notebooks': test_notebooks}
+            proc = Process(target=single_suite_process,
+                           args=(queue, test, verbosity),
+                           kwargs=keywords)
             proc.start()
             result = queue.get()
             proc.join()
             # all_success should be 0 in the end
             all_success = all_success & result
     else:
+        if test_cov and not test_notebooks:
+            cov = coverage.coverage()
+            cov.start()
         for test in testSuite:
             result = unittest.TextTestRunner(verbosity=verbosity).run(test)
             # all_success should be 0 in the end
             all_success = all_success & result.wasSuccessful()
+        if test_cov and not test_notebooks:
+            cov.stop()
+            cov.save()
 
     if all_success:
         sys.exit(0)
     else:
-        # This will retrun exit code 1
+        # This will return exit code 1
         sys.exit("At least one test has failed. "
                  "Please see test report for details.")
 

--- a/testrunner.py
+++ b/testrunner.py
@@ -202,7 +202,7 @@ def main(args):
         -u
         --unit
             Run only unit test
-        
+
         -n
         --notebook
             Run only notebook test
@@ -210,7 +210,7 @@ def main(args):
         -s
         --use-subprocess
             Run every testsuite in a subprocess.
-        
+
         -c
         --coverage
             Run notebook tests with code coverage

--- a/testrunner.py
+++ b/testrunner.py
@@ -11,6 +11,7 @@
 
 import sys
 import os
+import io
 import getopt
 import unittest
 import doctest
@@ -67,14 +68,14 @@ class NotebookTest(unittest.TestCase):
 
         with open(self.nbfile) as f:
             nb = nbformat.read(f, as_version=4)
-            exproc = ExecutePreprocessor(kernel_name=kernel, timeout=300)
+            exproc = ExecutePreprocessor(kernel_name=kernel, timeout=500)
 
             try:
                 exproc.preprocess(nb, {'metadata': {'path': current_dir}})
             except CellExecutionError as e:
                 raise e
 
-        with open(self.nbfile, 'wt') as f:
+        with io.open(self.nbfile, 'wt') as f:
             nbformat.write(nb, f)
 
         self.assertTrue(True)

--- a/testrunner.py
+++ b/testrunner.py
@@ -62,11 +62,12 @@ class NotebookTest(unittest.TestCase):
 
     def runTest(self):
         print(self.nbfile)
+        kernel = 'python%d' % sys.version_info[0]
         current_dir = os.path.dirname(self.nbfile)
 
         with open(self.nbfile) as f:
             nb = nbformat.read(f, as_version=4)
-            exproc = ExecutePreprocessor(timeout=300)
+            exproc = ExecutePreprocessor(kernel_name=kernel, timeout=300)
 
             try:
                 exproc.preprocess(nb, {'metadata': {'path': current_dir}})


### PR DESCRIPTION
Since introduction of the [execute-API](http://nbconvert.readthedocs.io/en/latest/execute_api.html#example) it is possible to execute notebooks within unittests. 

This way we can test the notebooks and in the same time get them rendered.