### PR TITLE
FIX: deprecate timeseries functions in `util`

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -49,6 +49,17 @@ Version 0.11.3
 * `georef.satellite.sat2pol`
 * `vis.plot_cg_ppi`, `vis.plot_cg_rhi`
 * `util.deprecated`
+* `util.aggregate_equidistant_tseries`
+* `util.aggregate_in_time`
+* `util.sum_over_time_windows`
+* `util.mean_over_time_windows`
+* `util.average_over_time_windows`
+* `util._get_func`
+* `util._tdelta2seconds`
+* `util._get_tdelta`
+* `util.iso2datetime`
+* `util.timestamp2index`
+
 
 
 Version 0.11.2

--- a/wradlib/georef/misc.py
+++ b/wradlib/georef/misc.py
@@ -172,8 +172,8 @@ def bin_altitude(r, theta, sitealt, re, ke=4./3.):
 
     Returns
     -------
-    altitude : float
-        height of the radar bin in [m]
+    altitude : :class:`numpy:numpy.ndarray`
+        Array of heights of the radar bins in [m]
 
     """
     reff = ke * re
@@ -213,8 +213,8 @@ def bin_distance(r, theta, sitealt, re, ke=4./3.):
 
     Returns
     -------
-    distance : float
-        great circle arc distance [m]
+    distance : :class:`numpy:numpy.ndarray`
+        Array of great circle arc distances [m]
     """
     reff = ke * re
     sr = reff + sitealt
@@ -256,8 +256,8 @@ def site_distance(r, theta, binalt, re=None, ke=4./3.):
 
     Returns
     -------
-    distance : float
-        great circle arc distance [m]
+    distance : :class:`numpy:numpy.ndarray`
+        Array of great circle arc distances [m]
     """
     reff = ke * re
     return reff * np.arcsin(r * np.cos(np.radians(theta)) / (reff + binalt))

--- a/wradlib/tests/test_util.py
+++ b/wradlib/tests/test_util.py
@@ -10,6 +10,7 @@ import datetime as dt
 
 
 class HelperFunctionsTest(unittest.TestCase):
+    @util.deprecated.fail_if_not_removed
     def test__get_func(self):
         self.assertEqual(util._get_func('arange').__class__,
                          np.arange.__class__)
@@ -20,6 +21,7 @@ class HelperFunctionsTest(unittest.TestCase):
     def test__shape2size(self):
         self.assertEqual(util._shape2size((10, 10, 10)), 10 * 10 * 10)
 
+    @util.deprecated.fail_if_not_removed
     def test__tdelta2seconds(self):
         self.assertEqual(util._tdelta2seconds(dt.datetime(2001, 1, 1, 1) -
                                               dt.datetime(2000, 1, 1)),
@@ -28,6 +30,7 @@ class HelperFunctionsTest(unittest.TestCase):
                                               dt.datetime(2001, 1, 1)),
                          365 * 24 * 60 * 60 + 3600)
 
+    @util.deprecated.fail_if_not_removed
     def test__get_tdelta(self):
         tstart = dt.datetime(2000, 1, 1)
         tend = dt.datetime(2001, 1, 1, 1)

--- a/wradlib/tests/test_util.py
+++ b/wradlib/tests/test_util.py
@@ -7,10 +7,11 @@ import numpy as np
 import wradlib.util as util
 import unittest
 import datetime as dt
+from deprecation import fail_if_not_removed
 
 
 class HelperFunctionsTest(unittest.TestCase):
-    @util.deprecated.fail_if_not_removed
+    @fail_if_not_removed
     def test__get_func(self):
         self.assertEqual(util._get_func('arange').__class__,
                          np.arange.__class__)
@@ -21,7 +22,7 @@ class HelperFunctionsTest(unittest.TestCase):
     def test__shape2size(self):
         self.assertEqual(util._shape2size((10, 10, 10)), 10 * 10 * 10)
 
-    @util.deprecated.fail_if_not_removed
+    @fail_if_not_removed
     def test__tdelta2seconds(self):
         self.assertEqual(util._tdelta2seconds(dt.datetime(2001, 1, 1, 1) -
                                               dt.datetime(2000, 1, 1)),
@@ -30,7 +31,7 @@ class HelperFunctionsTest(unittest.TestCase):
                                               dt.datetime(2001, 1, 1)),
                          365 * 24 * 60 * 60 + 3600)
 
-    @util.deprecated.fail_if_not_removed
+    @fail_if_not_removed
     def test__get_tdelta(self):
         tstart = dt.datetime(2000, 1, 1)
         tend = dt.datetime(2001, 1, 1, 1)

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -239,6 +239,8 @@ latest/gettingstarted.html#optional-dependencies
     return mod
 
 
+@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
+            current_version=short_version)
 def aggregate_equidistant_tseries(tstart, tend, tdelta, tends_src, tdelta_src,
                                   src, method="sum", minpercvalid=100.):
     """Aggregates an equidistant time series to equidistant target time windows.
