### PR TITLE
FIX: latex equations not displayed

### DIFF
--- a/notebooks/radolan/radolan_grid.ipynb
+++ b/notebooks/radolan/radolan_grid.ipynb
@@ -42,32 +42,32 @@
     "\n",
     "With formulas (1), (2) and (3) the geographic reference points ($\\lambda$, $\\phi$) can be converted to projected cartesian coordinates. The calculated (x y) is the distance vector to the origign of the cartesian coordinate system (north pole).\n",
     "\n",
-    "\\begin{equation}\n",
+    "$\\begin{equation}\n",
     "x = R * M(\\phi) * cos(\\phi) * sin(\\lambda - \\lambda_0)\n",
     "\\tag{1}\n",
-    "\\end{equation}\n",
+    "\\end{equation}$\n",
     "\n",
-    "\\begin{equation}\n",
+    "$\\begin{equation}\n",
     "y = -R * M(\\phi) * cos(\\phi) * cos(\\lambda - \\lambda_0)\n",
     "\\tag{2}\n",
-    "\\end{equation}\n",
+    "\\end{equation}$\n",
     "\n",
-    "\\begin{equation}\n",
+    "$\\begin{equation}\n",
     "M(\\phi) =  \\frac {1 + sin(\\phi_0)} {1 + sin(\\phi)}\n",
     "\\tag{3}\n",
-    "\\end{equation}\n",
+    "\\end{equation}$\n",
     "\n",
     "Assumed the point ($10.0^{\\circ}E$, $90.0^{\\circ}N$) is defined as coordinate system origin. Then all ccordinates can be calculated with the known grid-spacing d as:\n",
     "\n",
-    "\\begin{equation}\n",
+    "$\\begin{equation}\n",
     "x = x_0 + d * (j - j_0)\n",
     "\\tag{4}\n",
-    "\\end{equation}\n",
+    "\\end{equation}$\n",
     "\n",
-    "\\begin{equation}\n",
+    "$\\begin{equation}\n",
     "y = y_0 + d * (i - i_0)\n",
     "\\tag{5}\n",
-    "\\end{equation}\n",
+    "\\end{equation}$\n",
     "\n",
     "with i, j as cartesian indices.\n",
     "\n",
@@ -96,9 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "radolan_grid_xy = wrl.georef.get_radolan_grid(900,900)\n",
@@ -108,9 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "radolan_grid_ll = wrl.georef.get_radolan_grid(900,900, wgs84=True)\n",
@@ -130,15 +126,15 @@
    "source": [
     "The geographic coordinates of specific datapoints can be calculated by using the cartesian coordinates (x,y) and the following formulas:\n",
     "\n",
-    "\\begin{equation}\n",
+    "$\\begin{equation}\n",
     "\\lambda = \\arctan\\left(\\frac {-x} {y}\\right) + \\lambda_0\n",
     "\\tag{6}\n",
-    "\\end{equation}\n",
+    "\\end{equation}$\n",
     "   \n",
-    "\\begin{equation}\n",
+    "$\\begin{equation}\n",
     "\\phi = \\arcsin\\left(\\frac {R^2 * \\left(1 + \\sin\\phi_0\\right)^2 - \\left(x^2 + y^2\\right)} {R^2 * \\left(1 + \\sin\\phi_0\\right)^2 + \\left(x^2 + y^2\\right)}\\right)\n",
     "\\tag{7}\n",
-    "\\end{equation}"
+    "\\end{equation}$"
    ]
   },
   {
@@ -163,10 +159,10 @@
     "\n",
     "For the scale_factor the intersection of the projection plane with the earth sphere at $60.0^{\\circ}N$ has to be taken into account:\n",
     "\n",
-    "\\begin{equation}\n",
+    "$\\begin{equation}\n",
     "scale\\_factor = \\frac {1 + \\sin\\left(60.^{\\circ}\\right)} {1 + \\sin\\left(90.^{\\circ}\\right)} = 0.93301270189\n",
     "\\tag{8}\n",
-    "\\end{equation}\n",
+    "\\end{equation}$\n",
     "\n",
     "Also, the `PROJECTION[\"Stereographic_North_Pole\"]` isn't known within GDAL/OSR. It has to be changed to the known `PROJECTION[\"polar_stereographic\"]`.\n",
     "\n",
@@ -176,9 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "proj_stereo = wrl.georef.create_osr(\"dwd-radolan\")\n",
@@ -209,9 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# create radolan projection osr object\n",
@@ -238,9 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from osgeo import osr\n",
@@ -260,9 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "radolan_grid_ll = wrl.georef.reproject(radolan_grid_xy, projection_source=proj_stereo, projection_target=proj_wgs)\n",
@@ -279,9 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "radolan_grid_xy = wrl.georef.reproject(radolan_grid_ll, projection_source=proj_wgs, projection_target=proj_stereo)\n",
@@ -298,9 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# create Gauss Krueger zone 3 projection osr object\n",


### PR DESCRIPTION
latex equations in notebooks need to be within two "$" in any case to be properly processed with nbsphinx

closes #161 