### PR TITLE
FIX: add 'QN' header token to RADOLAN reader

### DIFF
--- a/wradlib/io.py
+++ b/wradlib/io.py
@@ -481,7 +481,7 @@ def get_radolan_header_token():
     head = {'BY': None, 'VS': None, 'SW': None, 'PR': None,
             'INT': None, 'GP': None, 'MS': None, 'LV': None,
             'CS': None, 'MX': None, 'BG': None, 'ST': None,
-            'VV': None, 'MF': None}
+            'VV': None, 'MF': None, 'QN': None}
     return head
 
 
@@ -600,6 +600,8 @@ def parse_DWD_quant_composite_header(header):
                 out['predictiontime'] = int(header[v[0]:v[1]])
             if k == 'MF':
                 out['moduleflag'] = int(header[v[0]:v[1]])
+            if k == 'QN':
+                out['quantification'] = int(header[v[0]:v[1]])
     return out
 
 

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -295,7 +295,7 @@ class RadolanTest(unittest.TestCase):
             if type(value) == np.ndarray:
                 self.assertTrue(np.allclose(value, test_rq[key]))
             else:
-                self.assertEqual(value, test_pg[key])
+                self.assertEqual(value, test_rq[key])
 
     def test_read_RADOLAN_composite(self):
         filename = 'radolan/misc/raa01-rw_10000-1408030950-dwd---bin.gz'


### PR DESCRIPTION
Add 'QN' header token to RADOLAN reader

closes #153 