### PR TITLE
FIX: adapt `georef.polar.sweep_centroids` to only use angles in degrees

### DIFF
--- a/wradlib/georef/polar.py
+++ b/wradlib/georef/polar.py
@@ -562,8 +562,8 @@ def sweep_centroids(nrays, rscale, nbins, elangle):
         array of shape (nrays,nbins,3) containing native centroid radar
         coordinates (slant range, azimuth, elevation)
     """
-    ascale = 2 * np.pi / nrays
-    azimuths = ascale / 2. + np.linspace(0, 2 * np.pi, nrays, endpoint=False)
+    ascale = 360. / nrays
+    azimuths = ascale / 2. + np.linspace(0, 360., nrays, endpoint=False)
     ranges = np.arange(nbins) * rscale + rscale / 2.
     coordinates = np.empty((nrays, nbins, 3), dtype=float)
     coordinates[:, :, 0] = np.tile(ranges, (nrays, 1))

--- a/wradlib/tests/test_clutter.py
+++ b/wradlib/tests/test_clutter.py
@@ -126,7 +126,7 @@ class FilterCloudtypeTest(unittest.TestCase):
                       pvol["where"]["height"])
 
         coord, proj_radar = georef.spherical_to_xyz(coord[..., 0],
-                                                    np.degrees(coord[..., 1]),
+                                                    coord[..., 1],
                                                     coord[..., 2], sitecoords,
                                                     re=6370040.,
                                                     ke=4. / 3.)

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -274,8 +274,8 @@ class CoordinateHelperTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(centroids, arr, decimal=3)
 
     def test_sweep_centroids(self):
-        self.assertTrue(np.allclose(georef.sweep_centroids(1, 100., 1, 2.0),
-                                    np.array([[[50., 3.14159265, 2.]]])))
+        np.testing.assert_array_equal(georef.sweep_centroids(1, 100., 1, 2.0),
+                                      np.array([[[50., 180., 2.]]]))
 
     def test__check_polar_coords(self):
         r = np.array([50., 100., 150., 200.])

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -218,7 +218,7 @@ class HDF5Test(unittest.TestCase):
         alt0_gr = gr_data['where']['height']
         coord = georef.sweep_centroids(nray_gr, dr_gr, ngate_gr, elev_gr)
         coords = georef.spherical_to_proj(coord[..., 0],
-                                          np.degrees(coord[..., 1]),
+                                          coord[..., 1],
                                           coord[..., 2],
                                           (lon0_gr, lat0_gr, alt0_gr))
         lon = coords[..., 0]
@@ -248,7 +248,7 @@ class HDF5Test(unittest.TestCase):
         alt0_gr = gr_data['where']['height']
         coord = georef.sweep_centroids(nray_gr, dr_gr, ngate_gr, elev_gr)
         coords = georef.spherical_to_proj(coord[..., 0],
-                                          np.degrees(coord[..., 1]),
+                                          coord[..., 1],
                                           coord[..., 2],
                                           (lon0_gr, lat0_gr, alt0_gr))
         lon = coords[..., 0]

--- a/wradlib/tests/test_ipol.py
+++ b/wradlib/tests/test_ipol.py
@@ -306,7 +306,7 @@ class RegularToIrregularTest(unittest.TestCase):
 
         coord = georef.sweep_centroids(4, 1, NX, 0.)
         xx = coord[..., 0]
-        yy = np.degrees(coord[..., 1])
+        yy = coord[..., 1]
 
         xxx = xx * np.cos(np.radians(90. - yy))
         x = xx * np.sin(np.radians(90. - yy))


### PR DESCRIPTION
fixes #384