@@ -388,6 +390,8 @@ def aggregate_equidistant_tseries(tstart, tend, tdelta, tends_src, tdelta_src,
     return tstarts, tends, agg
 
 
+@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
+            current_version=short_version)
 def aggregate_in_time(src, dt_src, dt_trg, taxis=0, func='sum'):
     """Aggregate time series data to a coarser temporal resolution.
 
@@ -489,6 +493,8 @@ def aggregate_in_time(src, dt_src, dt_trg, taxis=0, func='sum'):
     return trg
 
 
+@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
+            current_version=short_version)
 def sum_over_time_windows(src, dt_src, dt_trg, minpercvalid):
     """Returns the sums of time series <src> within the time windows dt_trg
 
@@ -541,6 +547,8 @@ def sum_over_time_windows(src, dt_src, dt_trg, minpercvalid):
     return accum
 
 
+@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
+            current_version=short_version)
 def mean_over_time_windows(src, dt_src, dt_trg, minbasepoints=1):
     """UNDER DEVELOPMENT: Aggregate time series data to a coarser temporal
     resolution.
@@ -610,6 +618,8 @@ def mean_over_time_windows(src, dt_src, dt_trg, minbasepoints=1):
     return trg
 
 
+@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
+            current_version=short_version)
 def average_over_time_windows(src, dt_src, dt_trg, maxdist=3600,
                               helper_interval=300, **ipargs):
     """UNDER DEVELOPMENT: Computes the average of a time series over given
@@ -694,6 +704,8 @@ def average_over_time_windows(src, dt_src, dt_trg, maxdist=3600,
     return trg
 
 
+@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
+            current_version=short_version)
 def _get_func(funcname):
     """
     Retrieve the numpy function with name <funcname>
@@ -753,6 +765,8 @@ def from_to(tstart, tend, tdelta):
     return tsteps
 
 
+@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
+            current_version=short_version)
 def _tdelta2seconds(tdelta):
     """
     Convert a dt.timedelta object to seconds
@@ -765,6 +779,8 @@ def _tdelta2seconds(tdelta):
     return tdelta.days * 86400 + tdelta.seconds
 
 
+@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
+            current_version=short_version)
 def _get_tdelta(tstart, tend, as_secs=False):
     """Returns the difference between two datetimes
     """
@@ -778,6 +794,8 @@ def _get_tdelta(tstart, tend, as_secs=False):
         return _tdelta2seconds(tend - tstart)
 
 
+@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
+            current_version=short_version)
 def iso2datetime(iso):
     """Converts an ISO formatted time string to a datetime object.
 
@@ -802,6 +820,8 @@ def iso2datetime(iso):
         raise
 
 
+@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
+            current_version=short_version)
 def timestamp2index(ts, delta, refts, **kwargs):
     """Calculates the array index for a certain time in an equidistant
     time-series given the reference time (where the index would be 0)

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -30,7 +30,7 @@ from time import mktime
 import warnings
 import functools
 import os
-from deprecation import deprecated
+from deprecation import deprecated as dep
 
 import numpy as np
 from scipy import interpolate
@@ -44,8 +44,8 @@ warnings.simplefilter('always', DeprecationWarning)
 # warnings.simplefilter('always', FutureWarning)
 
 
-@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
-            current_version=short_version)
+@dep(deprecated_in="0.11.3", removed_in="1.0.0",
+     current_version=short_version)
 def deprecated(replacement=None):
     """A decorator which can be used to mark functions as deprecated.
     replacement is a callable that will be called with the same args
@@ -239,8 +239,8 @@ latest/gettingstarted.html#optional-dependencies
     return mod
 
 
-@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
-            current_version=short_version)
+@dep(deprecated_in="0.11.3", removed_in="1.0.0",
+     current_version=short_version)
 def aggregate_equidistant_tseries(tstart, tend, tdelta, tends_src, tdelta_src,
                                   src, method="sum", minpercvalid=100.):
     """Aggregates an equidistant time series to equidistant target time windows.
