### PR TITLE
Read radolan from piped stdin

### DIFF
--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -622,8 +622,6 @@ def read_radolan_header(fid):
     -------
     header : string
     """
-    # rewind, just in case...
-    fid.seek(0, 0)
 
     header = ''
     while True:


### PR DESCRIPTION
I'd like to read a radolan file from stdin but am prevented from the

>  rewind, just in case...

Unfortunately stdin connected to a pipe is not seekable.

Apart from not seekable, if the user pass in a file handle it is his responsibility to position it correctly. The radolan data may not be contained at the start of the file handle.