### PR TITLE
FIX: docs clone root

### DIFF
--- a/doc/source/gettingstarted.rst
+++ b/doc/source/gettingstarted.rst
@@ -18,15 +18,13 @@ If your Anaconda Python installation is working, the following command (in a con
 
 Now you can use the ``conda`` package and environment manager (`conda documentation <http://conda.pydata.org/docs/#>`_) to setup your :math:`\omega radlib` installation.
 
-#. Clone the root environment or create one from scratch::
-
-    $ conda create --name wradlib --clone root
-    or
-    $ conda create --name wradlib python=2.7
-
 #. Add the conda-forge channel, where :math:`\omega radlib` and its dependencies are located. Read more about the community effort `conda-forge <https://conda-forge.github.io/>`_::
 
     $ conda config --add channels conda-forge
+
+#. Create a new environment from scratch::
+
+    $ conda create --name wradlib python=3.6
 
 #. Activate the :math:`\omega radlib` environment
 
@@ -46,6 +44,16 @@ Now you can use the ``conda`` package and environment manager (`conda documentat
 
     Linux/OSX::
 
+        (wradlib) $ echo $GDAL_DATA
+
+    Windows CMD.exe::
+
+        [wradlib] > echo %GDAL_DATA%
+
+#. If not, you can set it like this:
+
+    Linux/OSX::
+
         (wradlib) $ export GDAL_DATA=/path/to/anaconda/envs/wradlib/share/gdal
 
     Windows CMD.exe::
@@ -57,15 +65,15 @@ Now you have a ``conda`` environment with a working :math:`\omega radlib` instal
 Test the integrity of your :math:`\omega radlib` installation by opening a console window and typing calling the python interpreter::
 
     $ python
-    Python 3.5.1 |Continuum Analytics, Inc.| (default, Dec  7 2015, 11:16:01)
-    [GCC 4.4.7 20120313 (Red Hat 4.4.7-1)] on linux
+    Python 3.6.2 | packaged by conda-forge | (default, Jul 23 2017, 22:59:30)
+    [GCC 4.8.2 20140120 (Red Hat 4.8.2-15)] on linux
     Type "help", "copyright", "credits" or "license" for more information.
 
 The Python prompt should appear. Then type::
 
     >>> import wradlib
     >>> wradlib.__version__
-    '0.8.0'
+    '0.10.1'
 
 If everything is ok, this will show the running :math:`\omega radlib` version. If the :math:`\omega radlib` package is not found by the interpreter, you will get::
 

--- a/doc/source/gettingstarted.rst
+++ b/doc/source/gettingstarted.rst
@@ -40,7 +40,7 @@ Now you can use the ``conda`` package and environment manager (`conda documentat
 
     (wradlib) $ conda install wradlib
 
-#. Make sure the GDAL_DATA environment variable (needed for georeferencing) is set within your environment. If not, you can set it like this:
+#. Make sure the GDAL_DATA environment variable (needed for georeferencing) is set within your environment.
 
     Linux/OSX::
 

--- a/notebooks/interpolation/wradlib_ipol_example.ipynb
+++ b/notebooks/interpolation/wradlib_ipol_example.ipynb
@@ -193,7 +193,7 @@
     "def plotall(ax, trgx, trgy, src, interp, pts, title, vmin, vmax):\n",
     "    ix = np.where(np.isfinite(pts))\n",
     "    ax.pcolormesh(trgx, trgy, interp.reshape( (len(trgx),len(trgy) ) ), vmin=vmin, vmax=vmax )\n",
-    "    ax.scatter(src[ix, 0], src[ix, 1], c=pts.ravel()[ix], s=20, marker='s',\n",
+    "    ax.scatter(src[ix, 0].ravel(), src[ix, 1].ravel(), c=pts.ravel()[ix], s=20, marker='s',\n",
     "               vmin=vmin, vmax=vmax)\n",
     "    ax.set_title(title)\n",
     "    pl.axis(\"tight\")"

--- a/testrunner.py
+++ b/testrunner.py
@@ -61,6 +61,7 @@ class NotebookTest(unittest.TestCase):
         return self.nbfile
 
     def runTest(self):
+        print(self.id())
         kernel = 'python%d' % sys.version_info[0]
         cur_dir = os.path.dirname(self.nbfile)
 


### PR DESCRIPTION
As reported in #182 the conda-section in `gettingstarted.rst` is somehow misleading with respect to the cloning of the root environment. This PR removes that part and adds some minor edits to the `GDAL_DATA` treatment.