### PR TITLE
Correct error in documentation of sweep_centroids

### DIFF
--- a/wradlib/georef/polar.py
+++ b/wradlib/georef/polar.py
@@ -554,7 +554,7 @@ def sweep_centroids(nrays, rscale, nbins, elangle):
     nbins : int
         number of range bins
     elangle : float
-        elevation angle [radians]
+        elevation angle [deg]
 
     Returns
     -------


### PR DESCRIPTION
Documentation mentions elevation angle in [rads] ,but it should be [deg]. I already discussed in Issue #9.

