### PR TITLE
Fix spherical to xyz

### DIFF
--- a/wradlib/georef/polar.py
+++ b/wradlib/georef/polar.py
@@ -99,10 +99,10 @@ def spherical_to_xyz(r, phi, theta, sitecoords, re=None, ke=4./3.,
     phi = np.asanyarray(phi)
 
     if r.ndim:
-        r.shape = (1,) * (3 - r.ndim) + r.shape
+        r = r.reshape((1,) * (3 - r.ndim) + r.shape)
 
     if phi.ndim:
-        phi.shape = (1,) + phi.shape + (1,) * (2 - phi.ndim)
+        phi = phi.reshape((1,) + phi.shape + (1,) * (2 - phi.ndim))
 
     if not theta.ndim:
         theta = np.broadcast_to(theta, phi.shape)
@@ -115,7 +115,7 @@ def spherical_to_xyz(r, phi, theta, sitecoords, re=None, ke=4./3.,
             dims -= 1
 
     if theta.ndim and phi.ndim:
-        theta.shape = theta.shape + (1,) * (dims - theta.ndim)
+        theta = theta.reshape(theta.shape + (1,) * (dims - theta.ndim))
 
     z = bin_altitude(r, theta, centalt, re, ke=ke)
     dist = site_distance(r, theta, z, re, ke=ke)

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -41,75 +41,68 @@ class CoordinateTransformTest(unittest.TestCase):
                        1694.22337134])))
 
     def test_spherical_to_xyz(self):
-        self.assertTrue(georef.spherical_to_xyz(np.arange(10), np.arange(36),
+        self.assertTrue((1, 36, 10, 3) ==
+                        georef.spherical_to_xyz(np.arange(10),
+                                                np.arange(36),
                                                 10., self.csite,
-                                                squeeze=False)[0].shape ==
-                         (1, 36, 10, 3))
-        self.assertTrue(georef.spherical_to_xyz(np.arange(10), np.arange(36),
+                                                squeeze=False)[0].shape)
+        self.assertTrue((1, 36, 10, 3) ==
+                        georef.spherical_to_xyz(np.arange(10), np.arange(36),
                                                 np.arange(36), self.csite,
-                                                squeeze=False)[0].shape ==
-                        (1, 36, 10, 3))
-        self.assertTrue(georef.spherical_to_xyz(np.arange(10), np.arange(36),
+                                                squeeze=False)[0].shape)
+        self.assertTrue((36, 10, 3) ==
+                        georef.spherical_to_xyz(np.arange(10), np.arange(36),
                                                 np.arange(36), self.csite,
-                                                squeeze=True)[0].shape ==
-                        (36, 10, 3))
-        self.assertTrue(georef.spherical_to_xyz(np.arange(10), np.arange(36),
+                                                squeeze=True,
+                                                strict_dims=False)[0].shape)
+        self.assertTrue((36, 36, 10, 3) ==
+                        georef.spherical_to_xyz(np.arange(10), np.arange(36),
                                                 np.arange(36), self.csite,
-                                                strict_dims=True)[0].shape ==
-                        (36, 36, 10, 3))
-        self.assertTrue(georef.spherical_to_xyz(np.arange(10), np.arange(36),
+                                                strict_dims=True)[0].shape)
+        self.assertTrue((18, 36, 10, 3) ==
+                        georef.spherical_to_xyz(np.arange(10), np.arange(36),
                                                 np.arange(18), self.csite,
-                                                strict_dims=False)[0].shape ==
-                        (18, 36, 10, 3))
+                                                strict_dims=False)[0].shape)
         r, phi = np.meshgrid(np.arange(10), np.arange(36))
-        self.assertTrue(georef.spherical_to_xyz(r, phi,
-                                                10, self.csite,
+        self.assertTrue((1, 36, 10, 3) ==
+                        georef.spherical_to_xyz(r, phi, 10, self.csite,
                                                 squeeze=False,
-                                                strict_dims=False)[0].shape ==
-                        (1, 36, 10, 3))
+                                                strict_dims=False)[0].shape)
         r, phi = np.meshgrid(np.arange(10), np.arange(36))
-        self.assertTrue(georef.spherical_to_xyz(r, phi,
-                                                np.arange(36), self.csite,
-                                                squeeze=False,
-                                                strict_dims=False)[0].shape ==
-                        (1, 36, 10, 3))
+        self.assertTrue((1, 36, 10, 3) ==
+                        georef.spherical_to_xyz(r, phi, np.arange(36),
+                                                self.csite, squeeze=False,
+                                                strict_dims=False)[0].shape)
         r, phi = np.meshgrid(np.arange(10), np.arange(36))
