### PR TITLE
ENH: update versioning/release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ PLATFORMS = ["Linux", "Mac OS-X", "Unix", "Windows"]
 MAJOR = 1
 MINOR = 0
 PATCH = 0
-ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, PATCH)
 
 


### PR DESCRIPTION
resolves #263 

With these changes the `git_revision` will be build from the `git describe` command:

`X.Y.Z-N-g0123456`

- X.Y.Z - latest git tag
- N - commits since latest tag
- g0123456 - short git hash

With N = 0 we have a tagged release, with N > 0 we have devel. In the `version.py` is written:

- `short_version` - X.Y.Z
- `version` - X.Y.Z or X.Y.Z-N-g0123456 (depending on release or not)
- `full_version` - X.Y.Z-N-g0123456
- `git_revision` - long git hash
- `release` - True or False

If the the source is no git-repo and the `version.py` is missing, then pre-defined values ('unknown') are written to `version.py`.

Overall this has two benefits:

1. We have a more meaningful `full_version` as described above
2. No need to set `ISRELEASED` before and after cutting release

