### PR TITLE
MNT: fix imports, license header, requirements

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2011-2018 wradlib developers
+Copyright (c) 2011-2019 wradlib developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,9 @@
-numpy
-scipy
-matplotlib
+deprecation
+gdal
 h5py
 netCDF4
+numpy
+matplotlib
+scipy
 xarray
-gdal
-deprecation
 xmltodict
-semver

--- a/requirements_devel.txt
+++ b/requirements_devel.txt
@@ -1,4 +1,8 @@
-coverage
 codecov
+coverage
 pytest
 pytest-cov
+pytest-sugar
+pytest-xdist
+nbconvert
+nbformat

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 set -e
@@ -70,13 +70,7 @@ conda config --set channel_priority strict
 conda update --yes conda
 
 # Install wradlib dependencies
-DEPS="numpy scipy matplotlib netcdf4 h5py xarray deprecation xmltodict semver coverage codecov pytest pytest-cov pytest-xdist pytest-sugar"
-
-if [[ "$GDAL_VERSION" == "2" ]]; then
-    DEPS="$DEPS gdal=$GDAL_VERSION cartopy"
-else
-    DEPS="$DEPS gdal=$GDAL_VERSION"
-fi
+DEPS="gdal numpy scipy matplotlib netcdf4 h5py xarray cartopy deprecation xmltodict semver coverage codecov pytest pytest-cov pytest-xdist pytest-sugar"
 
 # Install twine for pypi upload
 if [[ "$DEPLOY" == "true" ]]; then

--- a/scripts/testrunner.py
+++ b/scripts/testrunner.py
@@ -1,20 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
-import sys
-import os
-import io
-import getopt
-import unittest
 import doctest
+import getopt
 import inspect
+import io
+import os
+import sys
+import unittest
 from multiprocessing import Process, Queue
+
+import coverage
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
 from nbconvert.preprocessors.execute import CellExecutionError
-import coverage
 
 VERBOSE = 2
 

--- a/scripts/trigger_readthedocs.sh
+++ b/scripts/trigger_readthedocs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 set -e

--- a/setup.py
+++ b/setup.py
@@ -11,16 +11,11 @@ intensity, identifying and correcting typical error sources (such as
 clutter or attenuation) and visualising the data.
 """
 
+import builtins
 import os
-import sys
 import semver
-import warnings
 from subprocess import check_output, CalledProcessError
-
-if sys.version_info[0] < 3:
-    import __builtin__ as builtins
-else:
-    import builtins
+import warnings
 
 DOCLINES = __doc__.split("\n")
 

--- a/wradlib/__init__.py
+++ b/wradlib/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """

--- a/wradlib/adjust.py
+++ b/wradlib/adjust.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -108,15 +108,10 @@ validation results::
    AdjustNone
 
 """
-
-# site packages
 import numpy as np
-from scipy.spatial import cKDTree
-from scipy.stats import linregress
+from scipy import spatial, stats
 
-# wradlib modules
-import wradlib.ipol as ipol
-import wradlib.util as util
+from wradlib import ipol, util
 
 
 class AdjustBase(ipol.IpolBase):
@@ -617,7 +612,7 @@ class AdjustMFB(AdjustBase):
             y = rawatobs[ix][ix_]
             # check whether we should adjust or not
             try:
-                slope, intercept, r, p, stderr = linregress(x, y)
+                slope, intercept, r, p, stderr = stats.linregress(x, y)
             except Exception:
                 slope, r, p = 0, 0, np.inf
             if (slope > self.mfb_args["minslope"]) and \
@@ -788,7 +783,7 @@ def _get_neighbours_ix(obs_coords, raw_coords, nnear):
 
     """
     # plant a tree
-    tree = cKDTree(raw_coords)
+    tree = spatial.cKDTree(raw_coords)
     # return nearest neighbour indices
     return tree.query(obs_coords, k=nnear)[1]
 

--- a/wradlib/atten.py
+++ b/wradlib/atten.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -22,10 +22,9 @@ Attenuation Correction
 
 import logging
 import numpy as np
-import scipy.ndimage
-import scipy.interpolate
-from . import trafo as trafo
-from . import zr as zr
+from scipy import ndimage, interpolate
+
+from wradlib import trafo, zr
 
 logger = logging.getLogger('attcorr')
 
