### PR TITLE
ENH: enable `ZonalDataBase` to take `DataSource`-object as parameter

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -65,7 +65,7 @@ conda create -n $WRADLIB_ENV --yes pip python=$WRADLIB_PYTHON
 source activate $WRADLIB_ENV
 
 # Install wradlib dependencies
-conda install --yes gdal numpy scipy matplotlib netcdf4 h5py deprecation xmltodict coverage codecov nose nose-timer
+conda install --yes gdal numpy scipy matplotlib=2* netcdf4 h5py deprecation xmltodict coverage codecov nose nose-timer
 conda list
 
 # Install wradlib-data if not set

--- a/wradlib/__init__.py
+++ b/wradlib/__init__.py
@@ -21,7 +21,8 @@ if __WRADLIB_SETUP__:
 else:
     # Make sure that deprecation warnings get printed by default
     import warnings as _warnings
-    _warnings.simplefilter("always", DeprecationWarning)
+    _warnings.filterwarnings('always', category=DeprecationWarning,
+                             module='wradlib')
 
     # versioning
     from .version import git_revision as __git_revision__  # noqa

--- a/wradlib/io/gdal.py
+++ b/wradlib/io/gdal.py
@@ -24,7 +24,7 @@ import os
 from osgeo import gdal, osr
 
 
-def open_vector(filename, driver=None):
+def open_vector(filename, driver=None, layer=0):
     """Open vector file, return gdal.Dataset and OGR.Layer
 
         .. warning:: dataset and layer have to live in the same context,
@@ -36,6 +36,7 @@ def open_vector(filename, driver=None):
         vector file name
     driver : string
         gdal driver string
+    layer : int or string
 
     Returns
     -------
@@ -49,7 +50,7 @@ def open_vector(filename, driver=None):
     if driver:
         gdal.GetDriverByName(driver)
 
-    layer = dataset.GetLayer()
+    layer = dataset.GetLayer(layer)
 
     return dataset, layer
 

--- a/wradlib/tests/test_zonalstats.py
+++ b/wradlib/tests/test_zonalstats.py
@@ -103,7 +103,7 @@ class DataSourceTest(unittest.TestCase):
         proj.ImportFromEPSG(31466)
         filename = util.get_wradlib_data_file('shapefiles/agger/'
                                               'agger_merge.shp')
-        test = zonalstats.DataSource(filename, proj)
+        test = zonalstats.DataSource(filename, srs=proj)
         test.dump_raster(tempfile.NamedTemporaryFile(mode='w+b').name,
                          driver='netCDF', pixel_size=100.)
         test.dump_raster(tempfile.NamedTemporaryFile(mode='w+b').name,
@@ -160,8 +160,21 @@ class ZonalDataBaseTest(unittest.TestCase):
         self.assertIsInstance(zdb.trg, zonalstats.DataSource)
         self.assertIsInstance(zdb.dst, zonalstats.DataSource)
         self.assertEqual(zdb._count_intersections, 2)
+        zd = zonalstats.DataSource(self.src, name='src', srs=self.proj)
+        zdb = zonalstats.ZonalDataBase(zd, self.trg, srs=self.proj)
+        self.assertIsInstance(zdb.src, zonalstats.DataSource)
+        self.assertIsInstance(zdb.trg, zonalstats.DataSource)
+        self.assertIsInstance(zdb.dst, zonalstats.DataSource)
+        self.assertEqual(zdb._count_intersections, 2)
+        zd1 = zonalstats.DataSource(self.src, name='src', srs=self.proj)
+        zd2 = zonalstats.DataSource(self.trg, name='trg', srs=self.proj)
+        zdb = zonalstats.ZonalDataBase(zd1, zd2, srs=self.proj)
+        self.assertIsInstance(zdb.src, zonalstats.DataSource)
+        self.assertIsInstance(zdb.trg, zonalstats.DataSource)
+        self.assertIsInstance(zdb.dst, zonalstats.DataSource)
+        self.assertEqual(zdb._count_intersections, 2)
 
-    def test_coun_intersections(self):
+    def test_count_intersections(self):
         zdb = zonalstats.ZonalDataBase(self.src, self.trg, srs=self.proj)
         self.assertEqual(zdb.count_intersections, 2)
 

--- a/wradlib/zonalstats.py
+++ b/wradlib/zonalstats.py
@@ -62,7 +62,7 @@ import warnings
 
 from .io import open_vector, gdal_create_dataset, write_raster_dataset
 from .georef import (numpy_to_ogr, ogr_add_feature, ogr_copy_layer,
-                     ogr_create_layer, ogr_to_numpy, ogr_copy_layer_by_name)
+                     ogr_create_layer, ogr_to_numpy)
 
 ogr.UseExceptions()
 gdal.UseExceptions()


### PR DESCRIPTION
- add `load_vector`-method to `DataSource`
- enable `ZonalDataBase` to take `DataSource` objects as parameters
- minor change in `io.open_vector`
- adapted tests

- resolves #284