### PR TITLE
FIX: align docstring with actual code and use `sweep`

### DIFF
--- a/wradlib/io/iris.py
+++ b/wradlib/io/iris.py
@@ -116,7 +116,7 @@ class IrisFile(object):
                 If kwdict, retrieves according to given kwdict::
 
                     loaddata = {'moment': ['DB_DBZ', 'DB_VEL'],
-                                'data': [0, 3, 9]}
+                                'sweep': [1, 3, 9]}
         rawdata : bool
             If true, returns raw unconverted/undecoded data.
         debug : bool
@@ -782,7 +782,7 @@ class IrisRawFile(IrisWrapperFile):
 
         loaddata = self.loaddata
         try:
-            sweep = loaddata.copy().pop('data', rsweeps)
+            sweep = loaddata.copy().pop('sweep', rsweeps)
             moment = loaddata.copy().pop('moment', dt_names)
         except AttributeError:
             sweep = rsweeps
@@ -1039,7 +1039,7 @@ def read_iris(filename, loaddata=True, rawdata=False, debug=False):
                 If kwdict, retrieves according to given kwdict::
 
                     loaddata = {'moment': ['DB_DBZ', 'DB_VEL'],
-                                'sweep': [0, 3, 9]}
+                                'sweep': [1, 3, 9]}
 
     rawdata : bool
         If true, returns raw unconverted/undecoded data.

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -784,7 +784,7 @@ class IrisTest(unittest.TestCase):
 
         data_types = ['DB_DBZ', 'DB_VEL']
         selected_data = [1, 3, 8]
-        loaddata = {'moment': data_types, 'data': selected_data}
+        loaddata = {'moment': data_types, 'sweep': selected_data}
         data = wrl.io.read_iris(sigmetfile, loaddata=loaddata, rawdata=True)
         self.assertEqual(list(data['data'][1]['sweep_data'].keys()),
                          data_types)


### PR DESCRIPTION
- align docstring with actual code and use `sweep`
- do not use `0` for sweep number in docstring
- fix tests