### PR TITLE
FIX: low cloud switch removes everything

### DIFF
--- a/wradlib/clutter.py
+++ b/wradlib/clutter.py
@@ -494,12 +494,12 @@ def filter_cloudtype(img, cloud, thrs=0, snow=False, low=False, cirrus=False,
     thrs : float
         Threshold above which to identify clutter
     snow : bool
-        Swith to use PGE02 class "land/sea snow" for clutter identification
+        Switch to use PGE02 class "land/sea snow" for clutter identification
     low : bool
-        Swith to use PGE02 class "low/very low stratus/cumulus" for
-        clutter identification
+        Switch to use PGE02 class very low stratus, very low cumulus and
+        low cumulus for clutter identification
     cirrus : bool
-        Swith to use PGE02 class "very thin cirrus" and "fractional clouds"
+        Switch to use PGE02 class "very thin cirrus" and "fractional clouds"
         for clutter identification
     smoothing : float
         Size [m] of the smoothing window used to take into account various
@@ -520,7 +520,7 @@ def filter_cloudtype(img, cloud, thrs=0, snow=False, low=False, cirrus=False,
     if snow:
         noprecip = noprecip | (cloud == 3) | (cloud == 4)
     if low:
-        noprecip = noprecip | (cloud >= 4) | (cloud <= 7)
+        noprecip = noprecip | (cloud == 5) | (cloud == 6) | (cloud == 7)
     if cirrus:
         noprecip = noprecip | (cloud == 14) | (cloud == 18)
     if smoothing is not None:

--- a/wradlib/tests/test_clutter.py
+++ b/wradlib/tests/test_clutter.py
@@ -147,8 +147,17 @@ class FilterCloudtypeTest(unittest.TestCase):
         self.error = np.absolute(timelag) * wind
 
     def test_filter_cloudtype(self):
-        clutter.filter_cloudtype(self.val, self.val_sat,
-                                 scale=self.rscale, smoothing=self.error)
+        nonmet = clutter.filter_cloudtype(self.val, self.val_sat,
+                                          scale=self.rscale,
+                                          smoothing=self.error)
+        nclutter = np.sum(nonmet)
+        self.assertTrue(nclutter == 8141)
+        nonmet = clutter.filter_cloudtype(self.val, self.val_sat,
+                                          scale=self.rscale,
+                                          smoothing=self.error,
+                                          low=True)
+        nclutter = np.sum(nonmet)
+        self.assertTrue(nclutter == 17856)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
There is an error in the logical expression for the low switch in clutter.filter_cloudtype.
It implies that all data are identified as clutter.
Now the cloud types are considered explicitly using equality.
A test has been added to discover this bug.