-        self.assertTrue(georef.spherical_to_xyz(r, phi,
-                                                np.arange(18), self.csite,
-                                                squeeze=False,
-                                                strict_dims=False)[0].shape ==
-                        (18, 36, 10, 3))
+        self.assertTrue((18, 36, 10, 3) ==
+                        georef.spherical_to_xyz(r, phi, np.arange(18),
+                                                self.csite, squeeze=False,
+                                                strict_dims=False)[0].shape)
         r, phi = np.meshgrid(np.arange(10), np.arange(36))
-        self.assertTrue(georef.spherical_to_xyz(r, phi,
-                                                np.arange(36), self.csite,
-                                                squeeze=False,
-                                                strict_dims=True)[0].shape ==
-                        (36, 36, 10, 3))
-        self.assertTrue(georef.spherical_to_xyz(10, 36, 10., self.csite,
-                                                squeeze=False,
-                                                )[0].shape ==
-                        (1, 1, 1, 3))
-        self.assertTrue(georef.spherical_to_xyz(np.arange(10), 36, 10.,
+        self.assertTrue((36, 36, 10, 3) ==
+                        georef.spherical_to_xyz(r, phi, np.arange(36),
+                                                self.csite, squeeze=False,
+                                                strict_dims=True)[0].shape)
+        self.assertTrue((1, 1, 1, 3) ==
+                        georef.spherical_to_xyz(10, 36, 10., self.csite,
+                                                squeeze=False)[0].shape)
+        self.assertTrue((1, 1, 10, 3) ==
+                        georef.spherical_to_xyz(np.arange(10), 36, 10.,
                                                 self.csite,
-                                                squeeze=False,
-                                                )[0].shape ==
-                        (1, 1, 10, 3))
-        self.assertTrue(georef.spherical_to_xyz(10, np.arange(36), 10.,
+                                                squeeze=False)[0].shape)
+        self.assertTrue((1, 36, 1, 3) ==
+                        georef.spherical_to_xyz(10, np.arange(36), 10.,
                                                 self.csite,
-                                                squeeze=False,
-                                                )[0].shape ==
-                        (1, 36, 1, 3))
-        self.assertTrue(georef.spherical_to_xyz(10, 36.,np.arange(10),
+                                                squeeze=False)[0].shape)
+        self.assertTrue((10, 1, 1, 3) ==
+                        georef.spherical_to_xyz(10, 36., np.arange(10),
                                                 self.csite,
-                                                squeeze=False,
-                                                )[0].shape ==
-                        (10, 1, 1, 3))
-        self.assertTrue(georef.spherical_to_xyz(10, np.arange(36),
+                                                squeeze=False)[0].shape)
+        self.assertTrue((10, 36, 1, 3) ==
+                        georef.spherical_to_xyz(10, np.arange(36),
                                                 np.arange(10),
                                                 self.csite,
-                                                squeeze=False,
-                                                )[0].shape ==
-                        (10, 36, 1, 3))
+                                                squeeze=False)[0].shape)
 
         coords, rad = georef.spherical_to_xyz(self.r.copy(), self.az.copy(),
                                               self.th.copy(), self.csite,

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -104,8 +104,8 @@ class CoordinateTransformTest(unittest.TestCase):
                                                 self.csite,
                                                 squeeze=False)[0].shape)
 
