### PR TITLE
FIX: skip NaT values to correctly retrieve start and end times

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -73,9 +73,9 @@ conda config --set channel_priority strict
 DEPS="numpy scipy matplotlib netcdf4 h5py xarray deprecation xmltodict semver coverage codecov pytest pytest-cov pytest-xdist pytest-sugar"
 
 if [[ "$GDAL_VERSION" == "2" ]]; then
-    DEPS="$DEPS gdal cartopy"
+    DEPS="$DEPS gdal=$GDAL_VESRION cartopy"
 else
-    DEPS="$DEPS gdal"
+    DEPS="$DEPS gdal=$GDAL_VERSION"
 fi
 
 # Install twine for pypi upload

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -834,7 +834,9 @@ def to_odim(volume, filename):
         # what group p. 21 ff.
         h5_ds_what = h5_dataset.create_group('what')
         ds_what = {}
-        t = sorted(ds.time.values)
+        # skip NaT values
+        valid_times = ~np.isnat(ds.time.values)
+        t = sorted(ds.time.values[valid_times])
         start = dt.datetime.utcfromtimestamp(t[0].astype('O') / 1e9)
         end = dt.datetime.utcfromtimestamp(
             np.rint(t[-1].astype('O') / 1e9))


### PR DESCRIPTION
This skips NaT values for xarray `to_odim` output generation.