### PR TITLE
ENH: minimal xarray wrapper for RADOLAN products

### DIFF
--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -720,7 +720,6 @@ def read_radolan_composite(f, missing=-9999, loaddata=True):
     if attrs['producttype'] in ['RX', 'EX', 'WX']:
         # convert to 8bit integer
         arr = np.frombuffer(indat, np.uint8).astype(np.uint8)
-        #arr = np.where(arr == 250, NODATA, arr)
         attrs['nodatamask'] = np.where(arr == 250)[0]
         attrs['cluttermask'] = np.where(arr == 249)[0]
     elif attrs['producttype'] in ['PG', 'PC']:
@@ -744,7 +743,7 @@ def read_radolan_composite(f, missing=-9999, loaddata=True):
     # anyway, bring it into right shape
     arr = arr.reshape((attrs['nrow'], attrs['ncol']))
 
-    if loaddata is 'xarray':
+    if loaddata == 'xarray':
         arr = radolan_to_xarray(arr, attrs)
     else:
         # apply precision factor

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -627,7 +627,7 @@ class RadolanTest(unittest.TestCase):
         data, attrs = radolan.read_radolan_composite(rx_file,
                                                      loaddata='xarray')
         self.assertEqual(data.RX.shape, (900, 900))
-        self.assertEqual(data.dims, {'x':900, 'y':900})
+        self.assertEqual(data.dims, {'x': 900, 'y': 900})
         self.assertEqual(data.RX.dims, ('y', 'x'))
         self.assertEqual(data.time.values,
                          np.datetime64('2014-08-10T20:50:00.000000000'))

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -615,13 +615,22 @@ class RadolanTest(unittest.TestCase):
 
         filename = 'radolan/misc/raa01-rx_10000-1408102050-dwd---bin.gz'
         rx_file = wrl.util.get_wradlib_data_file(filename)
-        # test for loaddata=False
         data, attrs = radolan.read_radolan_composite(rx_file)
 
         filename = 'radolan/misc/raa00-pc_10015-1408030905-dwd---bin.gz'
         pc_file = wrl.util.get_wradlib_data_file(filename)
-        # test for loaddata=False
         data, attrs = radolan.read_radolan_composite(pc_file)
+
+        # xarray test
+        filename = 'radolan/misc/raa01-rx_10000-1408102050-dwd---bin.gz'
+        rx_file = wrl.util.get_wradlib_data_file(filename)
+        data, attrs = radolan.read_radolan_composite(rx_file,
+                                                     loaddata='xarray')
+        self.assertEqual(data.RX.shape, (900, 900))
+        self.assertEqual(data.dims, {'x':900, 'y':900})
+        self.assertEqual(data.RX.dims, ('y', 'x'))
+        self.assertEqual(data.time.values,
+                         np.datetime64('2014-08-10T20:50:00.000000000'))
 
 
 class RainbowTest(unittest.TestCase):


### PR DESCRIPTION
- simple xarray wrapper for RADOLAN data
- returns xarray.Dataset with data array as well as coordinates (x, y - polar stereographic projection, time)
- data is transparently decoded using netcdf features (scale_factor, add_offset)