@@ -301,21 +300,21 @@ def _sector_filter(mask, min_sector_size):
     forward_origin = (-(min_sector_size - (min_sector_size // 2)) +
                       min_sector_size % 2)
     backward_origin = (min_sector_size - (min_sector_size // 2)) - 1
-    forward_sum = scipy.ndimage.correlate1d(mask.astype(np.int), kernelb,
-                                            axis=-1, mode='wrap',
-                                            origin=forward_origin)
-    backward_sum = scipy.ndimage.correlate1d(mask.astype(np.int), kernelb,
-                                             axis=-1, mode='wrap',
-                                             origin=backward_origin)
+    forward_sum = ndimage.correlate1d(mask.astype(np.int), kernelb,
+                                      axis=-1, mode='wrap',
+                                      origin=forward_origin)
+    backward_sum = ndimage.correlate1d(mask.astype(np.int), kernelb,
+                                       axis=-1, mode='wrap',
+                                       origin=backward_origin)
     forward_corners = (forward_sum == min_sector_size)
     backward_corners = (backward_sum == min_sector_size)
     forward_large_sectors = np.zeros_like(mask)
     backward_large_sectors = np.zeros_like(mask)
     for iii in range(mask.shape[0]):
-        forward_large_sectors[iii] = scipy.ndimage.morphology.binary_dilation(
+        forward_large_sectors[iii] = ndimage.morphology.binary_dilation(
             forward_corners[iii], kernela[0], origin=forward_origin).astype(
             int)
-        backward_large_sectors[iii] = scipy.ndimage.morphology.binary_dilation(
+        backward_large_sectors[iii] = ndimage.morphology.binary_dilation(
             backward_corners[iii], kernela[0],
             origin=backward_origin).astype(int)
 
@@ -339,9 +338,9 @@ def _interp_atten(pia, invalidbeams):
         # Build the extended pia-array.
         extended_pia = np.concatenate([sub_pia] * 3)
         # Build interpolation class.
-        intp = scipy.interpolate.interp1d(x[~extended_invalid],
-                                          extended_pia[~extended_invalid],
-                                          kind='linear')
+        intp = interpolate.interp1d(x[~extended_invalid],
+                                    extended_pia[~extended_invalid],
+                                    kind='linear')
         # Interpolate where sectors are invalid.
         pia[i, sub_invalid, -1] = intp(x[pia.shape[1]:2 * pia.shape[1]]
                                        [sub_invalid])

--- a/wradlib/classify.py
+++ b/wradlib/classify.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2018, wradlib developers.
+# Copyright (c) 2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -16,7 +16,6 @@ Hydrometeor Classification (HMC)
     probability
     classify
 """
-
 import numpy as np
 
 pr_types = {0: ('LR', 'Light Rain'), 1: ('MR', 'Moderate Rain'),

--- a/wradlib/clutter.py
+++ b/wradlib/clutter.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -20,9 +20,9 @@ Clutter Identification
 
 """
 import numpy as np
-import scipy.ndimage as ndi
-from . import dp as dp
-from . import util as util
+from scipy import ndimage
+
+from wradlib import dp, util
 
 
 def filter_gabella_a(img, wsize, tr1, cartesian=False, radial=False):
@@ -115,9 +115,9 @@ def filter_gabella_b(img, thrs=0.):
     # create binary image of the rainfall field
     binimg = img > thrs
     # label objects (individual rain cells, so to say)
-    labelimg, nlabels = ndi.label(binimg, conn)
+    labelimg, nlabels = ndimage.label(binimg, conn)
     # erode the image, thus removing the 'boundary pixels'
-    binimg_erode = ndi.binary_erosion(binimg, structure=conn)
+    binimg_erode = ndimage.binary_erosion(binimg, structure=conn)
     # determine the size of each object
     labelhist, edges = np.histogram(labelimg,
                                     bins=nlabels + 1,
@@ -188,7 +188,8 @@ def filter_gabella(img, wsize=5, thrsnorain=0., tr1=6., n_p=6, tr2=1.3,
         img[bad] = np.Inf
     ntr1 = filter_gabella_a(img, wsize, tr1, cartesian, radial)
     if not rm_nans:
-        f_good = ndi.filters.uniform_filter((~bad).astype(float), size=wsize)
+        f_good = ndimage.filters.uniform_filter((~bad).astype(float),
+                                                size=wsize)
         f_good[f_good == 0] = 1e-10
         ntr1 = ntr1 / f_good
         ntr1[bad] = n_p

--- a/wradlib/comp.py
+++ b/wradlib/comp.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """

--- a/wradlib/georef/__init__.py
+++ b/wradlib/georef/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 # flake8: noqa
 """
@@ -20,23 +20,23 @@ Georeferencing
 .. automodule:: wradlib.georef.xarray
 """
 
-from .misc import (bin_altitude, bin_distance, site_distance, get_earth_radius)
+from .misc import (bin_altitude, bin_distance, site_distance)
 
 from .polar import (centroid_to_polyvert, spherical_to_xyz, spherical_to_proj,
                     spherical_to_polyvert, spherical_to_centroids,
-                    sweep_centroids)
-
-from .rect import (get_radolan_coords, get_radolan_grid, xyz_to_spherical)
+                    sweep_centroids, maximum_intensity_projection)
 
 from .projection import (create_osr, proj4_to_osr, reproject,
                          get_default_projection, epsg_to_osr,
-                         wkt_to_osr)
+                         wkt_to_osr, get_earth_radius)
 
 from .raster import (pixel_coordinates, pixel_to_map, pixel_to_map3d,
                      read_gdal_coordinates, read_gdal_values,
                      read_gdal_projection, create_raster_dataset,
                      set_raster_origin, extract_raster_dataset,
                      reproject_raster_dataset)
+
+from .rect import (get_radolan_coords, get_radolan_grid, xyz_to_spherical)
 
 from .satellite import (correct_parallax, dist_from_orbit)
 

--- a/wradlib/georef/misc.py
+++ b/wradlib/georef/misc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -14,12 +14,8 @@ Miscellaneous
    bin_altitude
    bin_distance
    site_distance
-   get_earth_radius
 """
-
 import numpy as np
-
-from .projection import get_default_projection
 
 
 def bin_altitude(r, theta, sitealt, re, ke=4./3.):
@@ -140,37 +136,3 @@ def site_distance(r, theta, binalt, re=None, ke=4./3.):
     """
     reff = ke * re
     return reff * np.arcsin(r * np.cos(np.radians(theta)) / (reff + binalt))
-
-
-def get_earth_radius(latitude, sr=None):
-    """Get the radius of the Earth (in km) for a given Spheroid model (sr) at \
-    a given position.
-
-    .. math::
-
-        R^2 = \\frac{a^4 \\cos(f)^2 + b^4 \\sin(f)^2}
-        {a^2 \\cos(f)^2 + b^2 \\sin(f)^2}
-
-    Parameters
-    ----------
-    sr : osr object
-        spatial reference
-    latitude : float
-        geodetic latitude in degrees
-
-    Returns
-    -------
-    radius : float
-        earth radius in meter
-
-    """
-    if sr is None:
-        sr = get_default_projection()
-    radius_e = sr.GetSemiMajor()
-    radius_p = sr.GetSemiMinor()
-    latitude = np.radians(latitude)
-    radius = np.sqrt((np.power(radius_e, 4) * np.power(np.cos(latitude), 2) +
-                      np.power(radius_p, 4) * np.power(np.sin(latitude), 2)) /
-                     (np.power(radius_e, 2) * np.power(np.cos(latitude), 2) +
-                      np.power(radius_p, 2) * np.power(np.sin(latitude), 2)))
-    return radius

--- a/wradlib/georef/projection.py
+++ b/wradlib/georef/projection.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -16,10 +16,10 @@ Projection Functions
    proj4_to_osr
    epsg_to_osr
    wkt_to_osr
+   get_earth_radius
 """
-
-from osgeo import gdal, osr, ogr
 import numpy as np
+from osgeo import gdal, osr, ogr
 
 
 def create_osr(projname, **kwargs):
@@ -362,3 +362,37 @@ def wkt_to_osr(wkt=None):
                          "and can't be imported as OSR object")
 
     return proj
+
+
+def get_earth_radius(latitude, sr=None):
+    """Get the radius of the Earth (in km) for a given Spheroid model (sr) at \
+    a given position.
+
+    .. math::
+
+        R^2 = \\frac{a^4 \\cos(f)^2 + b^4 \\sin(f)^2}
+        {a^2 \\cos(f)^2 + b^2 \\sin(f)^2}
+
+    Parameters
+    ----------
+    sr : osr object
+        spatial reference
+    latitude : float
+        geodetic latitude in degrees
+
+    Returns
+    -------
+    radius : float
+        earth radius in meter
+
+    """
+    if sr is None:
+        sr = get_default_projection()
+    radius_e = sr.GetSemiMajor()
+    radius_p = sr.GetSemiMinor()
+    latitude = np.radians(latitude)
+    radius = np.sqrt((np.power(radius_e, 4) * np.power(np.cos(latitude), 2) +
+                      np.power(radius_p, 4) * np.power(np.sin(latitude), 2)) /
+                     (np.power(radius_e, 2) * np.power(np.cos(latitude), 2) +
+                      np.power(radius_p, 2) * np.power(np.sin(latitude), 2)))
+    return radius

--- a/wradlib/georef/raster.py
+++ b/wradlib/georef/raster.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -22,11 +22,10 @@ Raster Functions
    set_raster_origin
    extract_raster_dataset
 """
-
 import numpy as np
 from osgeo import gdal, osr, gdal_array
 
-from .projection import reproject
+from wradlib.georef import projection
 
 
 def pixel_coordinates(nx, ny, mode="centers"):
@@ -407,8 +406,8 @@ def reproject_raster_dataset(src_ds, **kwargs):
         src_srs.ImportFromWkt(src_ds.GetProjection())
 
         # Transformation
-        extent = reproject(extent, projection_source=src_srs,
-                           projection_target=dst_srs)
+        extent = projection.reproject(extent, projection_source=src_srs,
+                                      projection_target=dst_srs)
 
         # wkt needed
         src_srs = src_srs.ExportToWkt()

--- a/wradlib/georef/rect.py
+++ b/wradlib/georef/rect.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -15,11 +15,9 @@ Rectangular Grid Functions
     get_radolan_grid
     xyz_to_spherical
 """
-
 import numpy as np
 
-from .projection import (create_osr, reproject, get_default_projection)
-from .misc import get_earth_radius
+from wradlib.georef import projection
 
 
 def get_radolan_coords(lon, lat, trig=False):
@@ -56,13 +54,13 @@ def get_radolan_coords(lon, lat, trig=False):
         y = - er * m_phi * np.cos(phi_m) * np.cos(lam)
     else:
         # create radolan projection osr object
-        proj_stereo = create_osr("dwd-radolan")
+        proj_stereo = projection.create_osr("dwd-radolan")
 
         # create wgs84 projection osr object
-        proj_wgs = get_default_projection()
+        proj_wgs = projection.get_default_projection()
 
-        x, y = reproject(lon, lat, projection_source=proj_wgs,
-                         projection_target=proj_stereo)
+        x, y = projection.reproject(lon, lat, projection_source=proj_wgs,
+                                    projection_target=proj_stereo)
 
     return x, y
 
@@ -219,14 +217,14 @@ Polar-Stereographic-Projection`.
             radolan_grid = np.dstack((lon, lat))
         else:
             # create radolan projection osr object
-            proj_stereo = create_osr("dwd-radolan")
+            proj_stereo = projection.create_osr("dwd-radolan")
 
             # create wgs84 projection osr object
-            proj_wgs = get_default_projection()
+            proj_wgs = projection.get_default_projection()
 
-            radolan_grid = reproject(radolan_grid,
-                                     projection_source=proj_stereo,
-                                     projection_target=proj_wgs)
+            radolan_grid = projection.reproject(radolan_grid,
+                                                projection_source=proj_stereo,
+                                                projection_target=proj_wgs)
 
     return radolan_grid
 
@@ -266,7 +264,8 @@ def xyz_to_spherical(xyz, alt=0, proj=None, ke=4. / 3.):
     # for the latitude_of_center, if no projection is given assume
     # spherical earth
     try:
-        re = get_earth_radius(proj.GetProjParm('latitude_of_center'), proj)
+        lat0 = proj.GetProjParm('latitude_of_center')
+        re = projection.get_earth_radius(lat0, proj)
     except Exception:
         re = 6370040.
 

--- a/wradlib/georef/satellite.py
+++ b/wradlib/georef/satellite.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """

--- a/wradlib/georef/vector.py
+++ b/wradlib/georef/vector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -24,11 +24,13 @@ Vector Functions (GDAL)
    ogr_geocol_to_numpy
    get_centroid
 """
+import warnings
 
 import numpy as np
 from osgeo import gdal, ogr, osr
-from .projection import get_default_projection
-import warnings
+
+from wradlib.georef import projection
+
 ogr.UseExceptions()
 gdal.UseExceptions()
 
@@ -91,7 +93,7 @@ def transform_geometry(geom, dest_srs, **kwargs):
 
     # srs is None assume wgs84 lonlat, but warn too
     if srs is None:
-        srs = get_default_projection()
+        srs = projection.get_default_projection()
         warnings.warn("geometry without spatial reference - assuming wgs84")
 
     # transform if not the same spatial reference system

--- a/wradlib/georef/xarray.py
+++ b/wradlib/georef/xarray.py
@@ -15,12 +15,13 @@ Xarray Functions
    create_xarray_dataarray
    georeference_dataset
 """
+import collections
 
 import numpy as np
 import xarray as xr
-import collections
 from osgeo import osr
-from . import polar
+
+from wradlib.georef import polar
 
 
 def as_xarray_dataarray(data, dims, coords):

--- a/wradlib/io/__init__.py
+++ b/wradlib/io/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 # flake8: noqa
 
@@ -26,22 +26,29 @@ for an introduction on how to deal with different file formats.
 
 from .dem import (get_srtm)
 
-from .misc import (write_polygon_to_text, to_pickle, from_pickle,
-                   get_radiosonde, get_membership_functions)
 from .gdal import (read_safnwc, write_raster_dataset, open_vector, open_raster,
                    gdal_create_dataset)
+
 from .hdf import (read_generic_hdf5, read_opera_hdf5, read_gamic_hdf5,
                   to_hdf5, from_hdf5, read_gpm, read_trmm)
+
+from .iris import (IrisFile, IrisRecordFile, IrisRawFile, IrisIngestHeaderFile,
+                   IrisIngestDataFile, IrisProductFile,
+                   IrisCartesianProductFile, read_iris)
+
+from .misc import (write_polygon_to_text, to_pickle, from_pickle,
+                   get_radiosonde, get_membership_functions)
+
 from .netcdf import read_edge_netcdf, read_generic_netcdf
+
 from .rainbow import read_rainbow
+
 from .radolan import (read_dx, read_radolan_composite,
                       read_radolan_header, get_radolan_filehandle,
                       parse_dwd_composite_header,
                       read_radolan_binary_array,
                       decode_radolan_runlength_array)
-from .iris import (IrisFile, IrisRecordFile, IrisRawFile, IrisIngestHeaderFile,
-                   IrisIngestDataFile, IrisProductFile,
-                   IrisCartesianProductFile, read_iris)
+
 from .xarray import (CfRadial, OdimH5, create_xarray_dataarray)
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/wradlib/io/dem.py
+++ b/wradlib/io/dem.py
@@ -16,10 +16,9 @@ Provide surface/terrain elevation information from SRTM data
    download_srtm
    get_srtm
 """
-
-import numpy as np
 import os
 
+import numpy as np
 from osgeo import gdal
 import requests
 

--- a/wradlib/io/gdal.py
+++ b/wradlib/io/gdal.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -14,13 +14,8 @@ Raster and Vector I/O using GDAL
    read_safnwc
    write_raster_dataset
 """
-
-# standard libraries
-from __future__ import absolute_import
-
 import os
 
-# site packages
 from osgeo import gdal, osr
 
 

--- a/wradlib/io/hdf.py
+++ b/wradlib/io/hdf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -17,17 +17,10 @@ HDF Data I/O
    read_gpm
    read_trmm
 """
-
-# standard libraries
-from __future__ import absolute_import
-
-# site packages
 import h5py
-from netCDF4 import Dataset
+import netCDF4 as nc
 import numpy as np
 import datetime as dt
-
-from ..zonalstats import get_clip_mask
 
 
 def read_generic_hdf5(fname):
@@ -454,7 +447,7 @@ def read_gpm(filename, bbox=None):
     --------
     See :ref:`/notebooks/match3d/wradlib_match_workflow.ipynb`.
     """
-    pr_data = Dataset(filename, mode="r")
+    pr_data = nc.Dataset(filename, mode="r")
     lon = pr_data['NS'].variables['Longitude']
     lat = pr_data['NS'].variables['Latitude']
 
@@ -464,6 +457,7 @@ def read_gpm(filename, bbox=None):
                 [bbox['right'], bbox['top']],
                 [bbox['right'], bbox['bottom']],
                 [bbox['left'], bbox['bottom']]]
+        from wradlib.zonalstats import get_clip_mask
         mask = get_clip_mask(np.dstack((lon[:], lat[:])), poly)
     else:
         mask = np.ones_like(lon, dtype=bool, subok=False)
@@ -583,8 +577,8 @@ def read_trmm(filename1, filename2, bbox=None):
     See :ref:`/notebooks/match3d/wradlib_match_workflow.ipynb`.
     """
     # trmm 2A23 and 2A25 data is hdf4
-    pr_data1 = Dataset(filename1, mode="r")
-    pr_data2 = Dataset(filename2, mode="r")
+    pr_data1 = nc.Dataset(filename1, mode="r")
+    pr_data2 = nc.Dataset(filename2, mode="r")
 
     lon = pr_data1.variables['Longitude']
     lat = pr_data1.variables['Latitude']
@@ -595,6 +589,7 @@ def read_trmm(filename1, filename2, bbox=None):
                 [bbox['right'], bbox['top']],
                 [bbox['right'], bbox['bottom']],
                 [bbox['left'], bbox['bottom']]]
+        from wradlib.zonalstats import get_clip_mask
         mask = get_clip_mask(np.dstack((lon[:], lat[:])), poly)
     else:
         mask = np.ones_like(lon, dtype=bool)

--- a/wradlib/io/iris.py
+++ b/wradlib/io/iris.py
@@ -40,13 +40,13 @@ Using `rawdata=True` the data will be kept undecoded.
    read_iris
 
 """
+from collections import OrderedDict
+import copy
+import datetime as dt
+import struct
+import warnings
 
 import numpy as np
-import struct
-from collections import OrderedDict
-import warnings
-import datetime as dt
-import copy
 
 
 def get_dtype_size(dtype):
@@ -343,7 +343,7 @@ def _check_product(product_type):
                         'RTI', 'VIL', 'LAYER', 'BEAM', 'MLHGT']:
         return IrisCartesianProductFile
     elif product_type in ['CATCH', 'FCAST', 'NDOP', 'SLINE', 'TDWR', 'TRACK',
-                          'VAD', 'VVP', 'WARN', 'WIND', 'STATUS']:
+                          'VAD', 'VVP', 'WARN', 'WIND']:
         return IrisProductFile
     elif product_type in ['RAW']:
         return IrisRawFile
@@ -501,17 +501,17 @@ MAX_PSI_STRUCT = OrderedDict([('spare_0', {'fmt': '4s'}),
 
 # mlhgt_psi_struct (if MLGHT)
 # 4.3.18, page 34
-MLHGT_PSI_STRUCT = OrderedDict(
-    [('flags', UINT4),
-     ('averaged_ml_altitude', SINT2),
-     ('interval_ml_altitudes', SINT2),
-     ('vertical_grid_spacing', SINT2),
-     ('num_az_sectors', UINT2),
-     ('relaxation_time_mlhgt_confidence', UINT4),
-     ('modeled_fraction_melt_classifications', UINT2),
-     ('modeled_fraction_nomelt_classifications', UINT2),
-     ('min_confidence', UINT2),
-     ('spare_0', {'fmt': '58s'})])
+MLHGT_PSI_STRUCT = \
+    OrderedDict([('flags', UINT4),
+                 ('averaged_ml_altitude', SINT2),
+                 ('interval_ml_altitudes', SINT2),
+                 ('vertical_grid_spacing', SINT2),
+                 ('num_az_sectors', UINT2),
+                 ('relaxation_time_mlhgt_confidence', UINT4),
+                 ('modeled_fraction_melt_classifications', UINT2),
+                 ('modeled_fraction_nomelt_classifications', UINT2),
+                 ('min_confidence', UINT2),
+                 ('spare_0', {'fmt': '58s'})])
 
 # ndop_input Struct
 # 4.3.19, page 34
@@ -657,7 +657,7 @@ TRACK_RESULTS = OrderedDict([('latitude', BIN4),
                              ('input_data_scale_factor', SINT4),
                              ('track_index_number', SINT4),
                              ('text', string_dict(32)),
-                             ('time', _YMDS_TIME),
+                             ('time', YMDS_TIME),
                              ('eta_protected_areas', array_dict(32, 'int32')),
                              ('input_data_type', UINT4),
                              ('spare_2', {'fmt': '8s'}),
@@ -774,7 +774,7 @@ WIND_PSI_STRUCT = OrderedDict([('min_height', SINT4),
 # wind_results Struct
 # 4.3.76, page 70
 WIND_RESULTS = OrderedDict([('num_possible_hits', SINT4),
-                            ('num_data_points_used', SINT4),
+                            ('num__data_points_used', SINT4),
                             ('center_sector_range', SINT4),
                             ('center_sector_azimuth', BIN2),
                             ('east_velocity', SINT2),
@@ -782,121 +782,6 @@ WIND_RESULTS = OrderedDict([('num_possible_hits', SINT4),
                             ('north_velocity', SINT2),
                             ('north_velocity_std', SINT2),
                             ('spare_0', {'fmt': '10s'})])
-
-
-# status_antenna_info Structure
-# 4.3.40, page 51
-STATUS_ANTENNA_INFO = OrderedDict(
-    [('azimuth_position', BIN4),
-     ('elevation_position', BIN4),
-     ('azimuth_velocity', UINT4),
-     ('elevation_velocity', UINT4),
-     ('command_bits', UINT4),
-     ('command_bit_availability_mask', UINT4),
-     ('status_bits', UINT4),
-     ('status_bit_availability_mask', UINT4),
-     ('bite_fault_flag', UINT4),
-     ('lowest_field_num_generating_fault', SINT4),
-     ('status_bits_which_cause_critical_faults', UINT4),
-     ('mask_bite_fields_state',
-      array_dict(3, 'uint32')),
-     ('mask_bite_fields_faulted',
-      array_dict(3, 'uint32')),
-     ('spare_0', {'fmt': '32s'})])
-
-# status_message_info Structure
-# 4.3.42, page 52
-STATUS_MESSAGE_INFO = OrderedDict([('message_count', SINT4),
-                                   ('message_number', MESSAGE),
-                                   ('message_repeat_number', SINT4),
-                                   ('process_name', string_dict(16)),
-                                   ('message_text', string_dict(80)),
-                                   ('signal_name', string_dict(32)),
-                                   ('message_time', _YMDS_TIME),
-                                   ('message_type', UINT4),
-                                   ('spare_0', {'fmt': '36s'})])
-
-# status_misc_info Structure
-# 4.3.43, page 52
-STATUS_MISC_INFO = OrderedDict(
-    [('radar_status_configuration_name', string_dict(16)),
-     ('task_configuration_name', string_dict(16)),
-     ('product_scheduler_configuration_name', string_dict(16)),
-     ('product_output_configuration_name', string_dict(16)),
-     ('active_task_name', string_dict(16)),
-     ('active_product_name', string_dict(16)),
-     ('site_type', UINT4),
-     ('num_incoming_network_connects', SINT4),
-     ('num_iris_clients_connected', SINT4),
-     ('spare_0', {'fmt': '4s'}),
-     ('num_output_devices', SINT4),
-     ('flags', UINT4),
-     ('node_status_fault_site', string_dict(4)),
-     ('time_of_active_task', _YMDS_TIME),
-     ('spare_1', {'fmt': '64s'})])
-
-# status_one_device Structure
-# 4.3.44, page 53
-STATUS_ONE_DEVICE = OrderedDict([('device_type', UINT4),
-                                 ('unit_number', SINT4),
-                                 ('status', UINT4),
-                                 ('spare_0', {'fmt': '4s'}),
-                                 ('process_table_mode', UINT4),
-                                 ('string', string_dict(16)),
-                                 ('spare_1', {'fmt': '4s'})])
-
-# status_device_info Structure
-# 4.3.41, page 52
-STATUS_DEVICE_INFO = OrderedDict([('dsp', STATUS_ONE_DEVICE),
-                                  ('antenna', STATUS_ONE_DEVICE),
-                                  ('output_device_0', STATUS_ONE_DEVICE),
-                                  ('output_device_1', STATUS_ONE_DEVICE),
-                                  ('output_device_2', STATUS_ONE_DEVICE),
-                                  ('output_device_3', STATUS_ONE_DEVICE),
-                                  ('output_device_4', STATUS_ONE_DEVICE),
-                                  ('output_device_5', STATUS_ONE_DEVICE),
-                                  ('output_device_6', STATUS_ONE_DEVICE),
-                                  ('output_device_7', STATUS_ONE_DEVICE),
-                                  ('output_device_8', STATUS_ONE_DEVICE),
-                                  ('output_device_9', STATUS_ONE_DEVICE),
-                                  ('output_device_10', STATUS_ONE_DEVICE),
-                                  ('output_device_11', STATUS_ONE_DEVICE),
-                                  ('output_device_12', STATUS_ONE_DEVICE),
-                                  ('output_device_13', STATUS_ONE_DEVICE),
-                                  ('output_device_14', STATUS_ONE_DEVICE),
-                                  ('output_device_15', STATUS_ONE_DEVICE),
-                                  ('output_device_16', STATUS_ONE_DEVICE),
-                                  ('output_device_17', STATUS_ONE_DEVICE)])
-
-# status_one_process Structure
-# 4.3.45, page 54
-STATUS_ONE_PROCESS = OrderedDict([('command', UINT4),
-                                  ('mode', UINT4),
-                                  ('spare_0', {'fmt': '12s'})])
-
-# status_process_info Structure
-# 4.3.46, page 54
-STATUS_PROCESS_INFO = OrderedDict(
-    [('ingest_process', STATUS_ONE_PROCESS),
-     ('ingfio_process', STATUS_ONE_PROCESS),
-     ('spare_0', {'fmt': '20s'}),
-     ('output_master_process', STATUS_ONE_PROCESS),
-     ('product_process', STATUS_ONE_PROCESS),
-     ('watchdog_process', STATUS_ONE_PROCESS),
-     ('reingest_process', STATUS_ONE_PROCESS),
-     ('network_process', STATUS_ONE_PROCESS),
-     ('nordrad_process', STATUS_ONE_PROCESS),
-     ('server_process', STATUS_ONE_PROCESS),
-     ('ribbuild_process', STATUS_ONE_PROCESS),
-     ('spare_1', {'fmt': '180s'})])
-
-# status_results Structure
-# 4.3.47, page 54
-STATUS_RESULTS = OrderedDict([('status_misc_info', STATUS_MISC_INFO),
-                              ('status_process_info', STATUS_PROCESS_INFO),
-                              ('status_device_info', STATUS_DEVICE_INFO),
-                              ('status_antenna_info', STATUS_ANTENNA_INFO),
-                              ('status_message_info', STATUS_MESSAGE_INFO)])
 
 # spare (if USER, OTHER, TEXT)
 SPARE_PSI_STRUCT = OrderedDict([('spare_0', {'fmt': '80s'})])
@@ -1666,8 +1551,7 @@ PRODUCT_DATA_TYPE_CODES = OrderedDict([(0, {'name': 'NULL',
                                        (19, {'name': 'OTHER',
                                              'struct': SPARE_PSI_STRUCT}),
                                        (20, {'name': 'STATUS',
-                                             'struct': SPARE_PSI_STRUCT,
-                                             'result': STATUS_RESULTS}),
+                                             'struct': SPARE_PSI_STRUCT}),
                                        (21, {'name': 'SLINE',
                                              'struct': SLINE_PSI_STRUCT,
                                              'protect_setup': True}),
@@ -2280,7 +2164,7 @@ class IrisRecordFile(IrisFile, IrisProductHeader):
                           'CAPPI', 'RAINN', 'RAIN1', 'CROSS', 'SHEAR', 'SRI',
                           'RTI', 'VIL', 'LAYER', 'BEAM', 'MLHGT',
                           'CATCH', 'FCAST', 'NDOP', 'SLINE', 'TDWR', 'TRACK',
-                          'VAD', 'VVP', 'WARN', 'WIND', 'STATUS', 'RAW']
+                          'VAD', 'VVP', 'WARN', 'WIND', 'RAW']
 
     def __init__(self, filename, **kwargs):
         super(IrisRecordFile, self).__init__(filename=filename,
@@ -2749,7 +2633,7 @@ class IrisProductFile(IrisRecordFile):
     """
     product_identifier = [
         'CATCH', 'FCAST', 'NDOP', 'SLINE', 'TDWR', 'TRACK',
-        'VAD', 'VVP', 'WARN', 'WIND', 'STATUS'
+        'VAD', 'VVP', 'WARN', 'WIND'
         ]
 
     def __init__(self, filename, **kwargs):
@@ -2844,9 +2728,6 @@ class IrisProductFile(IrisRecordFile):
             res = _unpack_dictionary(dta, VVP_RESULTS,
                                      self._rawdata)
             result['VVP'] = res
-            self.get_results(result, num_elements,
-                             self.product_type_dict['result'])
-        elif self.product_type in ['STATUS']:
             self.get_results(result, num_elements,
                              self.product_type_dict['result'])
         else:
@@ -3002,15 +2883,6 @@ class IrisCartesianProductFile(IrisRecordFile):
                 kw.update(prod['fkw'])
             except KeyError:
                 pass
-            if prod['func'] in [decode_vel, decode_width, decode_kdp]:
-                wavelength = self.product_hdr['product_end']['wavelength']
-                if prod['func'] == decode_kdp:
-                    kw.update({'wavelength': wavelength / 100})
-                    return prod['func'](data, **kw)
-
-                prf = self.product_hdr['product_end']['prf']
-                nyquist = wavelength * prf / (10000. * 4.)
-                kw.update({'nyquist': nyquist})
             return prod['func'](data.view(prod['dtype']), **kw)
         else:
             return data

--- a/wradlib/io/misc.py
+++ b/wradlib/io/misc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -15,22 +15,15 @@ Miscellaneous Data I/O
    get_radiosonde
    get_membership_functions
 """
-
-# standard libraries
-from __future__ import absolute_import
-
-try:
-    import cPickle as pickle
-except ImportError:
-    import pickle
-
-import numpy as np
+import datetime as dt
+import io
+import pickle
 import urllib
 import warnings
-import datetime as dt
-from io import StringIO
 
-from .. import util as util
+import numpy as np
+
+from wradlib import util
 
 
 def _write_polygon_to_txt(f, idx, vertices):
@@ -179,7 +172,7 @@ def get_radiosonde(wmoid, date, cols=None):
     # read data
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', category=UserWarning)
-        data = np.genfromtxt(StringIO(url_data),
+        data = np.genfromtxt(io.StringIO(url_data),
                              names=names,
                              dtype=float,
                              usecols=cols,
@@ -188,7 +181,7 @@ def get_radiosonde(wmoid, date, cols=None):
 
     # read metadata
     meta = {}
-    for i, row in enumerate(StringIO(url_meta)):
+    for i, row in enumerate(io.StringIO(url_meta)):
         if i == 0:
             continue
         k, v = row.split(':')

--- a/wradlib/io/netcdf.py
+++ b/wradlib/io/netcdf.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -12,14 +12,11 @@ Read NetCDF
    read_edge_netcdf
    read_generic_netcdf
 """
-
-# standard libraries
-from __future__ import absolute_import
+import collections
 import datetime as dt
 
-from collections import OrderedDict
-import numpy as np
 import netCDF4 as nc
+import numpy as np
 
 
 def read_edge_netcdf(filename, enforce_equidist=False):
@@ -108,7 +105,7 @@ def read_netcdf_group(ncid):
         an ordered dictionary that contains both data and metadata
         according to the original netcdf file structure
     """
-    out = OrderedDict()
+    out = collections.OrderedDict()
 
     # attributes
     for k, v in ncid.__dict__.items():
@@ -122,9 +119,9 @@ def read_netcdf_group(ncid):
     # dimensions
     dimids = np.array([])
     if ncid.dimensions:
-        dim = OrderedDict()
+        dim = collections.OrderedDict()
         for k, v in ncid.dimensions.items():
-            tmp = OrderedDict()
+            tmp = collections.OrderedDict()
             try:
                 tmp['data_model'] = v._data_model
             except AttributeError:
@@ -145,7 +142,7 @@ def read_netcdf_group(ncid):
             out['dimensions'] = dim
         else:
             # need to sort
-            dim2 = OrderedDict()
+            dim2 = collections.OrderedDict()
             keys = dim.keys()
             for dimid in np.sort(dimids):
                 dim2[keys[dimid]] = dim[keys[dimid]]
@@ -153,9 +150,9 @@ def read_netcdf_group(ncid):
 
     # variables
     if ncid.variables:
-        var = OrderedDict()
+        var = collections.OrderedDict()
         for k, v in ncid.variables.items():
-            tmp = OrderedDict()
+            tmp = collections.OrderedDict()
             for k1 in v.ncattrs():
                 tmp[k1] = v.getncattr(k1)
             if v[:].dtype.kind == 'S':

--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -20,26 +20,16 @@ Reading DX and RADOLAN data from German Weather Service
     decode_radolan_runlength_array
     radolan_to_xarray
 """
-
-# standard libraries
-from __future__ import absolute_import
 import datetime as dt
-
-try:
-    from StringIO import StringIO
-    import io
-except ImportError:
-    from io import StringIO  # noqa
-    import io
-
+import io
 import re
 import warnings
 
-# site packages
 import numpy as np
 import xarray as xr
-from .. import util as util
-from .. import georef as georef
+
+from wradlib import util
+from wradlib.georef import rect
 
 # current DWD file naming pattern (2008) for example:
 # raa00-dx_10488-200608050000-drs---bin
@@ -815,7 +805,7 @@ def radolan_to_xarray(data, attrs):
     """
     product = attrs['producttype']
     pattrs = _get_radolan_product_attributes(attrs)
-    radolan_grid_xy = georef.get_radolan_grid(attrs['nrow'], attrs['ncol'])
+    radolan_grid_xy = rect.get_radolan_grid(attrs['nrow'], attrs['ncol'])
     x0 = radolan_grid_xy[0, :, 0]
     y0 = radolan_grid_xy[:, 0, 1]
     if pattrs:

--- a/wradlib/io/rainbow.py
+++ b/wradlib/io/rainbow.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -11,13 +11,10 @@ Read Rainbow
 
    read_rainbow
 """
-
-# standard libraries
-from __future__ import absolute_import
 import sys
-
 import numpy as np
-from .. import util as util
+
+from wradlib import util
 
 
 def find_key(key, dictionary):

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -56,23 +56,25 @@ Warning
    to_odim
 
 """
-
-import warnings
 import collections
-import numpy as np
 import datetime as dt
-import netCDF4 as nc
+import warnings
+
+import deprecation
 import h5py
+import netCDF4 as nc
+import numpy as np
 import xarray as xr
 
-from ..georef import xarray
+from wradlib.georef import xarray
+from wradlib import version
 
 
+@deprecation.deprecated(deprecated_in="1.5", removed_in="2.0",
+                        current_version=version.version,
+                        details="Use `wradlib.georef.create_xarray_dataarray` "
+                                "instead.")
 def create_xarray_dataarray(*args, **kwargs):
-    warnings.warn("WRADLIB: calling `wradlib.io.create_xarray_dataarray` is "
-                  "deprecated, please use "
-                  "`wradlib.georef.create_xarray_dataarray`.",
-                  DeprecationWarning)
     return xarray.create_xarray_dataarray(*args, **kwargs)
 
 

--- a/wradlib/qual.py
+++ b/wradlib/qual.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -29,7 +29,6 @@ fields except that they exhibit the numpy ndarray interface.
     get_bb_ratio
 
 """
-
 import numpy as np
 
 

--- a/wradlib/tests/__init__.py
+++ b/wradlib/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """

--- a/wradlib/tests/test_adjust.py
+++ b/wradlib/tests/test_adjust.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import unittest
-import wradlib.adjust as adjust
+
 import numpy as np
+
+from wradlib import adjust
 
 # Arguments to be used throughout all test classes
 raw_x, raw_y = np.meshgrid(np.arange(4).astype("f4"),

--- a/wradlib/tests/test_atten.py
+++ b/wradlib/tests/test_atten.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
-import numpy as np
-import wradlib.atten as atten
 import unittest
-from .. import util as util
-from .. import io as io
+
+import numpy as np
+
+from wradlib import atten, io, util
 
 
 class TestAttenuation(unittest.TestCase):

--- a/wradlib/tests/test_classify.py
+++ b/wradlib/tests/test_classify.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2018, wradlib developers.
+# Copyright (c) 2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import unittest
+
 import numpy as np
 
-from .. import classify as classify
-from .. import io as io
-from .. import util as util
+from wradlib import classify, io, util
 
 
 class HydrometeorClassificationTest(unittest.TestCase):

--- a/wradlib/tests/test_clutter.py
+++ b/wradlib/tests/test_clutter.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
-import numpy as np
-import wradlib.clutter as clutter
 import unittest
-from .. import io as io
-from .. import util as util
-from .. import georef as georef
-from .. import ipol as ipol
+
+import numpy as np
+
+from wradlib import clutter, georef, io, ipol, util
 
 
 # -------------------------------------------------------------------------------

--- a/wradlib/tests/test_comp.py
+++ b/wradlib/tests/test_comp.py
@@ -1,21 +1,19 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import unittest
+
 import numpy as np
-from .. import comp
-from .. import georef
-from .. import ipol
-from ..util import get_wradlib_data_file
-from ..io import read_dx
+
+from wradlib import comp, georef, io, ipol, util
 
 
 class ComposeTest(unittest.TestCase):
     def setUp(self):
         filename = 'dx/raa00-dx_10908-0806021655-fbg---bin.gz'
-        dx_file = get_wradlib_data_file(filename)
-        self.data, metadata = read_dx(dx_file)
+        dx_file = util.get_wradlib_data_file(filename)
+        self.data, metadata = io.read_dx(dx_file)
         radar_location = (8.005, 47.8744, 1517)
         elevation = 0.5  # in degree
         azimuths = np.arange(0, 360)  # in degrees

--- a/wradlib/tests/test_dp.py
+++ b/wradlib/tests/test_dp.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import unittest
 
-import wradlib.dp as dp
 import numpy as np
+
+from wradlib import dp
 
 
 class KDPFromPHIDPTest(unittest.TestCase):

--- a/wradlib/tests/test_ipol.py
+++ b/wradlib/tests/test_ipol.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
-import numpy as np
-import wradlib.ipol as ipol
-import wradlib.georef as georef
 import unittest
 import warnings
+
+import numpy as np
+
+from wradlib import georef, ipol
 
 
 class InterpolationTest(unittest.TestCase):

--- a/wradlib/tests/test_qual.py
+++ b/wradlib/tests/test_qual.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
-import numpy as np
-import wradlib.qual as qual
 import unittest
+
+import numpy as np
+
+from wradlib import qual
 
 
 class HelperFunctionsTest(unittest.TestCase):

--- a/wradlib/tests/test_trafo.py
+++ b/wradlib/tests/test_trafo.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import unittest
+
 import numpy as np
-import wradlib.trafo as trafo
+
+from wradlib import trafo
 
 
 class TransformationTest(unittest.TestCase):

--- a/wradlib/tests/test_util.py
+++ b/wradlib/tests/test_util.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
-import os
-import numpy as np
-import wradlib.util as util
-import unittest
 import datetime as dt
+import os
+import unittest
+
+import deprecation
+import numpy as np
+
+from wradlib import util
 
 
 class HelperFunctionsTest(unittest.TestCase):
@@ -78,6 +81,7 @@ class HelperFunctionsTest(unittest.TestCase):
         with self.assertRaises(AttributeError):
             mod.test()
 
+    @deprecation.fail_if_not_removed
     def test_maximum_intensity_projection(self):
         angle = 0.0
         elev = 0.0

--- a/wradlib/tests/test_verify.py
+++ b/wradlib/tests/test_verify.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import unittest
+
 import numpy as np
-import matplotlib.pyplot as pl
-pl.interactive(True)  # noqa
-from .. import verify
-from .. import georef
+
+from wradlib import georef, verify
 
 
 class PolarNeighboursTest(unittest.TestCase):

--- a/wradlib/tests/test_vis.py
+++ b/wradlib/tests/test_vis.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
-import unittest
 import sys
+import tempfile
+import unittest
 
-import wradlib.vis as vis
-import wradlib.georef as georef
 import numpy as np
 import matplotlib.pyplot as pl
-from wradlib.util import import_optional
-from tempfile import NamedTemporaryFile
-cartopy = import_optional('cartopy')
 pl.interactive(True)  # noqa
+
+from wradlib import georef, util, vis
+
+cartopy = util.import_optional('cartopy')
 
 
 class PolarPlotTest(unittest.TestCase):
@@ -189,8 +189,9 @@ class MiscPlotTest(unittest.TestCase):
         vis.plot_plan_and_vert(x, y, z, dataxy, datazx, datazy)
         vis.plot_plan_and_vert(x, y, z, dataxy, datazx, datazy,
                                title='Test')
+        tmp = tempfile.NamedTemporaryFile(mode='w+b').name
         vis.plot_plan_and_vert(x, y, z, dataxy, datazx, datazy,
-                               saveto=NamedTemporaryFile(mode='w+b').name)
+                               saveto=tmp)
         vis.plot_max_plan_and_vert(x, y, z, vol)
 
     def test_add_lines(self):

--- a/wradlib/tests/test_vpr.py
+++ b/wradlib/tests/test_vpr.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import unittest
 
-import wradlib.vpr as vpr
-import wradlib.georef as georef
 import numpy as np
+
+from wradlib import georef, vpr
 
 
 class VPRHelperFunctionsTest(unittest.TestCase):

--- a/wradlib/tests/test_zonalstats.py
+++ b/wradlib/tests/test_zonalstats.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018-2017, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import unittest
 import tempfile
-
-import wradlib.georef as georef
-import wradlib.zonalstats as zonalstats
-import wradlib.util as util
 import numpy as np
 from osgeo import osr
+
+from wradlib import georef, util, zonalstats
 
 np.set_printoptions(edgeitems=3, infstr='inf', linewidth=75, nanstr='nan',
                     precision=8, suppress=False, threshold=1000,

--- a/wradlib/tests/test_zr.py
+++ b/wradlib/tests/test_zr.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import unittest
 
-import wradlib.zr as zr
-import wradlib.trafo as trafo
 import numpy as np
+
+from wradlib import trafo, zr
 
 
 class ZRConversionTest(unittest.TestCase):

--- a/wradlib/trafo.py
+++ b/wradlib/trafo.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -15,22 +15,31 @@ attributable to the other modules
    :toctree: generated/
 
    from_to
-   maximum_intensity_projection
    filter_window_polar
    filter_window_cartesian
    find_bbox_indices
    get_raster_origin
    calculate_polynomial
 """
+import importlib
 import datetime as dt
-from datetime import tzinfo, timedelta
 import os
-from importlib import import_module
 
+import deprecation
 import numpy as np
-from scipy.ndimage import filters
 from osgeo import gdal, ogr
-from scipy.signal import medfilt
+from scipy import ndimage, signal
+
+from wradlib import version
+
+
+@deprecation.deprecated(deprecated_in="1.6", removed_in="2.0",
+                        current_version=version.version,
+                        details="Use `wradlib.georef.maximum_intensity_"
+                                "projection` instead.")
+def maximum_intensity_projection(*args, **kwargs):
+    from wradlib.georef import polar
+    return polar.maximum_intensity_projection(*args, **kwargs)
 
 
 class OptionalModuleStub(object):
@@ -102,7 +111,7 @@ latest/gettingstarted.html#optional-dependencies
     for further instructions.
     """
     try:
-        mod = import_module(module)
+        mod = importlib.import_module(module)
     except ImportError:
         mod = OptionalModuleStub(module)
 
@@ -281,151 +290,6 @@ def trapezoid(data, x1, x2, x3, x4):
     return d
 
 
-def maximum_intensity_projection(data, r=None, az=None, angle=None,
-                                 elev=None, autoext=True):
-    """Computes the maximum intensity projection along an arbitrary cut \
-    through the ppi from polar data.
-
-    Parameters
-    ----------
-    data : :class:`numpy:numpy.ndarray`
-        Array containing polar data (azimuth, range)
-    r : :class:`numpy:numpy.ndarray`
-        Array containing range data
-    az : array
-        Array containing azimuth data
-    angle : float
-        angle of slice, Defaults to 0. Should be between 0 and 180.
-        0. means horizontal slice, 90. means vertical slice
-    elev : float
-        elevation angle of scan, Defaults to 0.
-    autoext : True | False
-        This routine uses numpy.digitize to bin the data.
-        As this function needs bounds, we create one set of coordinates more
-        than would usually be provided by `r` and `az`.
-
-    Returns
-    -------
-    xs : :class:`numpy:numpy.ndarray`
-        meshgrid x array
-    ys : :class:`numpy:numpy.ndarray`
-        meshgrid y array
-    mip : :class:`numpy:numpy.ndarray`
-        Array containing the maximum intensity projection (range, range*2)
-    """
-
-    from wradlib.georef import bin_altitude as bin_altitude
-
-    # this may seem odd at first, but d1 and d2 are also used in several
-    # plotting functions and thus it may be easier to compare the functions
-    d1 = r
-    d2 = az
-
-    # providing 'reasonable defaults', based on the data's shape
-    if d1 is None:
-        d1 = np.arange(data.shape[1], dtype=np.float)
-    if d2 is None:
-        d2 = np.arange(data.shape[0], dtype=np.float)
-
-    if angle is None:
-        angle = 0.0
-
-    if elev is None:
-        elev = 0.0
-
-    if autoext:
-        # the ranges need to go 'one bin further', assuming some regularity
-        # we extend by the distance between the preceding bins.
-        x = np.append(d1, d1[-1] + (d1[-1] - d1[-2]))
-        # the angular dimension is supposed to be cyclic, so we just add the
-        # first element
-        y = np.append(d2, d2[0])
-    else:
-        # no autoext basically is only useful, if the user supplied the correct
-        # dimensions himself.
-        x = d1
-        y = d2
-
-    # roll data array to specified azimuth, assuming equidistant azimuth angles
-    ind = (d2 >= angle).nonzero()[0][0]
-    data = np.roll(data, ind, axis=0)
-
-    # build cartesian range array, add delta to last element to compensate for
-    # open bound (np.digitize)
-    dc = np.linspace(-np.max(d1), np.max(d1) + 0.0001, num=d1.shape[0] * 2 + 1)
-
-    # get height values from polar data and build cartesian height array
-    # add delta to last element to compensate for open bound (np.digitize)
-    hp = np.zeros((y.shape[0], x.shape[0]))
-    hc = bin_altitude(x, elev, 0, re=6370040.)
-    hp[:] = hc
-    hc[-1] += 0.0001
-
-    # create meshgrid for polar data
-    xx, yy = np.meshgrid(x, y)
-
-    # create meshgrid for cartesian slices
-    xs, ys = np.meshgrid(dc, hc)
-    # xs, ys = np.meshgrid(dc,x)
-
-    # convert polar coordinates to cartesian
-    xxx = xx * np.cos(np.radians(90. - yy))
-    # yyy = xx * np.sin(np.radians(90.-yy))
-
-    # digitize coordinates according to cartesian range array
-    range_dig1 = np.digitize(xxx.ravel(), dc)
-    range_dig1.shape = xxx.shape
-
-    # digitize heights according polar height array
-    height_dig1 = np.digitize(hp.ravel(), hc)
-    # reshape accordingly
-    height_dig1.shape = hp.shape
-
-    # what am I doing here?!
-    range_dig1 = range_dig1[0:-1, 0:-1]
-    height_dig1 = height_dig1[0:-1, 0:-1]
-
-    # create height and range masks
-    height_mask = [(height_dig1 == i).ravel().nonzero()[0]
-                   for i in range(1, len(hc))]
-    range_mask = [(range_dig1 == i).ravel().nonzero()[0]
-                  for i in range(1, len(dc))]
-
-    # create mip output array, set outval to inf
-    mip = np.zeros((d1.shape[0], 2 * d1.shape[0]))
-    mip[:] = np.inf
-
-    # fill mip array,
-    # in some cases there are no values found in the specified range and height
-    # then we fill in nans and interpolate afterwards
-    for i in range(0, len(range_mask)):
-        mask1 = range_mask[i]
-        found = False
-        for j in range(0, len(height_mask)):
-            mask2 = np.intersect1d(mask1, height_mask[j])
-            # this is to catch the ValueError from the max() routine when
-            # calculating on empty array
-            try:
-                mip[j, i] = data.ravel()[mask2].max()
-                if not found:
-                    found = True
-            except ValueError:
-                if found:
-                    mip[j, i] = np.nan
-
-    # interpolate nans inside image, do not touch outvals
-    good = ~np.isnan(mip)
-    xp = good.ravel().nonzero()[0]
-    fp = mip[~np.isnan(mip)]
-    x = np.isnan(mip).ravel().nonzero()[0]
-    mip[np.isnan(mip)] = np.interp(x, xp, fp)
-
-    # reset outval to nan
-    mip[mip == np.inf] = np.nan
-
-    return xs, ys, mip
-
-
 def filter_window_polar(img, wsize, fun, rscale, random=False):
     """Apply a filter of an approximated square window of half size `fsize` \
     on a given polar image `img`.
@@ -451,7 +315,7 @@ def filter_window_polar(img, wsize, fun, rscale, random=False):
     """
     ascale = 2 * np.pi / img.shape[0]
     data_filtered = np.empty(img.shape, dtype=img.dtype)
-    fun = getattr(filters, "%s_filter1d" % fun)
+    fun = getattr(ndimage.filters, "%s_filter1d" % fun)
     nbins = img.shape[-1]
     ranges = np.arange(nbins) * rscale + rscale / 2
     asize = ranges * ascale
@@ -516,7 +380,7 @@ def filter_window_cartesian(img, wsize, fun, scale, **kwargs):
         Array with the same shape as `img`, containing the filter's results.
 
     """
-    fun = getattr(filters, "%s_filter" % fun)
+    fun = getattr(ndimage.filters, "%s_filter" % fun)
     size = np.fix(wsize / scale + 0.5).astype(int)
     data_filtered = fun(img, size, **kwargs)
     return data_filtered
@@ -560,7 +424,7 @@ def roll2d_polar(img, shift=1, axis=0):
     return out
 
 
-class UTC(tzinfo):
+class UTC(dt.tzinfo):
     """UTC implementation for tzinfo.
 
     See e.g. http://python.active-venture.com/lib/datetime-tzinfo.html
@@ -571,14 +435,14 @@ class UTC(tzinfo):
     def __repr__(self):
         return "<UTC>"
 
-    def utcoffset(self, dt):
-        return timedelta(0)
+    def utcoffset(self, dtime):
+        return dt.timedelta(0)
 
-    def tzname(self, dt):
+    def tzname(self, dtime):
         return "UTC"
 
-    def dst(self, dt):
-        return timedelta(0)
+    def dst(self, dtime):
+        return dt.timedelta(0)
 
 
 def half_power_radius(r, bwhalf):
@@ -753,7 +617,7 @@ def medfilt_along_axis(x, n, axis=-1):
     kernel_size = np.array(x.shape)
     kernel_size[:] = 1
     kernel_size[axis] = n
-    return medfilt(x, kernel_size)
+    return signal.medfilt(x, kernel_size)
 
 
 def gradient_along_axis(x):

--- a/wradlib/verify.py
+++ b/wradlib/verify.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -17,16 +17,14 @@ estimates to ground truth.
    PolarNeighbours
 
 """
-# site packages
-import numpy as np
-from scipy.spatial import KDTree
-from scipy import stats
-from pprint import pprint
 import warnings
+from pprint import pprint
 
-# wradlib modules
-from . import georef as georef
-from . import util as util
+import numpy as np
+from scipy import spatial, stats
+
+from wradlib.georef import polar
+from wradlib import util
 
 
 class PolarNeighbours():
@@ -76,13 +74,13 @@ class PolarNeighbours():
         self.x = x
         self.y = y
         # compute the centroid coordinates in proj
-        bin_coords = georef.spherical_to_centroids(r, az, 0,
-                                                   sitecoords,
-                                                   proj=proj)
+        bin_coords = polar.spherical_to_centroids(r, az, 0,
+                                                  sitecoords,
+                                                  proj=proj)
         self.binx = bin_coords[..., 0].ravel()
         self.biny = bin_coords[..., 1].ravel()
         # compute the KDTree
-        tree = KDTree(list(zip(self.binx, self.biny)))
+        tree = spatial.KDTree(list(zip(self.binx, self.biny)))
         # query the tree for nearest neighbours
         self.dist, self.ix = tree.query(list(zip(x, y)), k=nnear)
 

--- a/wradlib/vis.py
+++ b/wradlib/vis.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -28,30 +28,25 @@ Standard plotting and mapping procedures.
 
 
 """
-
-# standard libraries
-import os.path as path
-import warnings
-import re
 import collections
+import os.path
+import re
+import warnings
 
-# site packages
 import numpy as np
 import matplotlib.pyplot as pl
 from matplotlib import patches, axes, lines
+from matplotlib.collections import LineCollection, PolyCollection
 from matplotlib.projections import PolarAxes
+from matplotlib.ticker import NullFormatter, FuncFormatter
 from matplotlib.transforms import Affine2D
 from mpl_toolkits.axisartist import (SubplotHost, ParasiteAxesAuxTrans,
                                      GridHelperCurveLinear)
 import mpl_toolkits.axisartist.angle_helper as ah
-from matplotlib.ticker import NullFormatter, FuncFormatter
-from matplotlib.collections import LineCollection, PolyCollection
 import xarray as xr
 from osgeo import osr
 
-# wradlib modules
-from . import georef as georef
-from . util import import_optional
+from wradlib import georef, util
 
 
 @xr.register_dataarray_accessor('wradlib')
@@ -263,7 +258,7 @@ class WradlibAccessor(object):
 
         # use cartopy, if available
         if hasattr(plax, 'projection'):
-            cartopy = import_optional('cartopy')
+            cartopy = util.import_optional('cartopy')
             map_trans = cartopy.crs.AzimuthalEquidistant(
                 central_longitude=self.site[0],
                 central_latitude=self.site[1])
@@ -1035,7 +1030,8 @@ def plot_plan_and_vert(x, y, z, dataxy, datazx, datazy, unit="",
             pl.close()
     else:
         # save plot to file
-        if (path.exists(path.dirname(saveto))) or (path.dirname(saveto) == ''):
+        if ((os.path.exists(os.path.dirname(saveto))) or
+                (os.path.dirname(saveto) == '')):
             pl.savefig(saveto)
             pl.close()
 

--- a/wradlib/vpr.py
+++ b/wradlib/vpr.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -84,12 +84,9 @@ volume data::
    PseudoCAPPI
 
 """
-
 import numpy as np
 
-from . import georef as georef
-from . import ipol as ipol
-from . import util as util
+from wradlib import georef, ipol, util
 
 
 class CartesianVolume():

--- a/wradlib/zonalstats.py
+++ b/wradlib/zonalstats.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -52,19 +52,17 @@ Calling the objects with actual data, however, will be very fast.
    get_clip_mask
 
 """
-
-import numpy as np
-from scipy.spatial import cKDTree
-from matplotlib.path import Path
-import matplotlib.patches as patches
-from osgeo import gdal, ogr
-import warnings
-import tempfile
 import os
+import tempfile
+import warnings
 
-from .io import open_vector, gdal_create_dataset, write_raster_dataset
-from .georef import (numpy_to_ogr, ogr_add_feature, ogr_copy_layer,
-                     ogr_create_layer, ogr_to_numpy)
+from matplotlib.path import Path
+from matplotlib import patches
+import numpy as np
+from osgeo import gdal, ogr
+from scipy import spatial
+
+from wradlib import georef, io
 
 ogr.UseExceptions()
 gdal.UseExceptions()
@@ -148,7 +146,7 @@ class DataSource(object):
         sources = []
         for feature in lyr:
             geom = feature.GetGeometryRef()
-            poly = ogr_to_numpy(geom)
+            poly = georef.vector.ogr_to_numpy(geom)
             sources.append(poly)
         return np.array(sources)
 
@@ -168,7 +166,7 @@ class DataSource(object):
         for i in idx:
             feature = lyr.GetFeature(i)
             geom = feature.GetGeometryRef()
-            poly = ogr_to_numpy(geom)
+            poly = georef.vector.ogr_to_numpy(geom)
             sources.append(poly)
         return np.array(sources)
 
@@ -226,9 +224,9 @@ class DataSource(object):
               on ogr.layer
         """
         tmpfile = tempfile.NamedTemporaryFile(mode='w+b').name
-        ogr_src = gdal_create_dataset('ESRI Shapefile',
-                                      os.path.join('/vsimem', tmpfile),
-                                      gdal_type=gdal.OF_VECTOR)
+        ogr_src = io.gdal.gdal_create_dataset('ESRI Shapefile',
+                                              os.path.join('/vsimem', tmpfile),
+                                              gdal_type=gdal.OF_VECTOR)
 
         src = np.array(src)
         # create memory datasource, layer and create features
@@ -238,9 +236,9 @@ class DataSource(object):
         else:
             geom_type = ogr.wkbPolygon
         fields = [('index', ogr.OFTInteger)]
-        ogr_create_layer(ogr_src, self._name, srs=self._srs,
-                         geom_type=geom_type, fields=fields)
-        ogr_add_feature(ogr_src, src, name=self._name)
+        georef.vector.ogr_create_layer(ogr_src, self._name, srs=self._srs,
+                                       geom_type=geom_type, fields=fields)
+        georef.vector.ogr_add_feature(ogr_src, src, name=self._name)
 
         return ogr_src
 
@@ -257,10 +255,10 @@ class DataSource(object):
             if True removes existing output file
 
         """
-        ds_out = gdal_create_dataset(driver, filename,
-                                     gdal_type=gdal.OF_VECTOR,
-                                     remove=remove)
-        ogr_copy_layer(self.ds, 0, ds_out)
+        ds_out = io.gdal.gdal_create_dataset(driver, filename,
+                                             gdal_type=gdal.OF_VECTOR,
+                                             remove=remove)
+        georef.vector.ogr_copy_layer(self.ds, 0, ds_out)
 
         # flush everything
         del ds_out
@@ -278,11 +276,12 @@ class DataSource(object):
             driver string
         """
         tmpfile = tempfile.NamedTemporaryFile(mode='w+b').name
-        self.ds = gdal_create_dataset('ESRI Shapefile',
-                                      os.path.join('/vsimem', tmpfile),
-                                      gdal_type=gdal.OF_VECTOR)
+        self.ds = io.gdal.gdal_create_dataset('ESRI Shapefile',
+                                              os.path.join('/vsimem', tmpfile),
+                                              gdal_type=gdal.OF_VECTOR)
         # get input file handles
-        ds_in, tmp_lyr = open_vector(filename, driver=driver, layer=source)
+        ds_in, tmp_lyr = io.gdal.open_vector(filename, driver=driver,
+                                             layer=source)
 
         # copy layer
         ogr_src_lyr = self.ds.CopyLayer(tmp_lyr, self._name)
@@ -329,8 +328,8 @@ class DataSource(object):
         rows = int((y_max - y_min) / pixel_size)
 
         # Todo: at the moment, always writing floats
-        ds_out = gdal_create_dataset('MEM', '', cols, rows, 1,
-                                     gdal_type=gdal.GDT_Float32)
+        ds_out = io.gdal.gdal_create_dataset('MEM', '', cols, rows, 1,
+                                             gdal_type=gdal.GDT_Float32)
 
         ds_out.SetGeoTransform((x_min, pixel_size, 0, y_max, 0, -pixel_size))
         proj = layer.GetSpatialRef()
@@ -350,7 +349,7 @@ class DataSource(object):
                                 options=["ALL_TOUCHED=TRUE"],
                                 callback=progress)
 
-        write_raster_dataset(filename, ds_out, driver, remove=remove)
+        io.gdal.write_raster_dataset(filename, ds_out, driver, remove=remove)
 
         del ds_out
 
@@ -595,13 +594,13 @@ class ZonalDataBase(object):
 
         # create mem-mapped temp file dataset
         tmpfile = tempfile.NamedTemporaryFile(mode='w+b').name
-        ds_out = gdal_create_dataset('ESRI Shapefile',
-                                     os.path.join('/vsimem', tmpfile),
-                                     gdal_type=gdal.OF_VECTOR)
+        ds_out = io.gdal.gdal_create_dataset('ESRI Shapefile',
+                                             os.path.join('/vsimem', tmpfile),
+                                             gdal_type=gdal.OF_VECTOR)
 
         # create intermediate mem dataset
-        ds_mem = gdal_create_dataset('Memory', 'out',
-                                     gdal_type=gdal.OF_VECTOR)
+        ds_mem = io.gdal.gdal_create_dataset('Memory', 'out',
+                                             gdal_type=gdal.OF_VECTOR)
 
         # get src geometry layer
         src_lyr = self.src.ds.GetLayerByName('src')
@@ -626,8 +625,9 @@ class ZonalDataBase(object):
         trg_lyr.ResetReading()
 
         # create tmp dest layer
-        self.tmp_lyr = ogr_create_layer(ds_mem, 'dst', srs=self._srs,
-                                        geom_type=geom_type)
+        self.tmp_lyr = georef.vector.ogr_create_layer(ds_mem, 'dst',
+                                                      srs=self._srs,
+                                                      geom_type=geom_type)
 
         trg_lyr.Intersection(src_lyr, self.tmp_lyr,
                              options=['SKIP_FAILURES=YES',
@@ -638,7 +638,7 @@ class ZonalDataBase(object):
                                       'PRETEST_CONTAINMENT=YES'],
                              callback=progress)
 
-        ogr_copy_layer(ds_mem, 0, ds_out)
+        georef.vector.ogr_copy_layer(ds_mem, 0, ds_out)
 
         return ds_out
 
@@ -705,7 +705,7 @@ class ZonalDataBase(object):
 
         # check for geometry
         if not type(trg) == ogr.Geometry:
-            trg = numpy_to_ogr(trg, 'Polygon')
+            trg = georef.vector.numpy_to_ogr(trg, 'Polygon')
 
         # apply Buffer value
         trg = trg.Buffer(buf)
@@ -1084,7 +1084,7 @@ def mask_from_bbox(x, y, bbox, polar=False):
 
     # Find bbox corners
     #    Plant a tree
-    tree = cKDTree(np.vstack((x.ravel(), y.ravel())).transpose())
+    tree = spatial.cKDTree(np.vstack((x.ravel(), y.ravel())).transpose())
     # find lower left corner index
     dists, ixll = tree.query([bbox["left"], bbox["bottom"]], k=1)
     ill = (ixll // nx) - 1

--- a/wradlib/zr.py
+++ b/wradlib/zr.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2018, wradlib developers.
+# Copyright (c) 2011-2019, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -23,7 +23,8 @@ into rainfall rates and vice versa
 """
 import numpy as np
 import scipy.ndimage.filters as filters
-from .trafo import decibel
+
+from wradlib import trafo
 
 
 def z_to_r(z, a=200., b=1.6):
@@ -122,7 +123,7 @@ def _z_to_r_enhanced(z):
     dimx = z.shape[1]
 
     # calculate the decibel values from the input
-    db = decibel(z)
+    db = trafo.decibel(z)
 
     # set up our output arrays
     r = np.zeros(z.shape)
@@ -187,7 +188,7 @@ def z_to_r_esifilter(data):
     """calculates the shower index for the enhanced z-r relation
 
     to be used as the callable for
-    :func:`scipy:scipy.ndimagefilters.generic_filter`
+    :func:`scipy:scipy.ndimage.filters.generic_filter`
     """
     if data[4] < 36.5:
         tdata = data.reshape((3, 3))
@@ -205,15 +206,15 @@ def _z_to_r_enhanced_mdfilt(z, mode='mirror'):
     """multidimensional version
 
     assuming the two last dimensions represent a 2-D image
-    Uses :func:`scipy:scipy.ndimagefilters.generic_filter` to reduce the number
-    of for-loops even more.
+    Uses :func:`scipy:scipy.ndimage.filters.generic_filter` to reduce the
+    number of for-loops even more.
     """
     # get the shape of the input
     # dimy = z.shape[-2]
     # dimx = z.shape[-1]
 
     # calculate the decibel values from the input
-    db = decibel(z)
+    db = trafo.decibel(z)
 
     # set up our output arrays
     r = np.zeros(z.shape)
@@ -255,7 +256,7 @@ def _z_to_r_enhanced_mdcorr(z, xmode='reflect', ymode='wrap'):
     # dimx = z.shape[-1]
 
     # calculate the decibel values from the input
-    db = decibel(z)
+    db = trafo.decibel(z)
     # calculate the shower differences by 1-d correlation with a differencing
     # kernel
     db_diffx = np.abs(filters.correlate1d(db, [1, -1], axis=-1,


### PR DESCRIPTION
fixes #348
fixes #375

The imports in wradlib modules follow now the [PEP8 recommendation](https://pep8.org/#imports):
eg.

```python
import os
import sys

import numpy as np
import xarray as xr

from wradlib import io, ipol
from wradlib.georef import projection
```

Absolute imports are used throughout the package.

We would have some name clash with system and wradlib `io` module. This is circumvented using ìmport io as sio`. Other possible name clashes with eg. `gdal` are possible but can also be mitigated.

The function `maximum_intensity_projection` was moved from `util` to `georef.polar` because it uses polar data and the circular dependency is avoided. There is only one circular dependency left in `io.hdf` (import zonalstats.get_clip_mask). This can also be removed after some refactoring in a later PR.