@@ -390,8 +390,8 @@ def aggregate_equidistant_tseries(tstart, tend, tdelta, tends_src, tdelta_src,
     return tstarts, tends, agg
 
 
-@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
-            current_version=short_version)
+@dep(deprecated_in="0.11.3", removed_in="1.0.0",
+     current_version=short_version)
 def aggregate_in_time(src, dt_src, dt_trg, taxis=0, func='sum'):
     """Aggregate time series data to a coarser temporal resolution.
 
@@ -493,8 +493,8 @@ def aggregate_in_time(src, dt_src, dt_trg, taxis=0, func='sum'):
     return trg
 
 
-@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
-            current_version=short_version)
+@dep(deprecated_in="0.11.3", removed_in="1.0.0",
+     current_version=short_version)
 def sum_over_time_windows(src, dt_src, dt_trg, minpercvalid):
     """Returns the sums of time series <src> within the time windows dt_trg
 
@@ -547,8 +547,8 @@ def sum_over_time_windows(src, dt_src, dt_trg, minpercvalid):
     return accum
 
 
-@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
-            current_version=short_version)
+@dep(deprecated_in="0.11.3", removed_in="1.0.0",
+     current_version=short_version)
 def mean_over_time_windows(src, dt_src, dt_trg, minbasepoints=1):
     """UNDER DEVELOPMENT: Aggregate time series data to a coarser temporal
     resolution.
@@ -618,8 +618,8 @@ def mean_over_time_windows(src, dt_src, dt_trg, minbasepoints=1):
     return trg
 
 
-@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
-            current_version=short_version)
+@dep(deprecated_in="0.11.3", removed_in="1.0.0",
+     current_version=short_version)
 def average_over_time_windows(src, dt_src, dt_trg, maxdist=3600,
                               helper_interval=300, **ipargs):
     """UNDER DEVELOPMENT: Computes the average of a time series over given
@@ -704,8 +704,8 @@ def average_over_time_windows(src, dt_src, dt_trg, maxdist=3600,
     return trg
 
 
-@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
-            current_version=short_version)
+@dep(deprecated_in="0.11.3", removed_in="1.0.0",
+     current_version=short_version)
 def _get_func(funcname):
     """
     Retrieve the numpy function with name <funcname>
@@ -765,8 +765,8 @@ def from_to(tstart, tend, tdelta):
     return tsteps
 
 
-@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
-            current_version=short_version)
+@dep(deprecated_in="0.11.3", removed_in="1.0.0",
+     current_version=short_version)
 def _tdelta2seconds(tdelta):
     """
     Convert a dt.timedelta object to seconds
@@ -779,8 +779,8 @@ def _tdelta2seconds(tdelta):
     return tdelta.days * 86400 + tdelta.seconds
 
 
-@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
-            current_version=short_version)
+@dep(deprecated_in="0.11.3", removed_in="1.0.0",
+     current_version=short_version)
 def _get_tdelta(tstart, tend, as_secs=False):
     """Returns the difference between two datetimes
     """
@@ -794,8 +794,8 @@ def _get_tdelta(tstart, tend, as_secs=False):
         return _tdelta2seconds(tend - tstart)
 
 
-@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
-            current_version=short_version)
+@dep(deprecated_in="0.11.3", removed_in="1.0.0",
+     current_version=short_version)
 def iso2datetime(iso):
     """Converts an ISO formatted time string to a datetime object.
 
@@ -820,8 +820,8 @@ def iso2datetime(iso):
         raise
 
 
-@deprecated(deprecated_in="0.11.3", removed_in="1.0.0",
-            current_version=short_version)
+@dep(deprecated_in="0.11.3", removed_in="1.0.0",
+     current_version=short_version)
 def timestamp2index(ts, delta, refts, **kwargs):
     """Calculates the array index for a certain time in an equidistant
     time-series given the reference time (where the index would be 0)


### PR DESCRIPTION
- plus minor change in docstrings in `georef.misc`, closes #216