### PR TITLE
WIP: ENH: apply changes to meet GDAL RFC46 

### DIFF
--- a/wradlib/georef.py
+++ b/wradlib/georef.py
@@ -1706,7 +1706,6 @@ def reproject_raster_dataset(src_ds, **kwargs):
     # create destination in-memory raster
     mem_drv = gdal.GetDriverByName('MEM')
 
-    print(rows, cols)
     # and set RasterSize according ro cols/rows
     dst_ds = mem_drv.Create('', cols, rows, 1, gdal.GDT_Float32)
 

--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -1998,7 +1998,7 @@ def write_raster_dataset(fpath, dataset, format, options=None, remove=False):
     options : list
         List of option strings for the corresponding format.
     remove : bool
-        if True, existing OGR.DataSource will be
+        if True, existing gdal.Dataset will be
         removed before creation
 
     Note
@@ -2334,7 +2334,7 @@ def read_raster_data(filename, driver=None, **kwargs):
 
 def open_shape(filename, driver=None):
     """
-    Open shapefile, return ogr dataset and layer
+    Open shapefile, return gdal.Dataset and OGR.Layer
 
     .. warning:: dataset and layer have to live in the same context,
                  if dataset is deleted all layer references will get lost
@@ -2350,7 +2350,7 @@ def open_shape(filename, driver=None):
 
     Returns
     -------
-    dataset : ogr.Dataset
+    dataset : gdal.Dataset
         dataset
     layer : ogr.Layer
         layer
@@ -2368,7 +2368,7 @@ def open_shape(filename, driver=None):
 
 def open_raster(filename, driver=None):
     """
-    Open raster file, return ogr dataset
+    Open raster file, return gdal.Dataset
 
     .. versionadded:: 0.6.0
 
@@ -2381,7 +2381,7 @@ def open_raster(filename, driver=None):
 
     Returns
     -------
-    dataset : ogr.Dataset
+    dataset : gdal.Dataset
         dataset
     """
 

--- a/wradlib/tests/test_zonalstats.py
+++ b/wradlib/tests/test_zonalstats.py
@@ -242,25 +242,31 @@ class ZonalStatsUtilTest(unittest.TestCase):
         self.ogrobj = zonalstats.numpy_to_ogr(self.npobj, 'Polygon')
 
     def test_gdal_create_dataset(self):
-        ds = zonalstats.gdal_create_dataset('GTiff', 'test.tif', 100, 100,
-                                            gdal.GDT_Float32)
+        ds = zonalstats.gdal_create_dataset('GTiff', 'test.tif', 100, 100, 1,
+                                            gdal_type=gdal.GDT_Float32)
         del ds
-        ds = zonalstats.gdal_create_dataset('GTiff', 'test.tif', 100, 100,
-                                            gdal.GDT_Float32, remove=True)
+        ds = zonalstats.gdal_create_dataset('GTiff', 'test.tif', 100, 100, 1,
+                                            gdal_type=gdal.GDT_Float32,
+                                            remove=True)
         self.assertTrue(isinstance(ds, gdal.Dataset))
         self.assertRaises(IOError,
                           lambda: zonalstats
                           .gdal_create_dataset('GXF',
                                                'test.gxf',
-                                               100, 100,
-                                               gdal.GDT_Float32))
+                                               100, 100, 1,
+                                               gdal_type=gdal.GDT_Float32))
+        del ds
+        ds = zonalstats.gdal_create_dataset('Memory', 'test',
+                                            gdal_type=gdal.OF_VECTOR)
+        self.assertTrue(isinstance(ds, gdal.Dataset))
 
     def test_ogr_create_datasource(self):
         ds = zonalstats.ogr_create_datasource('Memory', 'test')
         self.assertTrue(isinstance(ds, ogr.DataSource))
 
     def test_ogr_create_layer(self):
-        ds = zonalstats.ogr_create_datasource('Memory', 'test')
+        ds = zonalstats.gdal_create_dataset('Memory', 'test',
+                                            gdal_type=gdal.OF_VECTOR)
         self.assertRaises(TypeError,
                           lambda: zonalstats.ogr_create_layer(ds, 'test'))
         lyr = zonalstats.ogr_create_layer(ds, 'test', geom_type=ogr.wkbPoint,


### PR DESCRIPTION
apply changes to meet [GDAL RFC46](https://trac.osgeo.org/gdal/wiki/rfc46_gdal_ogr_unification).

see #149 

This just replaces `OGR.CreateDataSource()` with `gdal.Create()` as recommended in the linked RFC.

@heistermann

As gdal/ogr related code is constantly added to wradlib codebase in different modules, we should think about a major refactoring. We should concentrate those functions in a dedicated module to avoid circular dependencies among wradlib's modules. The module name could be `wradlib.gdal` (other ideas?). 

