### PR TITLE
MIN: add `open_vector` to io.gdal

### DIFF
--- a/wradlib/io/__init__.py
+++ b/wradlib/io/__init__.py
@@ -32,7 +32,7 @@ from .radolan import (readDX, read_RADOLAN_composite,
                       read_radolan_binary_array,
                       decode_radolan_runlength_array)
 from .gdal import (read_safnwc, write_raster_dataset,
-                   open_shape, open_raster, gdal_create_dataset)
+                   open_shape, open_vector, open_raster, gdal_create_dataset)
 from .iris import (IrisFile, read_iris)
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/wradlib/io/gdal.py
+++ b/wradlib/io/gdal.py
@@ -10,6 +10,7 @@ Raster and Vector I/O using GDAL
    :toctree: generated/
 
    open_shape
+   open_vector
    open_raster
    read_safnwc
    write_raster_dataset
@@ -23,7 +24,43 @@ import os
 # site packages
 from osgeo import gdal, ogr, osr
 
+# wradlib modules
+from .. import util as util
 
+
+def open_vector(filename, driver=None):
+    """Open vector file, return gdal.Dataset and OGR.Layer
+
+        .. warning:: dataset and layer have to live in the same context,
+            if dataset is deleted all layer references will get lost
+
+        .. versionadded:: 0.12.0
+
+    Parameters
+    ----------
+    filename : string
+        vector file name
+    driver : string
+        gdal driver string
+
+    Returns
+    -------
+    dataset : gdal.Dataset
+        dataset
+    layer : ogr.Layer
+        layer
+    """
+    dataset = gdal.OpenEx(filename)
+
+    if driver:
+        gdal.GetDriverByName(driver)
+
+    layer = dataset.GetLayer()
+
+    return dataset, layer
+
+
+@util.deprecated(open_vector)
 def open_shape(filename, driver=None):
     """Open shapefile, return gdal.Dataset and OGR.Layer
 
@@ -75,7 +112,7 @@ def open_raster(filename, driver=None):
         dataset
     """
 
-    dataset = gdal.Open(filename)
+    dataset = gdal.OpenEx(filename)
 
     if driver:
         gdal.GetDriverByName(driver)

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -512,7 +512,7 @@ class RasterTest(unittest.TestCase):
 
 class VectorTest(unittest.TestCase):
     def test_open_vector(self):
-        filename = 'shapefiles/agger/agger_merge.geojson'
+        filename = 'shapefiles/agger/agger_merge.shp'
         geofile = wrl.util.get_wradlib_data_file(filename)
         wrl.io.open_vector(geofile)
 

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -510,6 +510,13 @@ class RasterTest(unittest.TestCase):
         wrl.io.open_raster(geofile)
 
 
+class VectorTest(unittest.TestCase):
+    def test_open_vector(self):
+        filename = 'shapefiles/agger/agger_merge.geojson'
+        geofile = wrl.util.get_wradlib_data_file(filename)
+        wrl.io.open_vector(geofile)
+
+
 class IrisTest(unittest.TestCase):
     def test_open_iris(self):
         filename = 'sigmet/cor-main131125105503.RAW2049'


### PR DESCRIPTION
deprecate `open_shape`, add `test_open_vector`, use `gdal.OpenEx`

closes #193 