### PR TITLE
add missing dependency 'requests'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ gdal
 deprecation
 xmltodict
 semver
+requests


### PR DESCRIPTION
v1.5 is missing a dependency in its `requirements.txt`: `requests`

It's being used [here](https://github.com/wradlib/wradlib/blob/847a3c583081747394d0e55494506b815c5af2e3/wradlib/io/dem.py#L26).