### PR TITLE
enh: fix double rays before merging

### DIFF
--- a/wradlib/tests/test_io_odim.py
+++ b/wradlib/tests/test_io_odim.py
@@ -9,6 +9,7 @@ import xarray as xr
 import h5py
 
 from wradlib import io, util
+import wradlib as wrl
 
 
 def create_a1gate(i):
@@ -871,3 +872,61 @@ class TestSyntheticGamicVolume01(SyntheticDataVolume):
 
     dsdesc = 'scan{}'
     mdesc = 'moment_{}'
+
+
+def base_odim_data_double_th():
+    data = base_odim_data_02()
+    dataset = ['dataset1', 'dataset2']
+    for i, grp in enumerate(dataset):
+        sub = data[grp]
+        sub['data1']['what']['attrs']['quantity'] = "TH"
+        myaz = sub['how']['attrs']['startazA'][9]
+        sub['how']['attrs']['startazA'][10] = myaz
+        myaz = sub['how']['attrs']['stopazA'][9]
+        sub['how']['attrs']['stopazA'][10] = myaz
+    return data
+
+
+def base_odim_data_double_th_no_rtime():
+    data = base_odim_data_02()
+    dataset = ['dataset1', 'dataset2']
+    for i, grp in enumerate(dataset):
+        sub = data[grp]
+        sub['data1']['what']['attrs']['quantity'] = "TH"
+        myaz = sub['how']['attrs']['startazA'][9]
+        sub['how']['attrs']['startazA'][10] = myaz
+        myaz = sub['how']['attrs']['stopazA'][9]
+        sub['how']['attrs']['stopazA'][10] = myaz
+        del sub['how']['attrs']['startazT']
+        del sub['how']['attrs']['stopazT']
+    return data
+
+
+def create_test_file(name, data):
+    import tempfile
+    tmp_local = tempfile.NamedTemporaryFile(suffix='h5', prefix=name).name
+    with h5py.File(str(tmp_local), 'w') as f:
+        write_group(f, data)
+
+    return tmp_local
+
+
+class TestNotOdimCompliant():
+
+    def test_double_rays(self):
+
+        dbzh = base_odim_data_01()
+        dbzh = create_test_file("dbzh", dbzh)
+        th = base_odim_data_double_th()
+        th = create_test_file("th", th)
+        pvol = wrl.io.xarray.open_odim([dbzh, th])
+        pvol[0].data
+
+    def test_double_rays_no_rtime(self):
+
+        dbzh = base_odim_data_01()
+        dbzh = create_test_file("dbzh", dbzh)
+        th = base_odim_data_double_th_no_rtime()
+        th = create_test_file("th", th)
+        pvol = wrl.io.xarray.open_odim([dbzh, th])
+        pvol[0].data


### PR DESCRIPTION
Currently radar moments with same elevation and same timestamp are merged before obtaining coordinates.
Inconsistencies in the moments files could not be detected or corrected
With this PR the coordinates are obtained and fixed before merging.
