### PR TITLE
Consider NaNs adequately in weighted composition

### DIFF
--- a/wradlib/comp.py
+++ b/wradlib/comp.py
@@ -199,10 +199,15 @@ def compose_weighted(radargrids, qualitygrids):
     """
     radarinfo = np.array(radargrids)
     qualityinfo = np.array(qualitygrids)
+    # overall nanmask
+    nanmask = np.all(np.isnan(radarinfo), axis=0)
+    # quality grids must contain values only where radarinfo does
+    qualityinfo[np.isnan(radarinfo)] = np.nan
 
     qualityinfo /= np.nansum(qualityinfo, axis=0)
 
     composite = np.nansum(radarinfo * qualityinfo, axis=0)
+    composite[nanmask] = np.nan
 
     return composite
 


### PR DESCRIPTION
In case the quality / weighting grid for the composition are not masked with NaN values outside the radar domain, these areas should be masked based on the radar frids themselves. Otherwise, the resulting weights will be flawed.  