### PR TITLE
ENH: introduce flags to code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ script:
     - scripts/run_tests.sh
 
 after_success:
-    - if [[ "$COVERAGE" == "true" ]]; then codecov -f coverage-unittests -F unittests || echo "failed"; fi
-    - if [[ "$COVERAGE" == "true" ]]; then codecov -f coverage-doctests -F doctests || echo "failed"; fi
-    - if [[ "$COVERAGE" == "true" ]]; then codecov -f coverage-notebooktests -F notebooktests|| echo "failed"; fi
+    - if [[ "$COVERAGE" == "true" ]]; then codecov -f "$WRADLIB_BUILD_DIR/coverage-unittests" -F unittests || echo "failed"; fi
+    - if [[ "$COVERAGE" == "true" ]]; then codecov -f "$WRADLIB_BUILD_DIR/coverage-doctests" -F doctests || echo "failed"; fi
+    - if [[ "$COVERAGE" == "true" ]]; then codecov -f "$WRADLIB_BUILD_DIR/coverage-notebooktests" -F notebooktests|| echo "failed"; fi
     - if [[ "$DOC_BUILD" == "true" ]]; then scripts/copy_notebooks.sh; fi
     - if [[ "$DOC_BUILD" == "true" ]]; then cd $WRADLIB_BUILD_DIR; scripts/build_docs.sh; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ script:
     - scripts/run_tests.sh
 
 after_success:
-    - if [[ "$COVERAGE" == "true" ]]; then codecov -f "$WRADLIB_BUILD_DIR/coverage-unittests" -F unittests || echo "failed"; fi
-    - if [[ "$COVERAGE" == "true" ]]; then codecov -f "$WRADLIB_BUILD_DIR/coverage-doctests" -F doctests || echo "failed"; fi
-    - if [[ "$COVERAGE" == "true" ]]; then codecov -f "$WRADLIB_BUILD_DIR/coverage-notebooktests" -F notebooktests|| echo "failed"; fi
+    - if [[ "$COVERAGE" == "true" ]]; then codecov -f "$WRADLIB_BUILD_DIR/coverage-unittests.xml" -F unittests || echo "failed"; fi
+    - if [[ "$COVERAGE" == "true" ]]; then codecov -f "$WRADLIB_BUILD_DIR/coverage-doctests.xml" -F doctests || echo "failed"; fi
+    - if [[ "$COVERAGE" == "true" ]]; then codecov -f "$WRADLIB_BUILD_DIR/coverage-notebooktests.xml" -F notebooktests|| echo "failed"; fi
     - if [[ "$DOC_BUILD" == "true" ]]; then scripts/copy_notebooks.sh; fi
     - if [[ "$DOC_BUILD" == "true" ]]; then cd $WRADLIB_BUILD_DIR; scripts/build_docs.sh; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,9 @@ script:
     - scripts/run_tests.sh
 
 after_success:
-    - if [[ "$COVERAGE" == "true" ]]; then codecov || echo "failed"; fi
+    - if [[ "$COVERAGE" == "true" ]]; then codecov -f coverage-unittests -F unittests || echo "failed"; fi
+    - if [[ "$COVERAGE" == "true" ]]; then codecov -f coverage-doctests -F doctests || echo "failed"; fi
+    - if [[ "$COVERAGE" == "true" ]]; then codecov -f coverage-notebooktests -F notebooktests|| echo "failed"; fi
     - if [[ "$DOC_BUILD" == "true" ]]; then scripts/copy_notebooks.sh; fi
     - if [[ "$DOC_BUILD" == "true" ]]; then cd $WRADLIB_BUILD_DIR; scripts/build_docs.sh; fi
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -11,19 +11,19 @@ if [[ "$COVERAGE" == "true" ]]; then
     ./testrunner.py -u -c -s
     (( exit_status = ($? || $exit_status) ))
     coverage combine
-    mv .coverage coverage-unittests
+    coverage xml -o coverage-unittests.xml
     ./testrunner.py -d -c -s
     (( exit_status = ($? || $exit_status) ))
     coverage combine
-    mv .coverage coverage-doctests
+    coverage xml -o coverage-doctests.xml
     ./testrunner.py -e -c -s
     (( exit_status = ($? || $exit_status) ))
     coverage combine
-    mv .coverage coverage-exampletests
+    coverage xml -o coverage-exampletests.xml
     ./testrunner.py -n -c -s
     (( exit_status = ($? || $exit_status) ))
     coverage combine
-    mv .coverage coverage-notebooktests
+    coverage xml -o coverage-notebooktests.xml
 
 else
     # run tests, retrieve exit status

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -10,15 +10,20 @@ if [[ "$COVERAGE" == "true" ]]; then
     # run tests, retrieve exit status
     ./testrunner.py -u -c -s
     (( exit_status = ($? || $exit_status) ))
+    coverage combine
+    mv .coverage coverage-unittests
     ./testrunner.py -d -c -s
     (( exit_status = ($? || $exit_status) ))
+    coverage combine
+    mv .coverage coverage-doctests
     ./testrunner.py -e -c -s
     (( exit_status = ($? || $exit_status) ))
+    coverage combine
+    mv .coverage coverage-exampletests
     ./testrunner.py -n -c -s
     (( exit_status = ($? || $exit_status) ))
-
-    # combine coverage
     coverage combine
+    mv .coverage coverage-notebooktests
 
 else
     # run tests, retrieve exit status


### PR DESCRIPTION
This adds flags to code coverage. Introducing this the combined code coverage as well as the three different tests (doctests, unittests and notebooktests) are shown in the coverage reports.