-        coords, rad = georef.spherical_to_xyz(self.r.copy(), self.az.copy(),
-                                              self.th.copy(), self.csite,
+        coords, rad = georef.spherical_to_xyz(self.r, self.az,
+                                              self.th, self.csite,
                                               squeeze=True, strict_dims=False)
         self.assertTrue(np.allclose(coords[..., 0], self.result_xyz[0],
                         rtol=1e-03))
@@ -114,8 +114,8 @@ class CoordinateTransformTest(unittest.TestCase):
         self.assertTrue(np.allclose(coords[..., 2], self.result_xyz[2],
                         rtol=1e-03))
         re = georef.get_earth_radius(self.csite[1])
-        coords, rad = georef.spherical_to_xyz(self.r.copy(), self.az.copy(),
-                                              self.th.copy(), self.csite,
+        coords, rad = georef.spherical_to_xyz(self.r, self.az,
+                                              self.th, self.csite,
                                               re=re)
         self.assertTrue(np.allclose(coords[..., 0], self.result_xyz[0],
                                     rtol=1e-03))

--- a/wradlib/tests/test_verify.py
+++ b/wradlib/tests/test_verify.py
@@ -41,8 +41,8 @@ class PolarNeighboursTest(unittest.TestCase):
         pn = verify.PolarNeighbours(self.r, self.az, self.site, self.proj,
                                     self.x, self.y, nnear=4)
         bx, by = pn.get_bincoords()
-        self.assertAlmostEqual(bx[0], 3557908.88665658)
-        self.assertAlmostEqual(by[0], 5383452.639404581)
+        np.testing.assert_almost_equal(bx[0], 3557908.88665658)
+        np.testing.assert_almost_equal(by[0], 5383452.639404042)
 
     def test_get_bincoords_at_points(self):
         pn = verify.PolarNeighbours(self.r, self.az, self.site, self.proj,

--- a/wradlib/tests/test_zonalstats.py
+++ b/wradlib/tests/test_zonalstats.py
@@ -508,19 +508,19 @@ class ZonalDataTest(unittest.TestCase):
             for k in range(len(self.zdpoly.isecs[i])):
                 np.testing.assert_array_almost_equal(self.zdpoly.isecs[i, k],
                                                      self.isec_poly[i, k],
-                                                     decimal=7)
+                                                     decimal=3)
 
         np.testing.assert_array_almost_equal(self.zdpoint.isecs,
-                                             self.isec_point, decimal=7)
+                                             self.isec_point, decimal=2)
 
     def test_get_isec(self):
         for i in [0, 1]:
             for k, arr in enumerate(self.zdpoly.get_isec(i)):
                 np.testing.assert_array_almost_equal(arr,
                                                      self.isec_poly[i, k],
-                                                     decimal=7)
+                                                     decimal=3)
             np.testing.assert_array_almost_equal(self.zdpoint.get_isec(i),
-                                                 self.isec_point[i], decimal=7)
+                                                 self.isec_point[i], decimal=2)
 
     def test_get_source_index(self):
         np.testing.assert_array_equal(self.zdpoly.get_source_index(0),


### PR DESCRIPTION
This enhances `spherical_to_xyz` to output the resulting data in a more stringent fashion:

The output will be `(theta, phi, r, 3)` meaning that the dimensions of the output data reflect those of input data. 

Two keywords are added:
`squeeze` - if False output dimensions will not be squeezed, future default, if True output dimensions will be squeezed
`strict_dims` - If True, dimensions with the same length, will be treated on their own, if False equal-length dimensions are "combined/merged". Defaults to true in the future.

Here are some examples:

- Version 1:
    Input: r (1000), phi (360), theta (0), Output: (1, 360, 1000, 3), Squeezed: (360, 1000, 3)
- Version 2:
    Input: r (1000), phi (360), theta (360), Output: (360, 360, 1000, 3), NonStrict: (1, 360, 1000, 3), 
- Version 2b:
    Input: r(1000), phi(360), theta(90), Output: (90, 360, 1000, 3)
- Version 3:
    Input: r (360, 1000), phi(360, 1000), theta (0), Output: (1, 360, 1000, 3), Squeezed: (360, 1000, 3)
- Version 4:
    Input: r (360, 1000), phi(360, 1000), theta (360), Output: (360, 360, 1000, 3), NonStrict: (1, 360, 1000, 3)
- Version 4b:
    Input: r (360, 1000), phi(360, 1000), theta (90), Output: (90, 360, 1000, 3)
-   Version 5:
    Input: r(0), phi(0), theta(0), Output: (1, 1, 1, 3), Squeezed: (3)
-   Version 6:
    Input: r(1000), phi(0), theta(0), Output: (1, 1, 1000, 3), Squeezed: (1000, 3)
-   Version 7:
    Input: r(0), phi(360), theta(0), Output: (1, 360, 1, 3), Squeezed: (360, 3)
-   Version 8:
    Input: r(0), phi(0), theta(90), Output: (90, 1, 1, 3), Squeezed: (90, 3)
-   Version 9:
    Input: r(0), phi(360), theta(90), Output: (360, 90, 1, 3), Squeezed: (90, 360, 3)
-   Version 10:
    Input: r(0), phi(360), theta(360), Output: (360, 360, 1, 3), Squeezed: (360, 360, 3), NonStrict: (1, 360, 1, 3)

