### PR TITLE
MIN: update projection

### DIFF
--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -981,7 +981,6 @@ class TestSatellite:
 
     def test_correct_parallax(self):
         xy, r, z = georef.correct_parallax(self.pr_xy, self.nbin, self.dr, self.alpha)
-        xyz = np.concatenate((xy, z[..., np.newaxis]), axis=-1)
         pr_out = np.array(
             [
                 [

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -626,7 +626,8 @@ class TestProjections:
     def test_get_radar_projection(self):
         sitecoords = [5, 52, 90]
         p0 = georef.get_radar_projection(sitecoords)
-        assert p0.GetName() == "Unknown Azimuthal Equidistant"
+        if gdal.VersionInfo()[0] >= "3":
+            assert p0.GetName() == "Unknown Azimuthal Equidistant"
         assert p0.IsProjected()
         assert p0.IsSameGeogCS(georef.get_default_projection())
         assert p0.GetNormProjParm("latitude_of_center") == sitecoords[1]

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -6,158 +6,241 @@ import sys
 import unittest
 
 import numpy as np
-from osgeo import gdal, osr, ogr
-import xarray as xr
-
 import wradlib
+import xarray as xr
+from osgeo import gdal, ogr, osr
 from wradlib import georef, util
 
-
-np.set_printoptions(edgeitems=3, infstr='inf', linewidth=75, nanstr='nan',
-                    precision=8, suppress=False, threshold=1000,
-                    formatter=None)
+np.set_printoptions(
+    edgeitems=3,
+    infstr="inf",
+    linewidth=75,
+    nanstr="nan",
+    precision=8,
+    suppress=False,
+    threshold=1000,
+    formatter=None,
+)
 
 
 class CoordinateTransformTest(unittest.TestCase):
     def setUp(self):
-        self.r = np.array([0., 0., 111., 111., 111., 111.]) * 1000
-        self.az = np.array([0., 180., 0., 90., 180., 270.])
-        self.th = np.array([0., 0., 0., 0., 0., 0.5])
+        self.r = np.array([0.0, 0.0, 111.0, 111.0, 111.0, 111.0]) * 1000
+        self.az = np.array([0.0, 180.0, 0.0, 90.0, 180.0, 270.0])
+        self.th = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.5])
         self.csite = (9.0, 48.0, 0)
         self.result_xyz = tuple(
-            (np.array([0., 0., 0., 110993.6738, 0., -110976.7856]),
-             np.array([0., -0., 110993.6738, 0., -110976.7856, -0.]),
-             np.array([0., 0., 725.7159843, 725.7159843, 725.7159843,
-                       1694.22337134])))
+            (
+                np.array([0.0, 0.0, 0.0, 110993.6738, 0.0, -110976.7856]),
+                np.array([0.0, -0.0, 110993.6738, 0.0, -110976.7856, -0.0]),
+                np.array(
+                    [0.0, 0.0, 725.7159843, 725.7159843, 725.7159843, 1694.22337134]
+                ),
+            )
+        )
         self.result = tuple(
-            (np.array([9., 9., 9., 10.49189531, 9., 7.50810469]),
-             np.array([48., 48., 48.99839742, 47.99034027, 47.00160258,
-                       47.99034027]),
-             np.array([0., 0., 967.03198482, 967.03198482, 967.03198482,
-                       1935.45679527])))
+            (
+                np.array([9.0, 9.0, 9.0, 10.49189531, 9.0, 7.50810469]),
+                np.array(
+                    [48.0, 48.0, 48.99839742, 47.99034027, 47.00160258, 47.99034027]
+                ),
+                np.array(
+                    [0.0, 0.0, 967.03198482, 967.03198482, 967.03198482, 1935.45679527]
+                ),
+            )
+        )
         self.result_n = tuple(
-            (np.array([9., 9., 9., 10.48716091, 9., 7.51306531]),
-             np.array([48., 48., 48.99814438, 47.99037251, 47.00168131,
-                       47.99037544]),
-             np.array([0., 0., 725.7159843, 725.7159843, 725.7159843,
-                       1694.22337134])))
+            (
+                np.array([9.0, 9.0, 9.0, 10.48716091, 9.0, 7.51306531]),
+                np.array(
+                    [48.0, 48.0, 48.99814438, 47.99037251, 47.00168131, 47.99037544]
+                ),
+                np.array(
+                    [0.0, 0.0, 725.7159843, 725.7159843, 725.7159843, 1694.22337134]
+                ),
+            )
+        )
 
     def test_spherical_to_xyz(self):
-        self.assertTrue((1, 36, 10, 3) ==
-                        georef.spherical_to_xyz(np.arange(10),
-                                                np.arange(36),
-                                                10., self.csite,
-                                                squeeze=False)[0].shape)
-        self.assertTrue((1, 36, 10, 3) ==
-                        georef.spherical_to_xyz(np.arange(10), np.arange(36),
-                                                np.arange(36), self.csite,
-                                                squeeze=False)[0].shape)
-        self.assertTrue((36, 10, 3) ==
-                        georef.spherical_to_xyz(np.arange(10), np.arange(36),
-                                                np.arange(36), self.csite,
-                                                squeeze=True,
-                                                strict_dims=False)[0].shape)
-        self.assertTrue((36, 36, 10, 3) ==
-                        georef.spherical_to_xyz(np.arange(10), np.arange(36),
-                                                np.arange(36), self.csite,
-                                                strict_dims=True)[0].shape)
-        self.assertTrue((18, 36, 10, 3) ==
-                        georef.spherical_to_xyz(np.arange(10), np.arange(36),
-                                                np.arange(18), self.csite,
-                                                strict_dims=False)[0].shape)
+        self.assertTrue(
+            (1, 36, 10, 3)
+            == georef.spherical_to_xyz(
+                np.arange(10), np.arange(36), 10.0, self.csite, squeeze=False
+            )[0].shape
+        )
+        self.assertTrue(
+            (1, 36, 10, 3)
+            == georef.spherical_to_xyz(
+                np.arange(10), np.arange(36), np.arange(36), self.csite, squeeze=False
+            )[0].shape
+        )
+        self.assertTrue(
+            (36, 10, 3)
+            == georef.spherical_to_xyz(
+                np.arange(10),
+                np.arange(36),
+                np.arange(36),
+                self.csite,
+                squeeze=True,
+                strict_dims=False,
+            )[0].shape
+        )
+        self.assertTrue(
+            (36, 36, 10, 3)
+            == georef.spherical_to_xyz(
+                np.arange(10),
+                np.arange(36),
+                np.arange(36),
+                self.csite,
+                strict_dims=True,
+            )[0].shape
+        )
+        self.assertTrue(
+            (18, 36, 10, 3)
+            == georef.spherical_to_xyz(
+                np.arange(10),
+                np.arange(36),
+                np.arange(18),
+                self.csite,
+                strict_dims=False,
+            )[0].shape
+        )
         r, phi = np.meshgrid(np.arange(10), np.arange(36))
-        self.assertTrue((1, 36, 10, 3) ==
-                        georef.spherical_to_xyz(r, phi, 10, self.csite,
-                                                squeeze=False,
-                                                strict_dims=False)[0].shape)
+        self.assertTrue(
+            (1, 36, 10, 3)
+            == georef.spherical_to_xyz(
+                r, phi, 10, self.csite, squeeze=False, strict_dims=False
+            )[0].shape
+        )
         r, phi = np.meshgrid(np.arange(10), np.arange(36))
-        self.assertTrue((1, 36, 10, 3) ==
-                        georef.spherical_to_xyz(r, phi, np.arange(36),
-                                                self.csite, squeeze=False,
-                                                strict_dims=False)[0].shape)
+        self.assertTrue(
+            (1, 36, 10, 3)
+            == georef.spherical_to_xyz(
+                r, phi, np.arange(36), self.csite, squeeze=False, strict_dims=False
+            )[0].shape
+        )
         r, phi = np.meshgrid(np.arange(10), np.arange(36))
-        self.assertTrue((18, 36, 10, 3) ==
-                        georef.spherical_to_xyz(r, phi, np.arange(18),
-                                                self.csite, squeeze=False,
-                                                strict_dims=False)[0].shape)
+        self.assertTrue(
+            (18, 36, 10, 3)
+            == georef.spherical_to_xyz(
+                r, phi, np.arange(18), self.csite, squeeze=False, strict_dims=False
+            )[0].shape
+        )
         r, phi = np.meshgrid(np.arange(10), np.arange(36))
-        self.assertTrue((36, 36, 10, 3) ==
-                        georef.spherical_to_xyz(r, phi, np.arange(36),
-                                                self.csite, squeeze=False,
-                                                strict_dims=True)[0].shape)
-        self.assertTrue((1, 1, 1, 3) ==
-                        georef.spherical_to_xyz(10, 36, 10., self.csite,
-                                                squeeze=False)[0].shape)
-        self.assertTrue((1, 1, 10, 3) ==
-                        georef.spherical_to_xyz(np.arange(10), 36, 10.,
-                                                self.csite,
-                                                squeeze=False)[0].shape)
-        self.assertTrue((1, 36, 1, 3) ==
-                        georef.spherical_to_xyz(10, np.arange(36), 10.,
-                                                self.csite,
-                                                squeeze=False)[0].shape)
-        self.assertTrue((10, 1, 1, 3) ==
-                        georef.spherical_to_xyz(10, 36., np.arange(10),
-                                                self.csite,
-                                                squeeze=False)[0].shape)
-        self.assertTrue((10, 36, 1, 3) ==
-                        georef.spherical_to_xyz(10, np.arange(36),
-                                                np.arange(10),
-                                                self.csite,
-                                                squeeze=False)[0].shape)
+        self.assertTrue(
+            (36, 36, 10, 3)
+            == georef.spherical_to_xyz(
+                r, phi, np.arange(36), self.csite, squeeze=False, strict_dims=True
+            )[0].shape
+        )
+        self.assertTrue(
+            (1, 1, 1, 3)
+            == georef.spherical_to_xyz(10, 36, 10.0, self.csite, squeeze=False)[0].shape
+        )
+        self.assertTrue(
+            (1, 1, 10, 3)
+            == georef.spherical_to_xyz(
+                np.arange(10), 36, 10.0, self.csite, squeeze=False
+            )[0].shape
+        )
+        self.assertTrue(
+            (1, 36, 1, 3)
+            == georef.spherical_to_xyz(
+                10, np.arange(36), 10.0, self.csite, squeeze=False
+            )[0].shape
+        )
+        self.assertTrue(
+            (10, 1, 1, 3)
+            == georef.spherical_to_xyz(
+                10, 36.0, np.arange(10), self.csite, squeeze=False
+            )[0].shape
+        )
+        self.assertTrue(
+            (10, 36, 1, 3)
+            == georef.spherical_to_xyz(
+                10, np.arange(36), np.arange(10), self.csite, squeeze=False
+            )[0].shape
+        )
 
-        coords, rad = georef.spherical_to_xyz(self.r, self.az,
-                                              self.th, self.csite,
-                                              squeeze=True, strict_dims=False)
-        self.assertTrue(np.allclose(coords[..., 0], self.result_xyz[0],
-                        rtol=1e-03))
-        self.assertTrue(np.allclose(coords[..., 1], self.result_xyz[1],
-                        rtol=1e-03))
-        self.assertTrue(np.allclose(coords[..., 2], self.result_xyz[2],
-                        rtol=1e-03))
+        coords, rad = georef.spherical_to_xyz(
+            self.r, self.az, self.th, self.csite, squeeze=True, strict_dims=False
+        )
+        self.assertTrue(np.allclose(coords[..., 0], self.result_xyz[0], rtol=1e-03))
+        self.assertTrue(np.allclose(coords[..., 1], self.result_xyz[1], rtol=1e-03))
+        self.assertTrue(np.allclose(coords[..., 2], self.result_xyz[2], rtol=1e-03))
         re = georef.get_earth_radius(self.csite[1])
-        coords, rad = georef.spherical_to_xyz(self.r, self.az,
-                                              self.th, self.csite,
-                                              re=re, squeeze=True)
-        self.assertTrue(np.allclose(coords[..., 0], self.result_xyz[0],
-                                    rtol=1e-03))
-        self.assertTrue(np.allclose(coords[..., 1], self.result_xyz[1],
-                                    rtol=1e-03))
-        self.assertTrue(np.allclose(coords[..., 2], self.result_xyz[2],
-                                    rtol=1e-03))
+        coords, rad = georef.spherical_to_xyz(
+            self.r, self.az, self.th, self.csite, re=re, squeeze=True
+        )
+        self.assertTrue(np.allclose(coords[..., 0], self.result_xyz[0], rtol=1e-03))
+        self.assertTrue(np.allclose(coords[..., 1], self.result_xyz[1], rtol=1e-03))
+        self.assertTrue(np.allclose(coords[..., 2], self.result_xyz[2], rtol=1e-03))
 
     def test_bin_altitude(self):
-        altitude = georef.bin_altitude(np.arange(10., 101., 10.)
-                                       * 1000., 2., 0, 6370040.)
-        altref = np.array([354.87448647, 721.50702113, 1099.8960815,
-                           1490.04009656, 1891.93744678, 2305.58646416,
-                           2730.98543223, 3168.13258613, 3617.02611263,
-                           4077.66415017])
+        altitude = georef.bin_altitude(
+            np.arange(10.0, 101.0, 10.0) * 1000.0, 2.0, 0, 6370040.0
+        )
+        altref = np.array(
+            [
+                354.87448647,
+                721.50702113,
+                1099.8960815,
+                1490.04009656,
+                1891.93744678,
+                2305.58646416,
+                2730.98543223,
+                3168.13258613,
+                3617.02611263,
+                4077.66415017,
+            ]
+        )
         np.testing.assert_allclose(altref, altitude)
 
     def test_bin_distance(self):
-        distance = georef.bin_distance(np.arange(10., 101., 10.) * 1000., 2.,
-                                       0, 6370040.)
-        distref = np.array([9993.49302358, 19986.13717891, 29977.90491409,
-                            39968.76869178, 49958.70098959, 59947.6743006,
-                            69935.66113377, 79922.63401441, 89908.5654846,
-                            99893.4281037])
+        distance = georef.bin_distance(
+            np.arange(10.0, 101.0, 10.0) * 1000.0, 2.0, 0, 6370040.0
+        )
+        distref = np.array(
+            [
+                9993.49302358,
+                19986.13717891,
+                29977.90491409,
+                39968.76869178,
+                49958.70098959,
+                59947.6743006,
+                69935.66113377,
+                79922.63401441,
+                89908.5654846,
+                99893.4281037,
+            ]
+        )
         np.testing.assert_allclose(distref, distance)
 
     def test_site_distance(self):
-        altitude = georef.bin_altitude(np.arange(10., 101., 10.) * 1000., 2.,
-                                       0, 6370040.)
-        distance = georef.site_distance(np.arange(10., 101., 10.) * 1000., 2.,
-                                        altitude, 6370040.)
-        distref = np.array([9993.49302358, 19986.13717891, 29977.90491409,
-                            39968.76869178, 49958.70098959, 59947.6743006,
-                            69935.66113377, 79922.63401441, 89908.5654846,
-                            99893.4281037])
+        altitude = georef.bin_altitude(
+            np.arange(10.0, 101.0, 10.0) * 1000.0, 2.0, 0, 6370040.0
+        )
+        distance = georef.site_distance(
+            np.arange(10.0, 101.0, 10.0) * 1000.0, 2.0, altitude, 6370040.0
+        )
+        distref = np.array(
+            [
+                9993.49302358,
+                19986.13717891,
+                29977.90491409,
+                39968.76869178,
+                49958.70098959,
+                59947.6743006,
+                69935.66113377,
+                79922.63401441,
+                89908.5654846,
+                99893.4281037,
+            ]
+        )
         np.testing.assert_allclose(distref, distance)
 
     def test_spherical_to_proj(self):
-        coords = georef.spherical_to_proj(self.r, self.az,
-                                          self.th, self.csite)
+        coords = georef.spherical_to_proj(self.r, self.az, self.th, self.csite)
         self.assertTrue(np.allclose(coords[..., 0], self.result_n[0]))
         self.assertTrue(np.allclose(coords[..., 1], self.result_n[1]))
         self.assertTrue(np.allclose(coords[..., 2], self.result_n[2]))
@@ -166,7 +249,7 @@ class CoordinateTransformTest(unittest.TestCase):
         angle = 0.0
         elev = 0.0
 
-        filename = util.get_wradlib_data_file('misc/polar_dBZ_tur.gz')
+        filename = util.get_wradlib_data_file("misc/polar_dBZ_tur.gz")
         data = np.loadtxt(filename)
         # we need to have meter here for the georef function inside mip
         d1 = np.arange(data.shape[1], dtype=np.float) * 1000
@@ -174,288 +257,324 @@ class CoordinateTransformTest(unittest.TestCase):
         data = np.roll(data, (d2 >= angle).nonzero()[0][0], axis=0)
 
         # calculate max intensity proj
-        georef.maximum_intensity_projection(data, r=d1, az=d2,
-                                            angle=angle, elev=elev)
+        georef.maximum_intensity_projection(data, r=d1, az=d2, angle=angle, elev=elev)
         georef.maximum_intensity_projection(data, autoext=False)
 
 
 class CoordinateHelperTest(unittest.TestCase):
     def test_centroid_to_polyvert(self):
         np.testing.assert_array_equal(
-            georef.centroid_to_polyvert(np.array([0., 1.]),
-                                        [0.5, 1.5]),
-            np.array([[-0.5, -0.5],
-                      [-0.5, 2.5],
-                      [0.5, 2.5],
-                      [0.5, -0.5],
-                      [-0.5, -0.5]]))
+            georef.centroid_to_polyvert(np.array([0.0, 1.0]), [0.5, 1.5]),
+            np.array(
+                [[-0.5, -0.5], [-0.5, 2.5], [0.5, 2.5], [0.5, -0.5], [-0.5, -0.5]]
+            ),
+        )
         np.testing.assert_array_equal(
             georef.centroid_to_polyvert(np.arange(4).reshape((2, 2)), 0.5),
-            np.array([[[-0.5, 0.5],
-                       [-0.5, 1.5],
-                       [0.5, 1.5],
-                       [0.5, 0.5],
-                       [-0.5, 0.5]],
-                      [[1.5, 2.5],
-                       [1.5, 3.5],
-                       [2.5, 3.5],
-                       [2.5, 2.5],
-                       [1.5, 2.5]]]))
+            np.array(
+                [
+                    [[-0.5, 0.5], [-0.5, 1.5], [0.5, 1.5], [0.5, 0.5], [-0.5, 0.5]],
+                    [[1.5, 2.5], [1.5, 3.5], [2.5, 3.5], [2.5, 2.5], [1.5, 2.5]],
+                ]
+            ),
+        )
         with self.assertRaises(ValueError):
-            georef.centroid_to_polyvert([[0.], [1.]], [0.5, 1.5])
+            georef.centroid_to_polyvert([[0.0], [1.0]], [0.5, 1.5])
 
     def test_spherical_to_polyvert(self):
         sph = georef.get_default_projection()
-        polyvert = georef.spherical_to_polyvert(np.array([10000., 10100.]),
-                                                np.array([45., 90.]), 0,
-                                                (9., 48.), proj=sph)
-        arr = np.asarray([[[9.05084865, 48.08224715, 6.],
-                           [9.05136309, 48.0830778, 6.],
-                           [9.1238846, 48.03435008, 6.],
-                           [9.12264494, 48.03400725, 6.],
-                           [9.05084865, 48.08224715, 6.]],
-                          [[9.05136309, 48.0830778, 6.],
-                           [9.05187756, 48.08390846, 6.],
-                           [9.12512428, 48.03469291, 6.],
-                           [9.1238846, 48.03435008, 6.],
-                           [9.05136309, 48.0830778, 6.]],
-                          [[9.12264494, 48.03400725, 6.],
-                           [9.1238846, 48.03435008, 6.],
-                           [9.05136309, 48.0830778, 6.],
-                           [9.05084865, 48.08224715, 6.],
-                           [9.12264494, 48.03400725, 6.]],
-                          [[9.1238846, 48.03435008, 6.],
-                           [9.12512428, 48.03469291, 6.],
-                           [9.05187756, 48.08390846, 6.],
-                           [9.05136309, 48.0830778, 6.],
-                           [9.1238846, 48.03435008, 6.]]])
+        polyvert = georef.spherical_to_polyvert(
+            np.array([10000.0, 10100.0]),
+            np.array([45.0, 90.0]),
+            0,
+            (9.0, 48.0),
+            proj=sph,
+        )
+        arr = np.asarray(
+            [
+                [
+                    [9.05084865, 48.08224715, 6.0],
+                    [9.05136309, 48.0830778, 6.0],
+                    [9.1238846, 48.03435008, 6.0],
+                    [9.12264494, 48.03400725, 6.0],
+                    [9.05084865, 48.08224715, 6.0],
+                ],
+                [
+                    [9.05136309, 48.0830778, 6.0],
+                    [9.05187756, 48.08390846, 6.0],
+                    [9.12512428, 48.03469291, 6.0],
+                    [9.1238846, 48.03435008, 6.0],
+                    [9.05136309, 48.0830778, 6.0],
+                ],
+                [
+                    [9.12264494, 48.03400725, 6.0],
+                    [9.1238846, 48.03435008, 6.0],
+                    [9.05136309, 48.0830778, 6.0],
+                    [9.05084865, 48.08224715, 6.0],
+                    [9.12264494, 48.03400725, 6.0],
+                ],
+                [
+                    [9.1238846, 48.03435008, 6.0],
+                    [9.12512428, 48.03469291, 6.0],
+                    [9.05187756, 48.08390846, 6.0],
+                    [9.05136309, 48.0830778, 6.0],
+                    [9.1238846, 48.03435008, 6.0],
+                ],
+            ]
+        )
         np.testing.assert_array_almost_equal(polyvert, arr, decimal=3)
-        polyvert, pr = georef.spherical_to_polyvert(np.array([10000., 10100.]),
-                                                    np.array([45., 90.]), 0,
-                                                    (9., 48.))
-        arr = np.asarray([[[3.7885640e+03, 9.1464023e+03, 6.],
-                           [3.8268320e+03, 9.2387900e+03, 6.],
-                           [9.2387900e+03, 3.8268323e+03, 6.],
-                           [9.1464023e+03, 3.7885645e+03, 6.],
-                           [3.7885640e+03, 9.1464023e+03, 6.]],
-                          [[3.8268320e+03, 9.2387900e+03, 6.],
-                           [3.8651003e+03, 9.3311777e+03, 6.],
-                           [9.3311777e+03, 3.8651006e+03, 6.],
-                           [9.2387900e+03, 3.8268323e+03, 6.],
-                           [3.8268320e+03, 9.2387900e+03, 6.]],
-                          [[9.1464023e+03, 3.7885645e+03, 6.],
-                           [9.2387900e+03, 3.8268323e+03, 6.],
-                           [3.8268320e+03, 9.2387900e+03, 6.],
-                           [3.7885640e+03, 9.1464023e+03, 6.],
-                           [9.1464023e+03, 3.7885645e+03, 6.]],
-                          [[9.2387900e+03, 3.8268323e+03, 6.],
-                           [9.3311777e+03, 3.8651006e+03, 6.],
-                           [3.8651003e+03, 9.3311777e+03, 6.],
-                           [3.8268320e+03, 9.2387900e+03, 6.],
-                           [9.2387900e+03, 3.8268323e+03, 6.]]])
+        polyvert, pr = georef.spherical_to_polyvert(
+            np.array([10000.0, 10100.0]), np.array([45.0, 90.0]), 0, (9.0, 48.0)
+        )
+        arr = np.asarray(
+            [
+                [
+                    [3.7885640e03, 9.1464023e03, 6.0],
+                    [3.8268320e03, 9.2387900e03, 6.0],
+                    [9.2387900e03, 3.8268323e03, 6.0],
+                    [9.1464023e03, 3.7885645e03, 6.0],
+                    [3.7885640e03, 9.1464023e03, 6.0],
+                ],
+                [
+                    [3.8268320e03, 9.2387900e03, 6.0],
+                    [3.8651003e03, 9.3311777e03, 6.0],
+                    [9.3311777e03, 3.8651006e03, 6.0],
+                    [9.2387900e03, 3.8268323e03, 6.0],
+                    [3.8268320e03, 9.2387900e03, 6.0],
+                ],
+                [
+                    [9.1464023e03, 3.7885645e03, 6.0],
+                    [9.2387900e03, 3.8268323e03, 6.0],
+                    [3.8268320e03, 9.2387900e03, 6.0],
+                    [3.7885640e03, 9.1464023e03, 6.0],
+                    [9.1464023e03, 3.7885645e03, 6.0],
+                ],
+                [
+                    [9.2387900e03, 3.8268323e03, 6.0],
+                    [9.3311777e03, 3.8651006e03, 6.0],
+                    [3.8651003e03, 9.3311777e03, 6.0],
+                    [3.8268320e03, 9.2387900e03, 6.0],
+                    [9.2387900e03, 3.8268323e03, 6.0],
+                ],
+            ]
+        )
         np.testing.assert_array_almost_equal(polyvert, arr, decimal=3)
 
     def test_spherical_to_centroids(self):
-        r = np.array([10000., 10100.])
-        az = np.array([45., 90.])
-        sitecoords = (9., 48., 0.)
+        r = np.array([10000.0, 10100.0])
+        az = np.array([45.0, 90.0])
+        sitecoords = (9.0, 48.0, 0.0)
         sph = georef.get_default_projection()
-        centroids = georef.spherical_to_centroids(r, az, 0, sitecoords,
-                                                  proj=sph)
-        arr = np.asarray([[[9.09439583, 48.06323717, 6.],
-                           [9.09534571, 48.06387232, 6.]],
-                          [[9.1333325, 47.99992262, 6.],
-                           [9.13467253, 47.99992106, 6.]]])
+        centroids = georef.spherical_to_centroids(r, az, 0, sitecoords, proj=sph)
+        arr = np.asarray(
+            [
+                [[9.09439583, 48.06323717, 6.0], [9.09534571, 48.06387232, 6.0]],
+                [[9.1333325, 47.99992262, 6.0], [9.13467253, 47.99992106, 6.0]],
+            ]
+        )
         np.testing.assert_array_almost_equal(centroids, arr, decimal=3)
 
         centroids, pr = georef.spherical_to_centroids(r, az, 0, sitecoords)
-        arr = np.asarray([[[7.0357090e+03, 7.0357090e+03, 6.],
-                           [7.1064194e+03, 7.1064194e+03, 6.]],
-                          [[9.9499951e+03, 0., 6.],
-                           [1.0049995e+04, 0., 6.]]])
+        arr = np.asarray(
+            [
+                [[7.0357090e03, 7.0357090e03, 6.0], [7.1064194e03, 7.1064194e03, 6.0]],
+                [[9.9499951e03, 0.0, 6.0], [1.0049995e04, 0.0, 6.0]],
+            ]
+        )
         np.testing.assert_array_almost_equal(centroids, arr, decimal=3)
 
     def test_sweep_centroids(self):
-        np.testing.assert_array_equal(georef.sweep_centroids(1, 100., 1, 2.0),
-                                      np.array([[[50., 180., 2.]]]))
+        np.testing.assert_array_equal(
+            georef.sweep_centroids(1, 100.0, 1, 2.0), np.array([[[50.0, 180.0, 2.0]]])
+        )
 
     def test__check_polar_coords(self):
-        r = np.array([50., 100., 150., 200.])
-        az = np.array([0., 45., 90., 135., 180., 225., 270., 315., 360.])
+        r = np.array([50.0, 100.0, 150.0, 200.0])
+        az = np.array([0.0, 45.0, 90.0, 135.0, 180.0, 225.0, 270.0, 315.0, 360.0])
         with self.assertRaises(ValueError):
             georef.polar._check_polar_coords(r, az)
 
-        r = np.array([50., 100., 150., 200.])
-        az = np.array([10., 45., 90., 135., 180., 225., 270., 315.])
+        r = np.array([50.0, 100.0, 150.0, 200.0])
+        az = np.array([10.0, 45.0, 90.0, 135.0, 180.0, 225.0, 270.0, 315.0])
         with self.assertWarns(UserWarning):
             georef.polar._check_polar_coords(r, az)
 
-        r = np.array([0, 50., 100., 150., 200.])
-        az = np.array([0., 45., 90., 135., 180., 225., 270., 315.])
+        r = np.array([0, 50.0, 100.0, 150.0, 200.0])
+        az = np.array([0.0, 45.0, 90.0, 135.0, 180.0, 225.0, 270.0, 315.0])
         with self.assertRaises(ValueError):
             georef.polar._check_polar_coords(r, az)
 
-        r = np.array([50., 100., 100., 150., 200.])
-        az = np.array([0., 45., 90., 135., 180., 225., 270., 315.])
+        r = np.array([50.0, 100.0, 100.0, 150.0, 200.0])
+        az = np.array([0.0, 45.0, 90.0, 135.0, 180.0, 225.0, 270.0, 315.0])
         with self.assertRaises(ValueError):
             georef.polar._check_polar_coords(r, az)
 
-        r = np.array([100., 50., 150., 200.])
-        az = np.array([0., 45., 90., 135., 180., 225., 270., 315.])
+        r = np.array([100.0, 50.0, 150.0, 200.0])
+        az = np.array([0.0, 45.0, 90.0, 135.0, 180.0, 225.0, 270.0, 315.0])
         with self.assertRaises(ValueError):
             georef.polar._check_polar_coords(r, az)
 
-        r = np.array([50., 100., 125., 200.])
-        az = np.array([0., 45., 90., 135., 180., 225., 270., 315.])
+        r = np.array([50.0, 100.0, 125.0, 200.0])
+        az = np.array([0.0, 45.0, 90.0, 135.0, 180.0, 225.0, 270.0, 315.0])
         with self.assertRaises(ValueError):
             georef.polar._check_polar_coords(r, az)
 
-        r = np.array([50., 100., 150., 200.])
-        az = np.array([0., 45., 90., 135., 180., 225., 270., 315., 361.])
+        r = np.array([50.0, 100.0, 150.0, 200.0])
+        az = np.array([0.0, 45.0, 90.0, 135.0, 180.0, 225.0, 270.0, 315.0, 361.0])
         with self.assertRaises(ValueError):
             georef.polar._check_polar_coords(r, az)
 
-        r = np.array([50., 100., 150., 200.])
-        az = np.array([225., 270., 315., 0., 45., 90., 135., 180.])[::-1]
+        r = np.array([50.0, 100.0, 150.0, 200.0])
+        az = np.array([225.0, 270.0, 315.0, 0.0, 45.0, 90.0, 135.0, 180.0])[::-1]
         with self.assertRaises(ValueError):
             georef.polar._check_polar_coords(r, az)
 
     def test__get_range_resolution(self):
-        r = np.array([50.])
+        r = np.array([50.0])
         with self.assertRaises(ValueError):
             georef.polar._get_range_resolution(r)
-        r = np.array([50., 100., 150., 190., 250.])
+        r = np.array([50.0, 100.0, 150.0, 190.0, 250.0])
         with self.assertRaises(ValueError):
             georef.polar._get_range_resolution(r)
 
     def test__get_azimuth_resolution(self):
-        az = np.array([0., 45., 90., 135., 180., 224., 270., 315.])
+        az = np.array([0.0, 45.0, 90.0, 135.0, 180.0, 224.0, 270.0, 315.0])
         with self.assertRaises(ValueError):
             georef.polar._get_azimuth_resolution(az)
 
 
 class ProjectionsTest(unittest.TestCase):
     def setUp(self):
-        wgs84_gdal2 = ('GEOGCS["WGS 84",DATUM["WGS_1984",'
-                       'SPHEROID["WGS 84",6378137,298.257223563,'
-                       'AUTHORITY["EPSG","7030"]],'
-                       'AUTHORITY["EPSG","6326"]],'
-                       'PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],'
-                       'UNIT["degree",0.0174532925199433,'
-                       'AUTHORITY["EPSG","9122"]],'
-                       'AUTHORITY["EPSG","4326"]]')
-        wgs84_gdal3 = ('GEOGCS["WGS 84",DATUM["WGS_1984",'
-                       'SPHEROID["WGS 84",6378137,298.257223563,'
-                       'AUTHORITY["EPSG","7030"]],'
-                       'AUTHORITY["EPSG","6326"]],'
-                       'PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],'
-                       'UNIT["degree",0.0174532925199433,'
-                       'AUTHORITY["EPSG","9122"]],'
-                       'AXIS["Latitude",NORTH],'
-                       'AXIS["Longitude",EAST],'
-                       'AUTHORITY["EPSG","4326"]]')
+        wgs84_gdal2 = (
+            'GEOGCS["WGS 84",DATUM["WGS_1984",'
+            'SPHEROID["WGS 84",6378137,298.257223563,'
+            'AUTHORITY["EPSG","7030"]],'
+            'AUTHORITY["EPSG","6326"]],'
+            'PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],'
+            'UNIT["degree",0.0174532925199433,'
+            'AUTHORITY["EPSG","9122"]],'
+            'AUTHORITY["EPSG","4326"]]'
+        )
+        wgs84_gdal3 = (
+            'GEOGCS["WGS 84",DATUM["WGS_1984",'
+            'SPHEROID["WGS 84",6378137,298.257223563,'
+            'AUTHORITY["EPSG","7030"]],'
+            'AUTHORITY["EPSG","6326"]],'
+            'PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],'
+            'UNIT["degree",0.0174532925199433,'
+            'AUTHORITY["EPSG","9122"]],'
+            'AXIS["Latitude",NORTH],'
+            'AXIS["Longitude",EAST],'
+            'AUTHORITY["EPSG","4326"]]'
+        )
 
-        if gdal.VersionInfo()[0] >= '3':
+        if gdal.VersionInfo()[0] >= "3":
             self.wgs84 = wgs84_gdal3
         else:
             self.wgs84 = wgs84_gdal2
 
     def test_create_osr(self):
         self.maxDiff = None
-        radolan_wkt = ('PROJCS["Radolan projection",'
-                       'GEOGCS["Radolan Coordinate System",'
-                       'DATUM["Radolan Kugel",'
-                       'SPHEROID["Erdkugel",6370040.0,0.0]],'
-                       'PRIMEM["Greenwich",0.0,AUTHORITY["EPSG","8901"]],'
-                       'UNIT["degree",0.017453292519943295],'
-                       'AXIS["Longitude",EAST],'
-                       'AXIS["Latitude",NORTH]],'
-                       'PROJECTION["polar_stereographic"],'
-                       'PARAMETER["central_meridian",10.0],'
-                       'PARAMETER["latitude_of_origin",90.0],'
-                       'PARAMETER["scale_factor",{0:8.10f}],'
-                       'PARAMETER["false_easting",0.0],'
-                       'PARAMETER["false_northing",0.0],'
-                       'UNIT["m*1000.0",1000.0],'
-                       'AXIS["X",EAST],'
-                       'AXIS["Y",NORTH]]')
+        radolan_wkt = (
+            'PROJCS["Radolan projection",'
+            'GEOGCS["Radolan Coordinate System",'
+            'DATUM["Radolan Kugel",'
+            'SPHEROID["Erdkugel",6370040.0,0.0]],'
+            'PRIMEM["Greenwich",0.0,AUTHORITY["EPSG","8901"]],'
+            'UNIT["degree",0.017453292519943295],'
+            'AXIS["Longitude",EAST],'
+            'AXIS["Latitude",NORTH]],'
+            'PROJECTION["polar_stereographic"],'
+            'PARAMETER["central_meridian",10.0],'
+            'PARAMETER["latitude_of_origin",90.0],'
+            'PARAMETER["scale_factor",{0:8.10f}],'
+            'PARAMETER["false_easting",0.0],'
+            'PARAMETER["false_northing",0.0],'
+            'UNIT["m*1000.0",1000.0],'
+            'AXIS["X",EAST],'
+            'AXIS["Y",NORTH]]'
+        )
 
-        radolan_wkt3 = ('PROJCS["Radolan Projection",'
-                        'GEOGCS["Radolan Coordinate System",'
-                        'DATUM["Radolan_Kugel",'
-                        'SPHEROID["Erdkugel",6370040,0]],'
-                        'PRIMEM["Greenwich",0,'
-                        'AUTHORITY["EPSG","8901"]],'
-                        'UNIT["degree",0.0174532925199433,'
-                        'AUTHORITY["EPSG","9122"]]],'
-                        'PROJECTION["Polar_Stereographic"],'
-                        'PARAMETER["latitude_of_origin",90],'
-                        'PARAMETER["central_meridian",10],'
-                        'PARAMETER["scale_factor",{0:8.12f}],'
-                        'PARAMETER["false_easting",0],'
-                        'PARAMETER["false_northing",0],'
-                        'UNIT["kilometre",1000,'
-                        'AUTHORITY["EPSG","9036"]],'
-                        'AXIS["Easting",SOUTH],'
-                        'AXIS["Northing",SOUTH]]')
+        radolan_wkt3 = (
+            'PROJCS["Radolan Projection",'
+            'GEOGCS["Radolan Coordinate System",'
+            'DATUM["Radolan_Kugel",'
+            'SPHEROID["Erdkugel",6370040,0]],'
+            'PRIMEM["Greenwich",0,'
+            'AUTHORITY["EPSG","8901"]],'
+            'UNIT["degree",0.0174532925199433,'
+            'AUTHORITY["EPSG","9122"]]],'
+            'PROJECTION["Polar_Stereographic"],'
+            'PARAMETER["latitude_of_origin",90],'
+            'PARAMETER["central_meridian",10],'
+            'PARAMETER["scale_factor",{0:8.12f}],'
+            'PARAMETER["false_easting",0],'
+            'PARAMETER["false_northing",0],'
+            'UNIT["kilometre",1000,'
+            'AUTHORITY["EPSG","9036"]],'
+            'AXIS["Easting",SOUTH],'
+            'AXIS["Northing",SOUTH]]'
+        )
 
-        scale = (1. + np.sin(np.radians(60.))) / (1. + np.sin(np.radians(90.)))
+        scale = (1.0 + np.sin(np.radians(60.0))) / (1.0 + np.sin(np.radians(90.0)))
 
-        aeqd_wkt = ('PROJCS["unnamed",'
-                    'GEOGCS["WGS 84",'
-                    'DATUM["unknown",'
-                    'SPHEROID["WGS84",6378137,298.257223563]],'
-                    'PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],'
-                    'PROJECTION["Azimuthal_Equidistant"],'
-                    'PARAMETER["latitude_of_center",{0:-f}],'
-                    'PARAMETER["longitude_of_center",{1:-f}],'
-                    'PARAMETER["false_easting",{2:-f}],'
-                    'PARAMETER["false_northing",{3:-f}],'
-                    'UNIT["Meter",1]]')
+        aeqd_wkt = (
+            'PROJCS["unnamed",'
+            'GEOGCS["WGS 84",'
+            'DATUM["unknown",'
+            'SPHEROID["WGS84",6378137,298.257223563]],'
+            'PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],'
+            'PROJECTION["Azimuthal_Equidistant"],'
+            'PARAMETER["latitude_of_center",{0:-f}],'
+            'PARAMETER["longitude_of_center",{1:-f}],'
+            'PARAMETER["false_easting",{2:-f}],'
+            'PARAMETER["false_northing",{3:-f}],'
+            'UNIT["Meter",1]]'
+        )
 
-        aeqd_wkt3 = ('PROJCS["unnamed",'
-                     'GEOGCS["WGS 84",'
-                     'DATUM["unknown",'
-                     'SPHEROID["WGS84",6378137,298.257223563]],'
-                     'PRIMEM["Greenwich",0],'
-                     'UNIT["degree",0.0174532925199433]],'
-                     'PROJECTION["Azimuthal_Equidistant"],'
-                     'PARAMETER["latitude_of_center",{0:d}],'
-                     'PARAMETER["longitude_of_center",{1:d}],'
-                     'PARAMETER["false_easting",{2:d}],'
-                     'PARAMETER["false_northing",{3:d}],'
-                     'UNIT["Meter",1],'
-                     'AXIS["Easting",EAST],'
-                     'AXIS["Northing",NORTH]]')
+        aeqd_wkt3 = (
+            'PROJCS["unnamed",'
+            'GEOGCS["WGS 84",'
+            'DATUM["unknown",'
+            'SPHEROID["WGS84",6378137,298.257223563]],'
+            'PRIMEM["Greenwich",0],'
+            'UNIT["degree",0.0174532925199433]],'
+            'PROJECTION["Azimuthal_Equidistant"],'
+            'PARAMETER["latitude_of_center",{0:d}],'
+            'PARAMETER["longitude_of_center",{1:d}],'
+            'PARAMETER["false_easting",{2:d}],'
+            'PARAMETER["false_northing",{3:d}],'
+            'UNIT["Meter",1],'
+            'AXIS["Easting",EAST],'
+            'AXIS["Northing",NORTH]]'
+        )
 
-        if gdal.VersionInfo()[0] >= '3':
+        if gdal.VersionInfo()[0] >= "3":
             radolan_wkt = radolan_wkt3.format(scale)
             aeqd_wkt = aeqd_wkt3.format(49, 5, 0, 0)
         else:
             radolan_wkt = radolan_wkt.format(scale)
             aeqd_wkt = aeqd_wkt.format(49, 5, 0, 0)
 
-        self.assertEqual(georef.create_osr('dwd-radolan').ExportToWkt(),
-                         radolan_wkt)
+        self.assertEqual(georef.create_osr("dwd-radolan").ExportToWkt(), radolan_wkt)
 
-        self.assertEqual(georef.create_osr('aeqd',
-                                           lon_0=5,
-                                           lat_0=49).ExportToWkt(),
-                         aeqd_wkt)
-        self.assertEqual(georef.create_osr('aeqd',
-                                           lon_0=5,
-                                           lat_0=49,
-                                           x_0=0,
-                                           y_0=0).ExportToWkt(),
-                         aeqd_wkt)
+        self.assertEqual(
+            georef.create_osr("aeqd", lon_0=5, lat_0=49).ExportToWkt(), aeqd_wkt
+        )
+        self.assertEqual(
+            georef.create_osr("aeqd", lon_0=5, lat_0=49, x_0=0, y_0=0).ExportToWkt(),
+            aeqd_wkt,
+        )
         with self.assertRaises(ValueError):
-            georef.create_osr('lambert')
+            georef.create_osr("lambert")
 
     def test_proj4_to_osr(self):
-        projstr = ('+proj=tmerc +lat_0=0 +lon_0=9 +k=1 '
-                   '+x_0=3500000 +y_0=0 +ellps=bessel '
-                   '+towgs84=598.1,73.7,418.2,0.202,0.045,-2.455,6.7 '
-                   '+units=m +no_defs')
+        projstr = (
+            "+proj=tmerc +lat_0=0 +lon_0=9 +k=1 "
+            "+x_0=3500000 +y_0=0 +ellps=bessel "
+            "+towgs84=598.1,73.7,418.2,0.202,0.045,-2.455,6.7 "
+            "+units=m +no_defs"
+        )
 
         srs = georef.proj4_to_osr(projstr)
         p4 = srs.ExportToProj4()
@@ -466,100 +585,124 @@ class ProjectionsTest(unittest.TestCase):
             georef.proj4_to_osr("+proj=lcc1")
 
     def test_get_earth_radius(self):
-        self.assertEqual(georef.get_earth_radius(50.), 6365631.51753728)
+        self.assertEqual(georef.get_earth_radius(50.0), 6365631.51753728)
 
     def test_reproject(self):
         proj_gk = osr.SpatialReference()
         proj_gk.ImportFromEPSG(31466)
         proj_wgs84 = osr.SpatialReference()
         proj_wgs84.ImportFromEPSG(4326)
-        x, y, z = georef.reproject(7., 53., 0., projection_source=proj_wgs84,
-                                   projection_target=proj_gk)
-        lon, lat = georef.reproject(x, y, projection_source=proj_gk,
-                                    projection_target=proj_wgs84)
+        x, y, z = georef.reproject(
+            7.0, 53.0, 0.0, projection_source=proj_wgs84, projection_target=proj_gk
+        )
+        lon, lat = georef.reproject(
+            x, y, projection_source=proj_gk, projection_target=proj_wgs84
+        )
         self.assertAlmostEqual(lon, 7.0)
         self.assertAlmostEqual(lat, 53.0)
 
-        lonlat = georef.reproject(np.stack((x, y), axis=-1),
-                                  projection_source=proj_gk,
-                                  projection_target=proj_wgs84)
+        lonlat = georef.reproject(
+            np.stack((x, y), axis=-1),
+            projection_source=proj_gk,
+            projection_target=proj_wgs84,
+        )
         self.assertAlmostEqual(lonlat[0], 7.0)
         self.assertAlmostEqual(lonlat[1], 53.0)
 
         with self.assertRaises(TypeError):
             georef.reproject(np.stack((x, y, x, y), axis=-1))
 
-        lon, lat, alt = georef.reproject(x, y, z, projection_source=proj_gk,
-                                         projection_target=proj_wgs84)
-        self.assertAlmostEqual(lon, 7., places=5)
-        self.assertAlmostEqual(lat, 53., places=3)
-        self.assertAlmostEqual(alt, 0., places=3)
+        lon, lat, alt = georef.reproject(
+            x, y, z, projection_source=proj_gk, projection_target=proj_wgs84
+        )
+        self.assertAlmostEqual(lon, 7.0, places=5)
+        self.assertAlmostEqual(lat, 53.0, places=3)
+        self.assertAlmostEqual(alt, 0.0, places=3)
 
         with self.assertRaises(TypeError):
             georef.reproject(x, y, x, y)
         with self.assertRaises(TypeError):
             georef.reproject([np.arange(10)], [np.arange(11)])
         with self.assertRaises(TypeError):
-            georef.reproject([np.arange(10)], [np.arange(10)],
-                             [np.arange(11)])
+            georef.reproject([np.arange(10)], [np.arange(10)], [np.arange(11)])
 
     def test_get_default_projection(self):
-        self.assertEqual(georef.get_default_projection().ExportToWkt(),
-                         self.wgs84)
+        self.assertEqual(georef.get_default_projection().ExportToWkt(), self.wgs84)
 
     def test_epsg_to_osr(self):
-        self.assertEqual(georef.epsg_to_osr(4326).ExportToWkt(),
-                         self.wgs84)
+        self.assertEqual(georef.epsg_to_osr(4326).ExportToWkt(), self.wgs84)
 
-        self.assertEqual(georef.epsg_to_osr().ExportToWkt(),
-                         self.wgs84)
+        self.assertEqual(georef.epsg_to_osr().ExportToWkt(), self.wgs84)
 
     def test_wkt_to_osr(self):
-        self.assertTrue(georef.wkt_to_osr(self.wgs84).IsSame(
-            georef.get_default_projection()))
-
         self.assertTrue(
-            georef.wkt_to_osr().IsSame(georef.get_default_projection()))
+            georef.wkt_to_osr(self.wgs84).IsSame(georef.get_default_projection())
+        )
+
+        self.assertTrue(georef.wkt_to_osr().IsSame(georef.get_default_projection()))
 
     def test_get_radar_projection(self):
         sitecoords = [5, 52, 90]
-        georef.get_radar_projection(sitecoords)
+        p0 = georef.get_radar_projection(sitecoords)
+        assert p0.GetName() == "Unknown Azimuthal Equidistant"
+        assert p0.IsProjected()
+        assert p0.IsSameGeogCS(georef.get_default_projection())
+        assert p0.GetNormProjParm("latitude_of_center") == sitecoords[1]
+        assert p0.GetNormProjParm("longitude_of_center") == sitecoords[0]
 
     def test_get_earth_projection(self):
-        georef.get_earth_projection()
-        georef.get_earth_projection(geoid=True)
-        georef.get_earth_projection(sphere=True)
+        georef.get_earth_projection("ellipsoid")
+        georef.get_earth_projection("geoid")
+        georef.get_earth_projection("sphere")
 
     @unittest.skipIf(sys.platform.startswith("win"), "known break on windows")
     def test_geoid_to_ellipsoid(self):
-        coords = np.array([[5., 50., 300.], [2, 54, 300], [50, 5, 300]])
-        newcoords = georef.geoid_to_ellipsoid(coords)
+        coords = np.array([[5.0, 50.0, 300.0], [2, 54, 300], [50, 5, 300]])
+        geoid = georef.get_earth_projection("geoid")
+        ellipsoid = georef.get_earth_projection("ellipsoid")
+        newcoords = georef.reproject(
+            coords, projection_source=geoid, projection_target=ellipsoid
+        )
         assert np.any(np.not_equal(coords[..., 2], newcoords[..., 2]))
 
-        newcoords = georef.ellipsoid_to_geoid(newcoords)
+        newcoords = georef.reproject(
+            newcoords, projection_source=ellipsoid, projection_target=geoid
+        )
         np.testing.assert_allclose(coords, newcoords)
 
     def test_get_extent(self):
-        arr = np.asarray([[[9.05084865, 48.08224715, 6.],
-                           [9.05136309, 48.0830778, 6.],
-                           [9.1238846, 48.03435008, 6.],
-                           [9.12264494, 48.03400725, 6.],
-                           [9.05084865, 48.08224715, 6.]],
-                          [[9.05136309, 48.0830778, 6.],
-                           [9.05187756, 48.08390846, 6.],
-                           [9.12512428, 48.03469291, 6.],
-                           [9.1238846, 48.03435008, 6.],
-                           [9.05136309, 48.0830778, 6.]],
-                          [[9.12264494, 48.03400725, 6.],
-                           [9.1238846, 48.03435008, 6.],
-                           [9.05136309, 48.0830778, 6.],
-                           [9.05084865, 48.08224715, 6.],
-                           [9.12264494, 48.03400725, 6.]],
-                          [[9.1238846, 48.03435008, 6.],
-                           [9.12512428, 48.03469291, 6.],
-                           [9.05187756, 48.08390846, 6.],
-                           [9.05136309, 48.0830778, 6.],
-                           [9.1238846, 48.03435008, 6.]]])
+        arr = np.asarray(
+            [
+                [
+                    [9.05084865, 48.08224715, 6.0],
+                    [9.05136309, 48.0830778, 6.0],
+                    [9.1238846, 48.03435008, 6.0],
+                    [9.12264494, 48.03400725, 6.0],
+                    [9.05084865, 48.08224715, 6.0],
+                ],
+                [
+                    [9.05136309, 48.0830778, 6.0],
+                    [9.05187756, 48.08390846, 6.0],
+                    [9.12512428, 48.03469291, 6.0],
+                    [9.1238846, 48.03435008, 6.0],
+                    [9.05136309, 48.0830778, 6.0],
+                ],
+                [
+                    [9.12264494, 48.03400725, 6.0],
+                    [9.1238846, 48.03435008, 6.0],
+                    [9.05136309, 48.0830778, 6.0],
+                    [9.05084865, 48.08224715, 6.0],
+                    [9.12264494, 48.03400725, 6.0],
+                ],
+                [
+                    [9.1238846, 48.03435008, 6.0],
+                    [9.12512428, 48.03469291, 6.0],
+                    [9.05187756, 48.08390846, 6.0],
+                    [9.05136309, 48.0830778, 6.0],
+                    [9.1238846, 48.03435008, 6.0],
+                ],
+            ]
+        )
 
         ref = [9.05084865, 9.12512428, 48.03400725, 48.08390846]
         extent = georef.get_extent(arr)
@@ -576,28 +719,29 @@ class PixMapTest(unittest.TestCase):
 
 class GdalTests(unittest.TestCase):
     def setUp(self):
-        filename = 'geo/bonn_new.tif'
+        filename = "geo/bonn_new.tif"
         geofile = util.get_wradlib_data_file(filename)
         self.ds = wradlib.io.open_raster(geofile)
-        (self.data,
-         self.coords,
-         self.proj) = georef.extract_raster_dataset(self.ds)
+        (self.data, self.coords, self.proj) = georef.extract_raster_dataset(self.ds)
 
-        filename = 'hdf5/belgium.comp.hdf'
+        filename = "hdf5/belgium.comp.hdf"
         geofile = util.get_wradlib_data_file(filename)
         self.ds2 = wradlib.io.open_raster(geofile)
-        (self.data2,
-         self.coords2,
-         self.proj2) = georef.extract_raster_dataset(self.ds, mode="edge")
-        self.corner_gdalinfo = np.array([[3e5, 1e6],
-                                         [3e5, 3e5],
-                                         [1e6, 3e5],
-                                         [1e6, 1e6]])
+        (self.data2, self.coords2, self.proj2) = georef.extract_raster_dataset(
+            self.ds, mode="edge"
+        )
+        self.corner_gdalinfo = np.array(
+            [[3e5, 1e6], [3e5, 3e5], [1e6, 3e5], [1e6, 1e6]]
+        )
 
-        self.corner_geo_gdalinfo = np.array([[-0.925465, 53.6928559],
-                                             [-0.266697, 47.4167912],
-                                             [9.0028805, 47.4160381],
-                                             [9.6641599, 53.6919969]])
+        self.corner_geo_gdalinfo = np.array(
+            [
+                [-0.925465, 53.6928559],
+                [-0.266697, 47.4167912],
+                [9.0028805, 47.4160381],
+                [9.6641599, 53.6919969],
+            ]
+        )
 
     def test_read_gdal_coordinates(self):
         center_coords = georef.read_gdal_coordinates(self.ds)
@@ -611,43 +755,45 @@ class GdalTests(unittest.TestCase):
 
     def test_read_gdal_values(self):
         georef.read_gdal_values(self.ds)
-        georef.read_gdal_values(self.ds, nodata=9999.)
+        georef.read_gdal_values(self.ds, nodata=9999.0)
 
     def test_reproject_raster_dataset(self):
-        georef.reproject_raster_dataset(self.ds, spacing=0.005,
-                                        resample=gdal.GRA_Bilinear,
-                                        align=True)
-        georef.reproject_raster_dataset(self.ds, size=(1000, 1000),
-                                        resample=gdal.GRA_Bilinear,
-                                        align=True)
+        georef.reproject_raster_dataset(
+            self.ds, spacing=0.005, resample=gdal.GRA_Bilinear, align=True
+        )
+        georef.reproject_raster_dataset(
+            self.ds, size=(1000, 1000), resample=gdal.GRA_Bilinear, align=True
+        )
         with self.assertRaises(NameError):
             georef.reproject_raster_dataset(self.ds)
         dst = georef.epsg_to_osr(25832)
-        georef.reproject_raster_dataset(self.ds, spacing=100.,
-                                        resample=gdal.GRA_Bilinear,
-                                        align=True, projection_target=dst)
+        georef.reproject_raster_dataset(
+            self.ds,
+            spacing=100.0,
+            resample=gdal.GRA_Bilinear,
+            align=True,
+            projection_target=dst,
+        )
 
     def test_create_raster_dataset(self):
-        data, coords = georef.set_raster_origin(self.data.copy(),
-                                                self.coords.copy(),
-                                                'upper')
-        ds = georef.create_raster_dataset(data,
-                                          coords,
-                                          projection=self.proj,
-                                          nodata=-32768)
+        data, coords = georef.set_raster_origin(
+            self.data.copy(), self.coords.copy(), "upper"
+        )
+        ds = georef.create_raster_dataset(
+            data, coords, projection=self.proj, nodata=-32768
+        )
 
         data, coords, proj = georef.extract_raster_dataset(ds)
         np.testing.assert_array_equal(data, self.data)
         np.testing.assert_array_almost_equal(coords, self.coords)
         self.assertEqual(proj.ExportToWkt(), self.proj.ExportToWkt())
 
-        data, coords = georef.set_raster_origin(self.data2.copy(),
-                                                self.coords2.copy(),
-                                                'upper')
-        ds = georef.create_raster_dataset(data,
-                                          coords,
-                                          projection=self.proj,
-                                          nodata=-32768)
+        data, coords = georef.set_raster_origin(
+            self.data2.copy(), self.coords2.copy(), "upper"
+        )
+        ds = georef.create_raster_dataset(
+            data, coords, projection=self.proj, nodata=-32768
+        )
 
         data, coords, proj = georef.extract_raster_dataset(ds, mode="edge")
         np.testing.assert_array_equal(data, self.data2)
@@ -656,24 +802,21 @@ class GdalTests(unittest.TestCase):
 
     def test_set_raster_origin(self):
         testfunc = georef.set_raster_origin
-        data, coords = testfunc(self.data.copy(),
-                                self.coords.copy(), 'upper')
+        data, coords = testfunc(self.data.copy(), self.coords.copy(), "upper")
         np.testing.assert_array_equal(data, self.data)
         np.testing.assert_array_equal(coords, self.coords)
-        data, coords = testfunc(self.data.copy(),
-                                self.coords.copy(), 'lower')
+        data, coords = testfunc(self.data.copy(), self.coords.copy(), "lower")
         np.testing.assert_array_equal(data, np.flip(self.data, axis=-2))
         np.testing.assert_array_equal(coords, np.flip(self.coords, axis=-3))
 
-        data, coords = testfunc(self.data.copy()[:, :3600],
-                                self.coords.copy()[:3600, :3600],
-                                'lower')
-        np.testing.assert_array_equal(data, np.flip(self.data[:, :3600],
-                                                    axis=-2))
+        data, coords = testfunc(
+            self.data.copy()[:, :3600], self.coords.copy()[:3600, :3600], "lower"
+        )
+        np.testing.assert_array_equal(data, np.flip(self.data[:, :3600], axis=-2))
 
-        np.testing.assert_array_equal(coords,
-                                      np.flip(self.coords[:3600, :3600],
-                                              axis=-3))
+        np.testing.assert_array_equal(
+            coords, np.flip(self.coords[:3600, :3600], axis=-3)
+        )
 
     def test_extract_raster_dataset(self):
         ds = self.ds
@@ -684,7 +827,7 @@ class GdalTests(unittest.TestCase):
 
     @unittest.skipIf(sys.platform.startswith("win"), "known break on windows")
     def test_get_raster_elevation(self):
-        georef.get_raster_elevation(self.ds, download={'region': 'Eurasia'})
+        georef.get_raster_elevation(self.ds, download={"region": "Eurasia"})
 
     def test_get_raster_extent(self):
 
@@ -697,8 +840,7 @@ class GdalTests(unittest.TestCase):
         np.testing.assert_array_almost_equal(extent, window_geo)
 
         extent = georef.get_raster_extent(self.ds2, window=False)
-        np.testing.assert_array_almost_equal(extent, self.corner_gdalinfo,
-                                             decimal=3)
+        np.testing.assert_array_almost_equal(extent, self.corner_gdalinfo, decimal=3)
 
         extent = georef.get_raster_extent(self.ds2, geo=True, window=False)
         np.testing.assert_array_almost_equal(extent, self.corner_geo_gdalinfo)
@@ -706,8 +848,9 @@ class GdalTests(unittest.TestCase):
     @unittest.skipIf(sys.platform.startswith("win"), "known break on windows")
     def test_merge_raster_datasets(self):
         download = {"region": "Eurasia"}
-        datasets = wradlib.io.dem.get_srtm([3, 4, 47, 48], merge=False,
-                                           download=download)
+        datasets = wradlib.io.dem.get_srtm(
+            [3, 4, 47, 48], merge=False, download=download
+        )
         georef.merge_raster_datasets(datasets)
 
     def test_raster_to_polyvert(self):
@@ -722,15 +865,16 @@ class GetGridsTest(unittest.TestCase):
     def setUp(self):
         # calculate xy and lonlat grids with georef function
         self.radolan_grid_xy = georef.get_radolan_grid(900, 900, trig=True)
-        self.radolan_grid_ll = georef.get_radolan_grid(900, 900, trig=True,
-                                                       wgs84=True)
+        self.radolan_grid_ll = georef.get_radolan_grid(900, 900, trig=True, wgs84=True)
 
     def test_get_radolan_grid_equality(self):
         # create radolan projection osr object
-        scale = (1. + np.sin(np.radians(60.))) / (1. + np.sin(np.radians(90.)))
-        dwd_string = ('+proj=stere +lat_0=90 +lat_ts=90 +lon_0=10 '
-                      '+k={0:10.8f} +x_0=0 +y_0=0 +a=6370040 +b=6370040 '
-                      '+to_meter=1000 +no_defs'.format(scale))
+        scale = (1.0 + np.sin(np.radians(60.0))) / (1.0 + np.sin(np.radians(90.0)))
+        dwd_string = (
+            "+proj=stere +lat_0=90 +lat_ts=90 +lon_0=10 "
+            "+k={0:10.8f} +x_0=0 +y_0=0 +a=6370040 +b=6370040 "
+            "+to_meter=1000 +no_defs".format(scale)
+        )
         proj_stereo = georef.proj4_to_osr(dwd_string)
 
         # create wgs84 projection osr object
@@ -740,12 +884,16 @@ class GetGridsTest(unittest.TestCase):
         # transform radolan polar stereographic projection to wgs84 and wgs84
         # to polar stereographic
         # using osr transformation routines
-        radolan_grid_ll = georef.reproject(self.radolan_grid_xy,
-                                           projection_source=proj_stereo,
-                                           projection_target=proj_wgs)
-        radolan_grid_xy = georef.reproject(self.radolan_grid_ll,
-                                           projection_source=proj_wgs,
-                                           projection_target=proj_stereo)
+        radolan_grid_ll = georef.reproject(
+            self.radolan_grid_xy,
+            projection_source=proj_stereo,
+            projection_target=proj_wgs,
+        )
+        radolan_grid_xy = georef.reproject(
+            self.radolan_grid_ll,
+            projection_source=proj_wgs,
+            projection_target=proj_stereo,
+        )
 
         # check source and target arrays for equality
         self.assertTrue(np.allclose(radolan_grid_ll, self.radolan_grid_ll))
@@ -760,7 +908,7 @@ class GetGridsTest(unittest.TestCase):
 
     def test_get_radolan_grid_raises(self):
         with self.assertRaises(TypeError):
-            georef.get_radolan_grid('900', '900')
+            georef.get_radolan_grid("900", "900")
         with self.assertRaises(ValueError):
             georef.get_radolan_grid(2000, 2000)
 
@@ -781,69 +929,124 @@ class GetGridsTest(unittest.TestCase):
         xyz = np.array([[1000, 1000, 1000]])
         r, phi, theta = georef.xyz_to_spherical(xyz)
         self.assertAlmostEqual(r[0], 1732.11878135)
-        self.assertAlmostEqual(phi[0], 45.)
+        self.assertAlmostEqual(phi[0], 45.0)
         self.assertAlmostEqual(theta[0], 35.25802956)
 
 
 class SatelliteTest(unittest.TestCase):
     def setUp(self):
-        f = 'gpm/2A-CS-151E24S154E30S.GPM.Ku.V7-20170308.20141206-S095002-E095137.004383.V05A.HDF5'  # noqa
+        f = "gpm/2A-CS-151E24S154E30S.GPM.Ku.V7-20170308.20141206-S095002-E095137.004383.V05A.HDF5"  # noqa
         gpm_file = util.get_wradlib_data_file(f)
         pr_data = wradlib.io.read_generic_hdf5(gpm_file)
-        pr_lon = pr_data['NS/Longitude']['data']
-        pr_lat = pr_data['NS/Latitude']['data']
-        zenith = pr_data['NS/PRE/localZenithAngle']['data']
+        pr_lon = pr_data["NS/Longitude"]["data"]
+        pr_lat = pr_data["NS/Latitude"]["data"]
+        zenith = pr_data["NS/PRE/localZenithAngle"]["data"]
         wgs84 = georef.get_default_projection()
         a = wgs84.GetSemiMajor()
         b = wgs84.GetSemiMinor()
-        rad = georef.proj4_to_osr(('+proj=aeqd +lon_0={lon:f} ' +
-                                   '+lat_0={lat:f} +a={a:f} +b={b:f}' +
-                                   '').format(lon=pr_lon[68, 0],
-                                              lat=pr_lat[68, 0],
-                                              a=a, b=b))
-        pr_x, pr_y = georef.reproject(pr_lon, pr_lat,
-                                      projection_source=wgs84,
-                                      projection_target=rad)
-        self.re = georef.get_earth_radius(pr_lat[68, 0], wgs84) * 4. / 3.
+        rad = georef.proj4_to_osr(
+            (
+                "+proj=aeqd +lon_0={lon:f} " + "+lat_0={lat:f} +a={a:f} +b={b:f}" + ""
+            ).format(lon=pr_lon[68, 0], lat=pr_lat[68, 0], a=a, b=b)
+        )
+        pr_x, pr_y = georef.reproject(
+            pr_lon, pr_lat, projection_source=wgs84, projection_target=rad
+        )
+        self.re = georef.get_earth_radius(pr_lat[68, 0], wgs84) * 4.0 / 3.0
         self.pr_xy = np.dstack((pr_x, pr_y))
         self.alpha = zenith
-        self.zt = 407000.
-        self.dr = 125.
+        self.zt = 407000.0
+        self.dr = 125.0
         self.bw_pr = 0.71
         self.nbin = 176
         self.nray = pr_lon.shape[1]
 
-        self.pr_out = np.array([[[[-58533.78453556, 124660.60390174],
-                                  [-58501.33048429, 124677.58873852]],
-                                 [[-53702.13393133, 127251.83656509],
-                                  [-53670.98686161, 127268.11882882]]],
-                                [[[-56444.00788528, 120205.5374491],
-                                  [-56411.55421163, 120222.52300741]],
-                                 [[-51612.2360682, 122796.78620764],
-                                  [-51581.08938314, 122813.06920719]]]])
-        self.r_out = np.array([0., 125., 250., 375., 500., 625., 750., 875.,
-                               1000., 1125.])
-        self.z_out = np.array([0., 119.51255112, 239.02510224, 358.53765337,
-                               478.05020449, 597.56275561, 717.07530673,
-                               836.58785786, 956.10040898, 1075.6129601])
+        self.pr_out = np.array(
+            [
+                [
+                    [
+                        [-58533.78453556, 124660.60390174],
+                        [-58501.33048429, 124677.58873852],
+                    ],
+                    [
+                        [-53702.13393133, 127251.83656509],
+                        [-53670.98686161, 127268.11882882],
+                    ],
+                ],
+                [
+                    [
+                        [-56444.00788528, 120205.5374491],
+                        [-56411.55421163, 120222.52300741],
+                    ],
+                    [
+                        [-51612.2360682, 122796.78620764],
+                        [-51581.08938314, 122813.06920719],
+                    ],
+                ],
+            ]
+        )
+        self.r_out = np.array(
+            [0.0, 125.0, 250.0, 375.0, 500.0, 625.0, 750.0, 875.0, 1000.0, 1125.0]
+        )
+        self.z_out = np.array(
+            [
+                0.0,
+                119.51255112,
+                239.02510224,
+                358.53765337,
+                478.05020449,
+                597.56275561,
+                717.07530673,
+                836.58785786,
+                956.10040898,
+                1075.6129601,
+            ]
+        )
 
     def test_correct_parallax(self):
-        xy, r, z = georef.correct_parallax(self.pr_xy, self.nbin,
-                                           self.dr, self.alpha)
+        xy, r, z = georef.correct_parallax(self.pr_xy, self.nbin, self.dr, self.alpha)
         self.xyz = np.concatenate((xy, z[..., np.newaxis]), axis=-1)
-        pr_out = np.array([[[[-16582.50734831, 35678.47219358],
-                             [-16547.94607589, 35696.40777009]],
-                            [[-11742.02016667, 38252.32622057],
-                             [-11708.84553319, 38269.52268457]]],
-                           [[[-14508.62005182, 31215.98689653],
-                             [-14474.05905935, 31233.92329553]],
-                            [[-9667.99183645, 33789.86576047],
-                             [-9634.81750708, 33807.06305397]]]])
-        r_out = np.array([0., 125., 250., 375., 500., 625., 750., 875.,
-                          1000., 1125.])
-        z_out = np.array([0., 118.78164113, 237.56328225, 356.34492338,
-                          475.1265645, 593.90820563, 712.68984675,
-                          831.47148788, 950.25312901, 1069.03477013])
+        pr_out = np.array(
+            [
+                [
+                    [
+                        [-16582.50734831, 35678.47219358],
+                        [-16547.94607589, 35696.40777009],
+                    ],
+                    [
+                        [-11742.02016667, 38252.32622057],
+                        [-11708.84553319, 38269.52268457],
+                    ],
+                ],
+                [
+                    [
+                        [-14508.62005182, 31215.98689653],
+                        [-14474.05905935, 31233.92329553],
+                    ],
+                    [
+                        [-9667.99183645, 33789.86576047],
+                        [-9634.81750708, 33807.06305397],
+                    ],
+                ],
+            ]
+        )
+        r_out = np.array(
+            [0.0, 125.0, 250.0, 375.0, 500.0, 625.0, 750.0, 875.0, 1000.0, 1125.0]
+        )
+        z_out = np.array(
+            [
+                0.0,
+                118.78164113,
+                237.56328225,
+                356.34492338,
+                475.1265645,
+                593.90820563,
+                712.68984675,
+                831.47148788,
+                950.25312901,
+                1069.03477013,
+            ]
+        )
 
         np.testing.assert_allclose(xy[60:62, 0:2, 0:2, :], pr_out, rtol=1e-12)
         np.testing.assert_allclose(r[0:10], r_out, rtol=1e-12)
@@ -851,18 +1054,36 @@ class SatelliteTest(unittest.TestCase):
 
     def test_dist_from_orbit(self):
         beta = abs(-17.04 + np.arange(self.nray) * self.bw_pr)
-        xy, r, z = georef.correct_parallax(self.pr_xy, self.nbin,
-                                           self.dr, self.alpha)
-        dists = georef.dist_from_orbit(self.zt, self.alpha, beta, r,
-                                       re=self.re)
-        bd = np.array([426553.58667772, 426553.50342119, 426553.49658156,
-                       426553.51025979, 426553.43461609, 426553.42515894,
-                       426553.46559985, 426553.37020786, 426553.44407286,
-                       426553.42173696])
-        sd = np.array([426553.58667772, 424895.63462839, 423322.25176564,
-                       421825.47714885, 420405.9414294,  419062.44208923,
-                       417796.86827302, 416606.91482435, 415490.82582636,
-                       414444.11587979])
+        xy, r, z = georef.correct_parallax(self.pr_xy, self.nbin, self.dr, self.alpha)
+        dists = georef.dist_from_orbit(self.zt, self.alpha, beta, r, re=self.re)
+        bd = np.array(
+            [
+                426553.58667772,
+                426553.50342119,
+                426553.49658156,
+                426553.51025979,
+                426553.43461609,
+                426553.42515894,
+                426553.46559985,
+                426553.37020786,
+                426553.44407286,
+                426553.42173696,
+            ]
+        )
+        sd = np.array(
+            [
+                426553.58667772,
+                424895.63462839,
+                423322.25176564,
+                421825.47714885,
+                420405.9414294,
+                419062.44208923,
+                417796.86827302,
+                416606.91482435,
+                415490.82582636,
+                414444.11587979,
+            ]
+        )
         np.testing.assert_allclose(dists[0:10, 0, 0], bd, rtol=1e-12)
         np.testing.assert_allclose(dists[0, 0:10, 0], sd, rtol=1e-12)
 
@@ -873,36 +1094,44 @@ class VectorTest(unittest.TestCase):
         self.proj.ImportFromEPSG(31466)
         self.wgs84 = georef.get_default_projection()
 
-        self.npobj = np.array([[2600000., 5630000.], [2600000., 5630100.],
-                               [2600100., 5630100.], [2600100., 5630000.],
-                               [2600000., 5630000.]])
-        self.lonlat = np.array([[7.41779154, 50.79679579],
-                                [7.41781875, 50.79769443],
-                                [7.4192367, 50.79767718],
-                                [7.41920947, 50.79677854],
-                                [7.41779154, 50.79679579]])
+        self.npobj = np.array(
+            [
+                [2600000.0, 5630000.0],
+                [2600000.0, 5630100.0],
+                [2600100.0, 5630100.0],
+                [2600100.0, 5630000.0],
+                [2600000.0, 5630000.0],
+            ]
+        )
+        self.lonlat = np.array(
+            [
+                [7.41779154, 50.79679579],
+                [7.41781875, 50.79769443],
+                [7.4192367, 50.79767718],
+                [7.41920947, 50.79677854],
+                [7.41779154, 50.79679579],
+            ]
+        )
 
-        self.ogrobj = georef.numpy_to_ogr(self.npobj, 'Polygon')
+        self.ogrobj = georef.numpy_to_ogr(self.npobj, "Polygon")
         self.ogrobj.AssignSpatialReference(None)
-        self.projobj = georef.numpy_to_ogr(self.npobj, 'Polygon')
+        self.projobj = georef.numpy_to_ogr(self.npobj, "Polygon")
         self.projobj.AssignSpatialReference(self.proj)
 
-        filename = util.get_wradlib_data_file('shapefiles/agger/'
-                                              'agger_merge.shp')
+        filename = util.get_wradlib_data_file("shapefiles/agger/" "agger_merge.shp")
         self.ds, self.layer = wradlib.io.open_vector(filename)
 
     def test_ogr_create_layer(self):
-        ds = wradlib.io.gdal_create_dataset('Memory', 'test',
-                                            gdal_type=gdal.OF_VECTOR)
+        ds = wradlib.io.gdal_create_dataset("Memory", "test", gdal_type=gdal.OF_VECTOR)
         with self.assertRaises(TypeError):
-            georef.ogr_create_layer(ds, 'test')
-        lyr = georef.ogr_create_layer(ds, 'test', geom_type=ogr.wkbPoint,
-                                          fields=[('test', ogr.OFTReal)])
+            georef.ogr_create_layer(ds, "test")
+        lyr = georef.ogr_create_layer(
+            ds, "test", geom_type=ogr.wkbPoint, fields=[("test", ogr.OFTReal)]
+        )
         self.assertTrue(isinstance(lyr, ogr.Layer))
 
     def test_ogr_to_numpy(self):
-        self.assertTrue(
-            np.allclose(georef.ogr_to_numpy(self.ogrobj), self.npobj))
+        self.assertTrue(np.allclose(georef.ogr_to_numpy(self.ogrobj), self.npobj))
 
     def test_get_vector_points(self):
         # this also tests equality with `ogr_to_numpy`
@@ -919,7 +1148,7 @@ class VectorTest(unittest.TestCase):
     def test_get_vector_coordinates(self):
         # this also tests equality with `ogr_to_numpy`
 
-        x, attrs = georef.get_vector_coordinates(self.layer, key='FID')
+        x, attrs = georef.get_vector_coordinates(self.layer, key="FID")
         self.assertEqual(attrs, list(range(13)))
 
         x, attrs = georef.get_vector_coordinates(self.layer)
@@ -935,13 +1164,12 @@ class VectorTest(unittest.TestCase):
             np.testing.assert_allclose(x1, y1)
 
         self.layer.ResetReading()
-        x, attrs = georef.get_vector_coordinates(self.layer,
-                                                 source_srs=self.proj,
-                                                 dest_srs=self.wgs84)
+        x, attrs = georef.get_vector_coordinates(
+            self.layer, source_srs=self.proj, dest_srs=self.wgs84
+        )
 
         self.layer.ResetReading()
-        x, attrs = georef.get_vector_coordinates(self.layer,
-                                                 dest_srs=self.wgs84)
+        x, attrs = georef.get_vector_coordinates(self.layer, dest_srs=self.wgs84)
 
     def test_transform_geometry(self):
         geom = georef.transform_geometry(self.projobj, dest_srs=self.wgs84)
@@ -953,35 +1181,33 @@ class VectorTest(unittest.TestCase):
             georef.transform_geometry(self.ogrobj, dest_srs=self.wgs84)
 
     def test_ogr_copy_layer(self):
-        ds = wradlib.io.gdal_create_dataset('Memory', 'test',
-                                            gdal_type=gdal.OF_VECTOR)
+        ds = wradlib.io.gdal_create_dataset("Memory", "test", gdal_type=gdal.OF_VECTOR)
         georef.ogr_copy_layer(self.ds, 0, ds)
         self.assertTrue(isinstance(ds.GetLayer(), ogr.Layer))
 
     def test_ogr_copy_layer_by_name(self):
-        ds = wradlib.io.gdal_create_dataset('Memory', 'test',
-                                            gdal_type=gdal.OF_VECTOR)
-        georef.ogr_copy_layer_by_name(self.ds, 'agger_merge', ds)
+        ds = wradlib.io.gdal_create_dataset("Memory", "test", gdal_type=gdal.OF_VECTOR)
+        georef.ogr_copy_layer_by_name(self.ds, "agger_merge", ds)
         self.assertTrue(isinstance(ds.GetLayer(), ogr.Layer))
         with self.assertRaises(ValueError):
-            georef.ogr_copy_layer_by_name(self.ds, 'agger_merge1', ds)
+            georef.ogr_copy_layer_by_name(self.ds, "agger_merge1", ds)
 
     def test_ogr_add_feature(self):
-        ds = wradlib.io.gdal_create_dataset('Memory', 'test',
-                                            gdal_type=gdal.OF_VECTOR)
-        georef.ogr_create_layer(ds, 'test', geom_type=ogr.wkbPoint,
-                                fields=[('index', ogr.OFTReal)])
+        ds = wradlib.io.gdal_create_dataset("Memory", "test", gdal_type=gdal.OF_VECTOR)
+        georef.ogr_create_layer(
+            ds, "test", geom_type=ogr.wkbPoint, fields=[("index", ogr.OFTReal)]
+        )
 
         point = np.array([1198054.34, 648493.09])
         parr = np.array([point, point, point])
         georef.ogr_add_feature(ds, parr)
-        georef.ogr_add_feature(ds, parr, name='test')
+        georef.ogr_add_feature(ds, parr, name="test")
 
     def test_ogr_add_geometry(self):
-        ds = wradlib.io.gdal_create_dataset('Memory', 'test',
-                                            gdal_type=gdal.OF_VECTOR)
-        lyr = georef.ogr_create_layer(ds, 'test', geom_type=ogr.wkbPoint,
-                                      fields=[('test', ogr.OFTReal)])
+        ds = wradlib.io.gdal_create_dataset("Memory", "test", gdal_type=gdal.OF_VECTOR)
+        lyr = georef.ogr_create_layer(
+            ds, "test", geom_type=ogr.wkbPoint, fields=[("test", ogr.OFTReal)]
+        )
         point = ogr.Geometry(ogr.wkbPoint)
         point.AddPoint(1198054.34, 648493.09)
         georef.ogr_add_geometry(lyr, point, [42.42])
@@ -1017,12 +1243,16 @@ class VectorTest(unittest.TestCase):
 
         arr = georef.ogr_geocol_to_numpy(geomcol)[..., 0:2]
 
-        res = np.array([[1179091.1646903288, 712782.8838459781],
-                        [1161053.0218226474, 667456.2684348812],
-                        [1214704.933941905, 641092.8288590391],
-                        [1228580.428455506, 682719.3123998424],
-                        [1218405.0658121984, 721108.1805541387],
-                        [1179091.1646903288, 712782.8838459781]])
+        res = np.array(
+            [
+                [1179091.1646903288, 712782.8838459781],
+                [1161053.0218226474, 667456.2684348812],
+                [1214704.933941905, 641092.8288590391],
+                [1228580.428455506, 682719.3123998424],
+                [1218405.0658121984, 721108.1805541387],
+                [1179091.1646903288, 712782.8838459781],
+            ]
+        )
 
         np.testing.assert_allclose(arr, res)
 
@@ -1037,13 +1267,15 @@ class VectorTest(unittest.TestCase):
 class XarrayTest(unittest.TestCase):
     def setUp(self):
         func = georef.create_xarray_dataarray
-        self.da = func(np.random.rand(360, 1000),
-                       r=np.arange(0., 100000., 100.),
-                       phi=np.arange(0., 360.),
-                       theta=np.ones(360) * 1.0,
-                       site=(9., 48., 100.),
-                       proj=True,
-                       sweep_mode='azimuth_surveillance')
+        self.da = func(
+            np.random.rand(360, 1000),
+            r=np.arange(0.0, 100000.0, 100.0),
+            phi=np.arange(0.0, 360.0),
+            theta=np.ones(360) * 1.0,
+            site=(9.0, 48.0, 100.0),
+            proj=True,
+            sweep_mode="azimuth_surveillance",
+        )
         self.da = georef.georeference_dataset(self.da)
 
     def test_create_xarray_dataarray(self):
@@ -1058,10 +1290,10 @@ class XarrayTest(unittest.TestCase):
 
     def test_georeference_dataset(self):
         src_da = self.da.copy()
-        src_da.drop(['x', 'y', 'z', 'gr', 'rays', 'bins'])
+        src_da.drop(["x", "y", "z", "gr", "rays", "bins"])
         da = georef.georeference_dataset(src_da)
         xr.testing.assert_equal(self.da, da)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -5,59 +5,67 @@ import datetime
 import gzip
 import io as sio
 import os
-import sys
 import subprocess
+import sys
 import tempfile
 import unittest
 import zlib
 
 import deprecation
 import numpy as np
+import pytest
 import xarray as xr
-
 from wradlib import georef, io, util, zonalstats
 
 
-class DXTest(unittest.TestCase):
+class TestDX:
     # testing functions related to read_dx
     def test__get_timestamp_from_filename(self):
-        filename = 'raa00-dx_10488-200608050000-drs---bin'
-        self.assertEqual(io.radolan._get_timestamp_from_filename(filename),
-                         datetime.datetime(2006, 8, 5, 0))
-        filename = 'raa00-dx_10488-0608050000-drs---bin'
-        self.assertEqual(io.radolan._get_timestamp_from_filename(filename),
-                         datetime.datetime(2006, 8, 5, 0))
+        filename = "raa00-dx_10488-200608050000-drs---bin"
+        assert io.radolan._get_timestamp_from_filename(filename) == datetime.datetime(
+            2006, 8, 5, 0
+        )
+        filename = "raa00-dx_10488-0608050000-drs---bin"
+        assert io.radolan._get_timestamp_from_filename(filename) == datetime.datetime(
+            2006, 8, 5, 0
+        )
 
     def test_get_dx_timestamp(self):
-        filename = 'raa00-dx_10488-200608050000-drs---bin'
-        self.assertEqual(io.radolan.get_dx_timestamp(filename).__str__(),
-                         '2006-08-05 00:00:00+00:00')
-        filename = 'raa00-dx_10488-0608050000-drs---bin'
-        self.assertEqual(io.radolan.get_dx_timestamp(filename).__str__(),
-                         '2006-08-05 00:00:00+00:00')
+        filename = "raa00-dx_10488-200608050000-drs---bin"
+        assert (
+            io.radolan.get_dx_timestamp(filename).__str__()
+            == "2006-08-05 00:00:00+00:00"
+        )
+        filename = "raa00-dx_10488-0608050000-drs---bin"
+        assert (
+            io.radolan.get_dx_timestamp(filename).__str__()
+            == "2006-08-05 00:00:00+00:00"
+        )
 
     def test_parse_dx_header(self):
-        header = (b'DX021655109080608BY54213VS 2CO0CD2CS0EP0.30.30.40.50.'
-                  b'50.40.40.4MS999~ 54( 120,  46) 43-31 44 44 50 50 54 52 '
-                  b'52 42 39 36  ~ 53(  77,  39) 34-31 32 44 39 48 53 44 45 '
-                  b'35 28 28  ~ 53(  98,  88)-31-31-31 53 53 52 53 53 53 32-31'
-                  b' 18  ~ 57(  53,  25)-31-31 41 52 57 54 52 45 42 34 20 20  '
-                  b'~ 55(  37,  38)-31-31 55 48 43 39 50 51 42 15 15  5  ~ '
-                  b'56( 124,  19)-31 56 56 56 52 53 50 50 41 44 27 28  ~ '
-                  b'47(  62,  40)-31-31 46 42 43 40 47 41 34 27 16 10  ~ '
-                  b'46( 112,  62)-31-31 30 33 44 46 46 46 46 33 38 23  ~ '
-                  b'44( 100, -54)-31-31 41 41 38 44 43 43 28 35 30  6  ~ '
-                  b'47( 104,  75)-31-31 45 47 38 41 41 30 30 15 15  8  ^ '
-                  b'58( 104, -56) 58 58 58 58 53 37 37  9 15-31-31-31  ^ '
-                  b'58( 123,  16) 56-31 58 58 46 52 49 35 44 14 32  0  ^ '
-                  b'57(  39,  38)-31 55 53 57 55 27 29 18 11  1  1-31  ^ '
-                  b'54( 100,  85)-31-31 54 54 46 50-31-31 17-31-31-31  ^ '
-                  b'53(  71,  39)-31-31 46 53 52 34 34 40 32 32 23  0  ^ '
-                  b'53( 118,  49)-31-31 51 51 53 52 48 42 39 29 24-31  ` '
-                  b'28(  90,  43)-31-31 27 27 28 27 27 19 24 19  9  9  ` '
-                  b'42( 114,  53)-31-31 36 36 40 42 40 40 34 34 37 30  ` '
-                  b'54(  51,  27)-31-31 49 49 54 51 45 39 40 34..')
-        head = ''
+        header = (
+            b"DX021655109080608BY54213VS 2CO0CD2CS0EP0.30.30.40.50."
+            b"50.40.40.4MS999~ 54( 120,  46) 43-31 44 44 50 50 54 52 "
+            b"52 42 39 36  ~ 53(  77,  39) 34-31 32 44 39 48 53 44 45 "
+            b"35 28 28  ~ 53(  98,  88)-31-31-31 53 53 52 53 53 53 32-31"
+            b" 18  ~ 57(  53,  25)-31-31 41 52 57 54 52 45 42 34 20 20  "
+            b"~ 55(  37,  38)-31-31 55 48 43 39 50 51 42 15 15  5  ~ "
+            b"56( 124,  19)-31 56 56 56 52 53 50 50 41 44 27 28  ~ "
+            b"47(  62,  40)-31-31 46 42 43 40 47 41 34 27 16 10  ~ "
+            b"46( 112,  62)-31-31 30 33 44 46 46 46 46 33 38 23  ~ "
+            b"44( 100, -54)-31-31 41 41 38 44 43 43 28 35 30  6  ~ "
+            b"47( 104,  75)-31-31 45 47 38 41 41 30 30 15 15  8  ^ "
+            b"58( 104, -56) 58 58 58 58 53 37 37  9 15-31-31-31  ^ "
+            b"58( 123,  16) 56-31 58 58 46 52 49 35 44 14 32  0  ^ "
+            b"57(  39,  38)-31 55 53 57 55 27 29 18 11  1  1-31  ^ "
+            b"54( 100,  85)-31-31 54 54 46 50-31-31 17-31-31-31  ^ "
+            b"53(  71,  39)-31-31 46 53 52 34 34 40 32 32 23  0  ^ "
+            b"53( 118,  49)-31-31 51 51 53 52 48 42 39 29 24-31  ` "
+            b"28(  90,  43)-31-31 27 27 28 27 27 19 24 19  9  9  ` "
+            b"42( 114,  53)-31-31 36 36 40 42 40 40 34 34 37 30  ` "
+            b"54(  51,  27)-31-31 49 49 54 51 45 39 40 34.."
+        )
+        head = ""
         for c in sio.BytesIO(header):
             head += str(c.decode())
         io.radolan.parse_dx_header(head)
@@ -66,31 +74,45 @@ class DXTest(unittest.TestCase):
         pass
 
     def test_read_dx(self):
-        filename = 'dx/raa00-dx_10908-0806021655-fbg---bin.gz'
+        filename = "dx/raa00-dx_10908-0806021655-fbg---bin.gz"
         dxfile = util.get_wradlib_data_file(filename)
         data, attrs = io.radolan.read_dx(dxfile)
 
 
-class MiscTest(unittest.TestCase):
+class TestMisc:
     def test_write_polygon_to_text(self):
-        poly1 = [[0., 0., 0., 0.], [0., 1., 0., 1.], [1., 1., 0., 2.],
-                 [0., 0., 0., 0.]]
-        poly2 = [[0., 0., 0., 0.], [0., 1., 0., 1.], [1., 1., 0., 2.],
-                 [0., 0., 0., 0.]]
+        poly1 = [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 1.0],
+            [1.0, 1.0, 0.0, 2.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ]
+        poly2 = [
+            [0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 1.0],
+            [1.0, 1.0, 0.0, 2.0],
+            [0.0, 0.0, 0.0, 0.0],
+        ]
         polygons = [poly1, poly2]
-        res = ['Polygon\n', '0 0\n', '0 0.000000 0.000000 0.000000 0.000000\n',
-               '1 0.000000 1.000000 0.000000 1.000000\n',
-               '2 1.000000 1.000000 0.000000 2.000000\n',
-               '3 0.000000 0.000000 0.000000 0.000000\n', '1 0\n',
-               '0 0.000000 0.000000 0.000000 0.000000\n',
-               '1 0.000000 1.000000 0.000000 1.000000\n',
-               '2 1.000000 1.000000 0.000000 2.000000\n',
-               '3 0.000000 0.000000 0.000000 0.000000\n', 'END\n']
+        res = [
+            "Polygon\n",
+            "0 0\n",
+            "0 0.000000 0.000000 0.000000 0.000000\n",
+            "1 0.000000 1.000000 0.000000 1.000000\n",
+            "2 1.000000 1.000000 0.000000 2.000000\n",
+            "3 0.000000 0.000000 0.000000 0.000000\n",
+            "1 0\n",
+            "0 0.000000 0.000000 0.000000 0.000000\n",
+            "1 0.000000 1.000000 0.000000 1.000000\n",
+            "2 1.000000 1.000000 0.000000 2.000000\n",
+            "3 0.000000 0.000000 0.000000 0.000000\n",
+            "END\n",
+        ]
         tmp = tempfile.NamedTemporaryFile()
         name = tmp.name
         tmp.close()
         io.misc.write_polygon_to_text(name, polygons)
-        self.assertEqual(open(name, 'r').readlines(), res)
+        assert open(name, "r").readlines() == res
 
     def test_pickle(self):
         arr = np.zeros((124, 248), dtype=np.int16)
@@ -99,128 +121,173 @@ class MiscTest(unittest.TestCase):
         tmp.close()
         io.misc.to_pickle(name, arr)
         res = io.misc.from_pickle(name)
-        self.assertTrue(np.allclose(arr, res))
+        np.testing.assert_allclose(arr, res)
 
     def test_get_radiosonde(self):
         date = datetime.datetime(2013, 7, 1, 15, 30)
-        res1 = np.array([(1000., 153., 17.4, 13.5, 13.5, 78., 78., 9.81, 200.,
-                          6., 290.6, 318.5, 292.3)],
-                        dtype=[('PRES', '<f8'), ('HGHT', '<f8'),
-                               ('TEMP', '<f8'), ('DWPT', '<f8'),
-                               ('FRPT', '<f8'), ('RELH', '<f8'),
-                               ('RELI', '<f8'), ('MIXR', '<f8'),
-                               ('DRCT', '<f8'), ('SKNT', '<f8'),
-                               ('THTA', '<f8'), ('THTE', '<f8'),
-                               ('THTV', '<f8')])
+        res1 = np.array(
+            [
+                (
+                    1000.0,
+                    153.0,
+                    17.4,
+                    13.5,
+                    13.5,
+                    78.0,
+                    78.0,
+                    9.81,
+                    200.0,
+                    6.0,
+                    290.6,
+                    318.5,
+                    292.3,
+                )
+            ],
+            dtype=[
+                ("PRES", "<f8"),
+                ("HGHT", "<f8"),
+                ("TEMP", "<f8"),
+                ("DWPT", "<f8"),
+                ("FRPT", "<f8"),
+                ("RELH", "<f8"),
+                ("RELI", "<f8"),
+                ("MIXR", "<f8"),
+                ("DRCT", "<f8"),
+                ("SKNT", "<f8"),
+                ("THTA", "<f8"),
+                ("THTE", "<f8"),
+                ("THTV", "<f8"),
+            ],
+        )
 
-        res2 = {'Station identifier': 'EDZE',
-                'Station number': 10410,
-                'Observation time': datetime.datetime(2013, 7, 1, 12, 0),
-                'Station latitude': 51.4,
-                'Station longitude': 6.96,
-                'Station elevation': 153.0,
-                'Showalter index': 6.1,
-                'Lifted index': 0.58,
-                'LIFT computed using virtual temperature': 0.52,
-                'SWEAT index': 77.7,
-                'K index': 11.7,
-                'Cross totals index': 13.7,
-                'Vertical totals index': 28.7,
-                'Totals totals index': 42.4,
-                'Convective Available Potential Energy': 6.9,
-                'CAPE using virtual temperature': 17.78,
-                'Convective Inhibition': 0.0,
-                'CINS using virtual temperature': 0.0,
-                'Equilibrum Level': 597.86,
-                'Equilibrum Level using virtual temperature': 589.7,
-                'Level of Free Convection': 931.41,
-                'LFCT using virtual temperature': 934.07,
-                'Bulk Richardson Number': 0.24,
-                'Bulk Richardson Number using CAPV': 0.62,
-                'Temp [K] of the Lifted Condensation Level': 284.16,
-                'Pres [hPa] of the Lifted Condensation Level': 934.07,
-                'Mean mixed layer potential temperature': 289.76,
-                'Mean mixed layer mixing ratio': 8.92,
-                '1000 hPa to 500 hPa thickness': 5537.0,
-                'Precipitable water [mm] for entire sounding': 19.02}
+        res2 = {
+            "Station identifier": "EDZE",
+            "Station number": 10410,
+            "Observation time": datetime.datetime(2013, 7, 1, 12, 0),
+            "Station latitude": 51.4,
+            "Station longitude": 6.96,
+            "Station elevation": 153.0,
+            "Showalter index": 6.1,
+            "Lifted index": 0.58,
+            "LIFT computed using virtual temperature": 0.52,
+            "SWEAT index": 77.7,
+            "K index": 11.7,
+            "Cross totals index": 13.7,
+            "Vertical totals index": 28.7,
+            "Totals totals index": 42.4,
+            "Convective Available Potential Energy": 6.9,
+            "CAPE using virtual temperature": 17.78,
+            "Convective Inhibition": 0.0,
+            "CINS using virtual temperature": 0.0,
+            "Equilibrum Level": 597.86,
+            "Equilibrum Level using virtual temperature": 589.7,
+            "Equivalent potential temp [K] of the LCL": 315.05,
+            "Level of Free Convection": 931.41,
+            "LFCT using virtual temperature": 934.07,
+            "Bulk Richardson Number": 0.24,
+            "Bulk Richardson Number using CAPV": 0.62,
+            "Temp [K] of the Lifted Condensation Level": 284.16,
+            "Pres [hPa] of the Lifted Condensation Level": 934.07,
+            "Mean mixed layer potential temperature": 289.76,
+            "Mean mixed layer mixing ratio": 8.92,
+            "1000 hPa to 500 hPa thickness": 5537.0,
+            "Precipitable water [mm] for entire sounding": 19.02,
+        }
 
-        res3 = {'PRES': 'hPa', 'HGHT': 'm', 'TEMP': 'C', 'DWPT': 'C',
-                'FRPT': 'C', 'RELH': '%', 'RELI': '%', 'MIXR': 'g/kg',
-                'DRCT': 'deg', 'SKNT': 'knot', 'THTA': 'K', 'THTE': 'K',
-                'THTV': 'K'}
+        res3 = {
+            "PRES": "hPa",
+            "HGHT": "m",
+            "TEMP": "C",
+            "DWPT": "C",
+            "FRPT": "C",
+            "RELH": "%",
+            "RELI": "%",
+            "MIXR": "g/kg",
+            "DRCT": "deg",
+            "SKNT": "knot",
+            "THTA": "K",
+            "THTE": "K",
+            "THTV": "K",
+        }
         import urllib
+
         try:
-            with self.assertRaises(ValueError):
+            with pytest.raises(ValueError):
                 data, meta = io.misc.get_radiosonde(10411, date)
             data, meta = io.misc.get_radiosonde(10410, date)
         except urllib.error.HTTPError:
             print("HTTPError while retrieving radiosonde data, test skipped!")
         else:
-            self.assertEqual(data[0], res1[0])
-            quant = meta.pop('quantity')
-            self.assertEqual(meta, res2)
-            self.assertEqual(quant, res3)
+            assert data[0] == res1[0]
+            quant = meta.pop("quantity")
+            assert meta == res2
+            assert meta == res2
+            assert quant == res3
 
     def test_get_membership_functions(self):
-        filename = util.get_wradlib_data_file('misc/msf_xband.gz')
+        filename = util.get_wradlib_data_file("misc/msf_xband.gz")
         msf = io.misc.get_membership_functions(filename)
         res = np.array(
-            [[6.000e+00, 5.000e+00, 1.000e+01, 3.500e+01, 4.000e+01],
-             [6.000e+00, -7.458e-01, -4.457e-01, 5.523e-01, 8.523e-01],
-             [6.000e+00, 7.489e-01, 7.689e-01, 9.236e-01, 9.436e-01],
-             [6.000e+00, -5.037e-01, -1.491e-01, -1.876e-01, 1.673e-01],
-             [6.000e+00, -5.000e+00, 0.000e+00, 4.000e+01, 2.000e+03]])
-        self.assertEqual(msf.shape, (11, 5, 55, 5))
+            [
+                [6.000e00, 5.000e00, 1.000e01, 3.500e01, 4.000e01],
+                [6.000e00, -7.458e-01, -4.457e-01, 5.523e-01, 8.523e-01],
+                [6.000e00, 7.489e-01, 7.689e-01, 9.236e-01, 9.436e-01],
+                [6.000e00, -5.037e-01, -1.491e-01, -1.876e-01, 1.673e-01],
+                [6.000e00, -5.000e00, 0.000e00, 4.000e01, 2.000e03],
+            ]
+        )
+        assert msf.shape == (11, 5, 55, 5)
         np.testing.assert_array_equal(msf[0, :, 8, :], res)
 
 
-class HDF5Test(unittest.TestCase):
+class TestHDF5:
     def test_to_hdf5(self):
         arr = np.zeros((124, 248), dtype=np.int16)
-        metadata = {'test': 12.}
+        metadata = {"test": 12.0}
         tmp = tempfile.NamedTemporaryFile()
         name = tmp.name
         tmp.close()
         io.hdf.to_hdf5(name, arr, metadata=metadata)
         res, resmeta = io.hdf.from_hdf5(name)
-        self.assertTrue(np.allclose(arr, res))
-        self.assertDictEqual(metadata, resmeta)
+        np.testing.assert_allclose(arr, res)
+        assert metadata == resmeta
 
-        with self.assertRaises(KeyError):
-            io.hdf.from_hdf5(name, 'NotAvailable')
+        with pytest.raises(KeyError):
+            io.hdf.from_hdf5(name, "NotAvailable")
 
     def test_read_safnwc(self):
-        filename = 'hdf5/SAFNWC_MSG3_CT___201304290415_BEL_________.h5'
+        filename = "hdf5/SAFNWC_MSG3_CT___201304290415_BEL_________.h5"
         safnwcfile = util.get_wradlib_data_file(filename)
         io.gdal.read_safnwc(safnwcfile)
 
-        command = 'rm -rf test1.h5'
+        command = "rm -rf test1.h5"
         subprocess.check_call(command, shell=True)
-        command = 'h5copy -i {} -o test1.h5 -s CT -d CT'.format(safnwcfile)
+        command = "h5copy -i {} -o test1.h5 -s CT -d CT".format(safnwcfile)
         subprocess.check_call(command, shell=True)
-        with self.assertRaises(KeyError):
-            io.gdal.read_safnwc('test1.h5')
+        with pytest.raises(KeyError):
+            io.gdal.read_safnwc("test1.h5")
 
     def test_read_gpm(self):
-        filename1 = ('gpm/2A-CS-151E24S154E30S.GPM.Ku.V7-20170308.20141206-'
-                     'S095002-E095137.004383.V05A.HDF5')
+        filename1 = (
+            "gpm/2A-CS-151E24S154E30S.GPM.Ku.V7-20170308.20141206-"
+            "S095002-E095137.004383.V05A.HDF5"
+        )
         gpm_file = util.get_wradlib_data_file(filename1)
-        filename2 = ('hdf5/IDR66_20141206_094829.vol.h5')
+        filename2 = "hdf5/IDR66_20141206_094829.vol.h5"
         gr2gpm_file = util.get_wradlib_data_file(filename2)
         gr_data = io.netcdf.read_generic_netcdf(gr2gpm_file)
-        dset = gr_data['dataset{0}'.format(2)]
-        nray_gr = dset['where']['nrays']
-        ngate_gr = dset['where']['nbins'].astype("i4")
-        elev_gr = dset['where']['elangle']
-        dr_gr = dset['where']['rscale']
-        lon0_gr = gr_data['where']['lon']
-        lat0_gr = gr_data['where']['lat']
-        alt0_gr = gr_data['where']['height']
+        dset = gr_data["dataset{0}".format(2)]
+        nray_gr = dset["where"]["nrays"]
+        ngate_gr = dset["where"]["nbins"].astype("i4")
+        elev_gr = dset["where"]["elangle"]
+        dr_gr = dset["where"]["rscale"]
+        lon0_gr = gr_data["where"]["lon"]
+        lat0_gr = gr_data["where"]["lat"]
+        alt0_gr = gr_data["where"]["height"]
         coord = georef.sweep_centroids(nray_gr, dr_gr, ngate_gr, elev_gr)
-        coords = georef.spherical_to_proj(coord[..., 0],
-                                          coord[..., 1],
-                                          coord[..., 2],
-                                          (lon0_gr, lat0_gr, alt0_gr))
+        coords = georef.spherical_to_proj(
+            coord[..., 0], coord[..., 1], coord[..., 2], (lon0_gr, lat0_gr, alt0_gr)
+        )
         lon = coords[..., 0]
         lat = coords[..., 1]
         bbox = zonalstats.get_bbox(lon, lat)
@@ -229,28 +296,29 @@ class HDF5Test(unittest.TestCase):
     def test_read_trmm(self):
         # define TRMM data sets
         trmm_2a23_file = util.get_wradlib_data_file(
-            'trmm/2A-CS-151E24S154E30S.TRMM.PR.2A23.20100206-'
-            'S111425-E111526.069662.7.HDF')
+            "trmm/2A-CS-151E24S154E30S.TRMM.PR.2A23.20100206-"
+            "S111425-E111526.069662.7.HDF"
+        )
         trmm_2a25_file = util.get_wradlib_data_file(
-            'trmm/2A-CS-151E24S154E30S.TRMM.PR.2A25.20100206-'
-            'S111425-E111526.069662.7.HDF')
+            "trmm/2A-CS-151E24S154E30S.TRMM.PR.2A25.20100206-"
+            "S111425-E111526.069662.7.HDF"
+        )
 
-        filename2 = ('hdf5/IDR66_20141206_094829.vol.h5')
+        filename2 = "hdf5/IDR66_20141206_094829.vol.h5"
         gr2gpm_file = util.get_wradlib_data_file(filename2)
         gr_data = io.netcdf.read_generic_netcdf(gr2gpm_file)
-        dset = gr_data['dataset{0}'.format(2)]
-        nray_gr = dset['where']['nrays']
-        ngate_gr = dset['where']['nbins'].astype("i4")
-        elev_gr = dset['where']['elangle']
-        dr_gr = dset['where']['rscale']
-        lon0_gr = gr_data['where']['lon']
-        lat0_gr = gr_data['where']['lat']
-        alt0_gr = gr_data['where']['height']
+        dset = gr_data["dataset{0}".format(2)]
+        nray_gr = dset["where"]["nrays"]
+        ngate_gr = dset["where"]["nbins"].astype("i4")
+        elev_gr = dset["where"]["elangle"]
+        dr_gr = dset["where"]["rscale"]
+        lon0_gr = gr_data["where"]["lon"]
+        lat0_gr = gr_data["where"]["lat"]
+        alt0_gr = gr_data["where"]["height"]
         coord = georef.sweep_centroids(nray_gr, dr_gr, ngate_gr, elev_gr)
-        coords = georef.spherical_to_proj(coord[..., 0],
-                                          coord[..., 1],
-                                          coord[..., 2],
-                                          (lon0_gr, lat0_gr, alt0_gr))
+        coords = georef.spherical_to_proj(
+            coord[..., 0], coord[..., 1], coord[..., 2], (lon0_gr, lat0_gr, alt0_gr)
+        )
         lon = coords[..., 0]
         lat = coords[..., 1]
         bbox = zonalstats.get_bbox(lon, lat)
@@ -258,69 +326,106 @@ class HDF5Test(unittest.TestCase):
         io.hdf.read_trmm(trmm_2a23_file, trmm_2a25_file, bbox)
 
     def test_read_generic_hdf5(self):
-        filename = ('hdf5/IDR66_20141206_094829.vol.h5')
+        filename = "hdf5/IDR66_20141206_094829.vol.h5"
         h5_file = util.get_wradlib_data_file(filename)
         io.hdf.read_generic_hdf5(h5_file)
 
     def test_read_opera_hdf5(self):
-        filename = ('hdf5/IDR66_20141206_094829.vol.h5')
+        filename = "hdf5/IDR66_20141206_094829.vol.h5"
         h5_file = util.get_wradlib_data_file(filename)
         io.hdf.read_opera_hdf5(h5_file)
 
     def test_read_gamic_hdf5(self):
-        ppi = ('hdf5/2014-08-10--182000.ppi.mvol')
-        rhi = ('hdf5/2014-06-09--185000.rhi.mvol')
-        filename = ('gpm/2A-CS-151E24S154E30S.GPM.Ku.V7-20170308.20141206-'
-                    'S095002-E095137.004383.V05A.HDF5')
+        ppi = "hdf5/2014-08-10--182000.ppi.mvol"
+        rhi = "hdf5/2014-06-09--185000.rhi.mvol"
+        filename = (
+            "gpm/2A-CS-151E24S154E30S.GPM.Ku.V7-20170308.20141206-"
+            "S095002-E095137.004383.V05A.HDF5"
+        )
 
         h5_file = util.get_wradlib_data_file(ppi)
         io.hdf.read_gamic_hdf5(h5_file)
         h5_file = util.get_wradlib_data_file(rhi)
         io.hdf.read_gamic_hdf5(h5_file)
         h5_file = util.get_wradlib_data_file(filename)
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             io.hdf.read_gamic_hdf5(h5_file)
 
 
 class RadolanTest(unittest.TestCase):
     def test_get_radolan_header_token(self):
-        keylist = ['BY', 'VS', 'SW', 'PR', 'INT', 'GP',
-                   'MS', 'LV', 'CS', 'MX', 'BG', 'ST',
-                   'VV', 'MF', 'QN', 'VR', 'U']
+        keylist = [
+            "BY",
+            "VS",
+            "SW",
+            "PR",
+            "INT",
+            "GP",
+            "MS",
+            "LV",
+            "CS",
+            "MX",
+            "BG",
+            "ST",
+            "VV",
+            "MF",
+            "QN",
+            "VR",
+            "U",
+        ]
         head = io.radolan.get_radolan_header_token()
         for key in keylist:
-            self.assertIsNone(head[key])
+            assert head[key] is None
 
     def test_get_radolan_header_token_pos(self):
-        header = ('RW030950100000814BY1620130VS 3SW   2.13.1PR E-01'
-                  'INT  60GP 900x 900MS 58<boo,ros,emd,hnr,pro,ess,'
-                  'asd,neu,nhb,oft,tur,isn,fbg,mem>')
+        header = (
+            "RW030950100000814BY1620130VS 3SW   2.13.1PR E-01"
+            "INT  60GP 900x 900MS 58<boo,ros,emd,hnr,pro,ess,"
+            "asd,neu,nhb,oft,tur,isn,fbg,mem>"
+        )
 
         test_head = io.radolan.get_radolan_header_token()
-        test_head['PR'] = (43, 48)
-        test_head['GP'] = (57, 66)
-        test_head['INT'] = (51, 55)
-        test_head['SW'] = (32, 41)
-        test_head['VS'] = (28, 30)
-        test_head['MS'] = (68, 128)
-        test_head['BY'] = (19, 26)
+        test_head["PR"] = (43, 48)
+        test_head["GP"] = (57, 66)
+        test_head["INT"] = (51, 55)
+        test_head["SW"] = (32, 41)
+        test_head["VS"] = (28, 30)
+        test_head["MS"] = (68, 128)
+        test_head["BY"] = (19, 26)
 
         head = io.radolan.get_radolan_header_token_pos(header)
-        self.assertDictEqual(head, test_head)
+        assert head == test_head
 
-        header = ('RQ210945100000517BY1620162VS 2SW 1.7.2PR E-01'
-                  'INT 60GP 900x 900VV 0MF 00000002QN 001'
-                  'MS 67<bln,drs,eis,emd,ess,fbg,fld,fra,ham,han,muc,'
-                  'neu,nhb,ros,tur,umd>')
-        test_head = {'BY': (19, 26), 'VS': (28, 30), 'SW': (32, 38),
-                     'PR': (40, 45), 'INT': (48, 51), 'GP': (53, 62),
-                     'MS': (85, 153), 'LV': None, 'CS': None, 'MX': None,
-                     'BG': None, 'ST': None, 'VV': (64, 66), 'MF': (68, 77),
-                     'QN': (79, 83), 'VR': None, 'U': None}
+        header = (
+            "RQ210945100000517BY1620162VS 2SW 1.7.2PR E-01"
+            "INT 60GP 900x 900VV 0MF 00000002QN 001"
+            "MS 67<bln,drs,eis,emd,ess,fbg,fld,fra,ham,han,muc,"
+            "neu,nhb,ros,tur,umd>"
+        )
+        test_head = {
+            "BY": (19, 26),
+            "VS": (28, 30),
+            "SW": (32, 38),
+            "PR": (40, 45),
+            "INT": (48, 51),
+            "GP": (53, 62),
+            "MS": (85, 153),
+            "LV": None,
+            "CS": None,
+            "MX": None,
+            "BG": None,
+            "ST": None,
+            "VV": (64, 66),
+            "MF": (68, 77),
+            "QN": (79, 83),
+            "VR": None,
+            "U": None,
+        }
         head = io.radolan.get_radolan_header_token_pos(header)
-        self.assertDictEqual(head, test_head)
+        assert head == test_head
 
     def test_decode_radolan_runlength_line(self):
+        # fmt: off
         testarr = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
                    0., 0., 0.,
                    0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
@@ -372,167 +477,296 @@ class RadolanTest(unittest.TestCase):
                    0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
                    0., 0., 0.,
                    0., 0., 0., 0., 0., 0., 0., 0., 0., 0.]
-
-        testline = (b'\x10\x98\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9'
-                    b'\xf9\xf9\xf9\xf9\xf9\xf9\xd9\n')
-        testline1 = (b'\x10\n')
-        testattrs = {'ncol': 460, 'nodataflag': 0}
+        # fmt: on
+        testline = (
+            b"\x10\x98\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9"
+            b"\xf9\xf9\xf9\xf9\xf9\xf9\xd9\n"
+        )
+        testline1 = b"\x10\n"
+        testattrs = {"ncol": 460, "nodataflag": 0}
         arr = np.frombuffer(testline, np.uint8).astype(np.uint8)
         line = io.radolan.decode_radolan_runlength_line(arr, testattrs)
-        self.assertTrue(np.allclose(line, testarr))
+        np.testing.assert_allclose(line, testarr)
         arr = np.frombuffer(testline1, np.uint8).astype(np.uint8)
         line = io.radolan.decode_radolan_runlength_line(arr, testattrs)
-        self.assertTrue(np.allclose(line, [0] * 460))
+        np.testing.assert_allclose(line, [0] * 460)
 
     def test_read_radolan_runlength_line(self):
-        testline = (b'\x10\x98\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9'
-                    b'\xf9\xf9\xf9\xf9\xf9\xf9\xd9\n')
+        testline = (
+            b"\x10\x98\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9\xf9"
+            b"\xf9\xf9\xf9\xf9\xf9\xf9\xd9\n"
+        )
         testarr = np.frombuffer(testline, np.uint8).astype(np.uint8)
         fid, temp_path = tempfile.mkstemp()
-        tmp_id = open(temp_path, 'wb')
+        tmp_id = open(temp_path, "wb")
         tmp_id.write(testline)
         tmp_id.close()
-        tmp_id = open(temp_path, 'rb')
+        tmp_id = open(temp_path, "rb")
         line = io.radolan.read_radolan_runlength_line(tmp_id)
         tmp_id.close()
         os.close(fid)
         os.remove(temp_path)
-        self.assertTrue(np.allclose(line, testarr))
+        np.testing.assert_allclose(line, testarr)
 
     def test_decode_radolan_runlength_array(self):
-        filename = 'radolan/misc/raa00-pc_10015-1408030905-dwd---bin.gz'
+        filename = "radolan/misc/raa00-pc_10015-1408030905-dwd---bin.gz"
         pg_file = util.get_wradlib_data_file(filename)
         pg_fid = io.radolan.get_radolan_filehandle(pg_file)
         header = io.radolan.read_radolan_header(pg_fid)
         attrs = io.radolan.parse_dwd_composite_header(header)
-        data = io.radolan.read_radolan_binary_array(pg_fid, attrs['datasize'])
-        attrs['nodataflag'] = 255
+        data = io.radolan.read_radolan_binary_array(pg_fid, attrs["datasize"])
+        attrs["nodataflag"] = 255
         arr = io.radolan.decode_radolan_runlength_array(data, attrs)
-        self.assertEqual(arr.shape, (460, 460))
+        assert arr.shape == (460, 460)
 
     def test_read_radolan_binary_array(self):
-        filename = 'radolan/misc/raa01-rw_10000-1408030950-dwd---bin.gz'
+        filename = "radolan/misc/raa01-rw_10000-1408030950-dwd---bin.gz"
         rw_file = util.get_wradlib_data_file(filename)
         rw_fid = io.radolan.get_radolan_filehandle(rw_file)
         header = io.radolan.read_radolan_header(rw_fid)
         attrs = io.radolan.parse_dwd_composite_header(header)
-        data = io.radolan.read_radolan_binary_array(rw_fid, attrs['datasize'])
-        self.assertEqual(len(data), attrs['datasize'])
+        data = io.radolan.read_radolan_binary_array(rw_fid, attrs["datasize"])
+        assert len(data) == attrs["datasize"]
 
         rw_fid = io.radolan.get_radolan_filehandle(rw_file)
         header = io.radolan.read_radolan_header(rw_fid)
         attrs = io.radolan.parse_dwd_composite_header(header)
-        with self.assertRaises(IOError):
-            io.radolan.read_radolan_binary_array(rw_fid,
-                                                 attrs['datasize'] + 10)
+        with pytest.raises(IOError):
+            io.radolan.read_radolan_binary_array(rw_fid, attrs["datasize"] + 10)
 
-    @unittest.skipIf(sys.platform.startswith("win"), "no gunzip on windows")
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="no gunzip on windows")
     def test_get_radolan_filehandle(self):
-        filename = 'radolan/misc/raa01-rw_10000-1408030950-dwd---bin.gz'
+        filename = "radolan/misc/raa01-rw_10000-1408030950-dwd---bin.gz"
         rw_file = util.get_wradlib_data_file(filename)
         rw_fid = io.radolan.get_radolan_filehandle(rw_file)
-        self.assertEqual(rw_file, rw_fid.name)
+        assert rw_file == rw_fid.name
 
-        command = 'gunzip -k -f {}'.format(rw_file)
+        command = "gunzip -k -f {}".format(rw_file)
         subprocess.check_call(command, shell=True)
 
         rw_fid = io.radolan.get_radolan_filehandle(rw_file[:-3])
-        self.assertEqual(rw_file[:-3], rw_fid.name)
+        assert rw_file[:-3] == rw_fid.name
 
     def test_read_radolan_header(self):
-        rx_header = (b'RW030950100000814BY1620130VS 3SW   2.13.1PR E-01'
-                     b'INT  60GP 900x 900MS 58<boo,ros,emd,hnr,pro,ess,'
-                     b'asd,neu,nhb,oft,tur,isn,fbg,mem>')
+        rx_header = (
+            b"RW030950100000814BY1620130VS 3SW   2.13.1PR E-01"
+            b"INT  60GP 900x 900MS 58<boo,ros,emd,hnr,pro,ess,"
+            b"asd,neu,nhb,oft,tur,isn,fbg,mem>"
+        )
 
         buf = sio.BytesIO(rx_header)
-        with self.assertRaises(EOFError):
+        with pytest.raises(EOFError):
             io.radolan.read_radolan_header(buf)
 
         buf = sio.BytesIO(rx_header + b"\x03")
         header = io.radolan.read_radolan_header(buf)
-        self.assertEqual(header, rx_header.decode())
+        assert header == rx_header.decode()
 
     def test_parse_dwd_composite_header(self):
-        rx_header = ('RW030950100000814BY1620130VS 3SW   2.13.1PR E-01INT  60'
-                     'GP 900x 900MS 58<boo,ros,emd,hnr,pro,ess,asd,neu,nhb,'
-                     'oft,tur,isn,fbg,mem>')
-        test_rx = {'maxrange': '150 km',
-                   'radarlocations': ['boo', 'ros', 'emd', 'hnr', 'pro',
-                                      'ess', 'asd', 'neu', 'nhb', 'oft',
-                                      'tur', 'isn', 'fbg', 'mem'],
-                   'nrow': 900, 'intervalseconds': 3600, 'precision': 0.1,
-                   'datetime': datetime.datetime(2014, 8, 3, 9, 50),
-                   'ncol': 900,
-                   'radolanversion': '2.13.1', 'producttype': 'RW',
-                   'radarid': '10000',
-                   'datasize': 1620001, }
+        rx_header = (
+            "RW030950100000814BY1620130VS 3SW   2.13.1PR E-01INT  60"
+            "GP 900x 900MS 58<boo,ros,emd,hnr,pro,ess,asd,neu,nhb,"
+            "oft,tur,isn,fbg,mem>"
+        )
+        test_rx = {
+            "maxrange": "150 km",
+            "radarlocations": [
+                "boo",
+                "ros",
+                "emd",
+                "hnr",
+                "pro",
+                "ess",
+                "asd",
+                "neu",
+                "nhb",
+                "oft",
+                "tur",
+                "isn",
+                "fbg",
+                "mem",
+            ],
+            "nrow": 900,
+            "intervalseconds": 3600,
+            "precision": 0.1,
+            "datetime": datetime.datetime(2014, 8, 3, 9, 50),
+            "ncol": 900,
+            "radolanversion": "2.13.1",
+            "producttype": "RW",
+            "radarid": "10000",
+            "datasize": 1620001,
+        }
 
-        pg_header = ('PG030905100000814BY20042LV 6  1.0 19.0 28.0 37.0 46.0 '
-                     '55.0CS0MX 0MS 82<boo,ros,emd,hnr,pro,ess,asd,neu,nhb,'
-                     'oft,tur,isn,fbg,mem,czbrd> are used, BG460460')
+        pg_header = (
+            "PG030905100000814BY20042LV 6  1.0 19.0 28.0 37.0 46.0 "
+            "55.0CS0MX 0MS 82<boo,ros,emd,hnr,pro,ess,asd,neu,nhb,"
+            "oft,tur,isn,fbg,mem,czbrd> are used, BG460460"
+        )
         test_pg = {
-            'radarlocations': ['boo', 'ros', 'emd', 'hnr', 'pro', 'ess', 'asd',
-                               'neu',
-                               'nhb', 'oft', 'tur', 'isn', 'fbg', 'mem',
-                               'czbrd'],
-            'nrow': 460, 'level': [1., 19., 28., 37., 46., 55.],
-            'datetime': datetime.datetime(2014, 8, 3, 9, 5), 'ncol': 460,
-            'producttype': 'PG', 'radarid': '10000', 'nlevel': 6,
-            'indicator': 'near ground level', 'imagecount': 0,
-            'datasize': 19889}
+            "radarlocations": [
+                "boo",
+                "ros",
+                "emd",
+                "hnr",
+                "pro",
+                "ess",
+                "asd",
+                "neu",
+                "nhb",
+                "oft",
+                "tur",
+                "isn",
+                "fbg",
+                "mem",
+                "czbrd",
+            ],
+            "nrow": 460,
+            "level": [1.0, 19.0, 28.0, 37.0, 46.0, 55.0],
+            "datetime": datetime.datetime(2014, 8, 3, 9, 5),
+            "ncol": 460,
+            "producttype": "PG",
+            "radarid": "10000",
+            "nlevel": 6,
+            "indicator": "near ground level",
+            "imagecount": 0,
+            "datasize": 19889,
+        }
 
-        rq_header = ('RQ210945100000517BY1620162VS 2SW 1.7.2PR E-01'
-                     'INT 60GP 900x 900VV 0MF 00000002QN 001'
-                     'MS 67<bln,drs,eis,emd,ess,fbg,fld,fra,ham,han,muc,'
-                     'neu,nhb,ros,tur,umd>')
+        rq_header = (
+            "RQ210945100000517BY1620162VS 2SW 1.7.2PR E-01"
+            "INT 60GP 900x 900VV 0MF 00000002QN 001"
+            "MS 67<bln,drs,eis,emd,ess,fbg,fld,fra,ham,han,muc,"
+            "neu,nhb,ros,tur,umd>"
+        )
 
-        test_rq = {'producttype': 'RQ',
-                   'datetime': datetime.datetime(2017, 5, 21, 9, 45),
-                   'radarid': '10000', 'datasize': 1620008,
-                   'maxrange': '128 km', 'radolanversion': '1.7.2',
-                   'precision': 0.1, 'intervalseconds': 3600,
-                   'nrow': 900, 'ncol': 900,
-                   'radarlocations': ['bln', 'drs', 'eis', 'emd', 'ess',
-                                      'fbg', 'fld', 'fra', 'ham', 'han',
-                                      'muc', 'neu', 'nhb', 'ros', 'tur',
-                                      'umd'],
-                   'predictiontime': 0, 'moduleflag': 2,
-                   'quantification': 1}
+        test_rq = {
+            "producttype": "RQ",
+            "datetime": datetime.datetime(2017, 5, 21, 9, 45),
+            "radarid": "10000",
+            "datasize": 1620008,
+            "maxrange": "128 km",
+            "radolanversion": "1.7.2",
+            "precision": 0.1,
+            "intervalseconds": 3600,
+            "nrow": 900,
+            "ncol": 900,
+            "radarlocations": [
+                "bln",
+                "drs",
+                "eis",
+                "emd",
+                "ess",
+                "fbg",
+                "fld",
+                "fra",
+                "ham",
+                "han",
+                "muc",
+                "neu",
+                "nhb",
+                "ros",
+                "tur",
+                "umd",
+            ],
+            "predictiontime": 0,
+            "moduleflag": 2,
+            "quantification": 1,
+        }
 
-        sq_header = ('SQ102050100000814BY1620231VS 3SW   2.13.1PR E-01'
-                     'INT 360GP 900x 900MS 62<boo,ros,emd,hnr,umd,pro,ess,'
-                     'asd,neu,nhb,oft,tur,isn,fbg,mem> ST 92<asd 6,boo 6,'
-                     'emd 6,ess 6,fbg 6,hnr 6,isn 6,mem 6,neu 6,nhb 6,oft 6,'
-                     'pro 6,ros 6,tur 6,umd 6>')
+        sq_header = (
+            "SQ102050100000814BY1620231VS 3SW   2.13.1PR E-01"
+            "INT 360GP 900x 900MS 62<boo,ros,emd,hnr,umd,pro,ess,"
+            "asd,neu,nhb,oft,tur,isn,fbg,mem> ST 92<asd 6,boo 6,"
+            "emd 6,ess 6,fbg 6,hnr 6,isn 6,mem 6,neu 6,nhb 6,oft 6,"
+            "pro 6,ros 6,tur 6,umd 6>"
+        )
 
-        test_sq = {'producttype': 'SQ',
-                   'datetime': datetime.datetime(2014, 8, 10, 20, 50),
-                   'radarid': '10000', 'datasize': 1620001,
-                   'maxrange': '150 km', 'radolanversion': '2.13.1',
-                   'precision': 0.1, 'intervalseconds': 21600, 'nrow': 900,
-                   'ncol': 900,
-                   'radarlocations': ['boo', 'ros', 'emd', 'hnr', 'umd', 'pro',
-                                      'ess', 'asd', 'neu', 'nhb', 'oft', 'tur',
-                                      'isn', 'fbg', 'mem'],
-                   'radardays': ['asd 6', 'boo 6', 'emd 6', 'ess 6', 'fbg 6',
-                                 'hnr 6', 'isn 6', 'mem 6', 'neu 6', 'nhb 6',
-                                 'oft 6', 'pro 6', 'ros 6', 'tur 6', 'umd 6']}
+        test_sq = {
+            "producttype": "SQ",
+            "datetime": datetime.datetime(2014, 8, 10, 20, 50),
+            "radarid": "10000",
+            "datasize": 1620001,
+            "maxrange": "150 km",
+            "radolanversion": "2.13.1",
+            "precision": 0.1,
+            "intervalseconds": 21600,
+            "nrow": 900,
+            "ncol": 900,
+            "radarlocations": [
+                "boo",
+                "ros",
+                "emd",
+                "hnr",
+                "umd",
+                "pro",
+                "ess",
+                "asd",
+                "neu",
+                "nhb",
+                "oft",
+                "tur",
+                "isn",
+                "fbg",
+                "mem",
+            ],
+            "radardays": [
+                "asd 6",
+                "boo 6",
+                "emd 6",
+                "ess 6",
+                "fbg 6",
+                "hnr 6",
+                "isn 6",
+                "mem 6",
+                "neu 6",
+                "nhb 6",
+                "oft 6",
+                "pro 6",
+                "ros 6",
+                "tur 6",
+                "umd 6",
+            ],
+        }
 
-        yw_header = ('YW070235100001014BY1980156VS 3SW   2.18.3PR E-02'
-                     'INT   5U0GP1100x 900MF 00000000VR2017.002'
-                     'MS 61<boo,ros,emd,hnr,umd,pro,ess,asd,neu,'
-                     'nhb,oft,tur,isn,fbg,mem>')
+        yw_header = (
+            "YW070235100001014BY1980156VS 3SW   2.18.3PR E-02"
+            "INT   5U0GP1100x 900MF 00000000VR2017.002"
+            "MS 61<boo,ros,emd,hnr,umd,pro,ess,asd,neu,"
+            "nhb,oft,tur,isn,fbg,mem>"
+        )
 
-        test_yw = {'producttype': 'YW',
-                   'datetime': datetime.datetime(2014, 10, 7, 2, 35),
-                   'radarid': '10000', 'datasize': 1980000,
-                   'maxrange': '150 km', 'radolanversion': '2.18.3',
-                   'precision': 0.01, 'intervalseconds': 300,
-                   'intervalunit': 0, 'nrow': 1100, 'ncol': 900,
-                   'moduleflag': 0, 'reanalysisversion': '2017.002',
-                   'radarlocations': ['boo', 'ros', 'emd', 'hnr', 'umd', 'pro',
-                                      'ess', 'asd', 'neu', 'nhb', 'oft', 'tur',
-                                      'isn', 'fbg', 'mem']}
+        test_yw = {
+            "producttype": "YW",
+            "datetime": datetime.datetime(2014, 10, 7, 2, 35),
+            "radarid": "10000",
+            "datasize": 1980000,
+            "maxrange": "150 km",
+            "radolanversion": "2.18.3",
+            "precision": 0.01,
+            "intervalseconds": 300,
+            "intervalunit": 0,
+            "nrow": 1100,
+            "ncol": 900,
+            "moduleflag": 0,
+            "reanalysisversion": "2017.002",
+            "radarlocations": [
+                "boo",
+                "ros",
+                "emd",
+                "hnr",
+                "umd",
+                "pro",
+                "ess",
+                "asd",
+                "neu",
+                "nhb",
+                "oft",
+                "tur",
+                "isn",
+                "fbg",
+                "mem",
+            ],
+        }
 
         rx = io.radolan.parse_dwd_composite_header(rx_header)
         pg = io.radolan.parse_dwd_composite_header(pg_header)
@@ -541,487 +775,567 @@ class RadolanTest(unittest.TestCase):
         yw = io.radolan.parse_dwd_composite_header(yw_header)
 
         for key, value in rx.items():
-            self.assertEqual(value, test_rx[key])
+            assert value == test_rx[key]
         for key, value in pg.items():
             if type(value) == np.ndarray:
-                self.assertTrue(np.allclose(value, test_pg[key]))
+                np.testing.assert_allclose(value, test_pg[key])
             else:
-                self.assertEqual(value, test_pg[key])
+                assert value == test_pg[key]
         for key, value in rq.items():
             if type(value) == np.ndarray:
-                self.assertTrue(np.allclose(value, test_rq[key]))
+                np.testing.assert_allclose(value, test_rq[key])
             else:
-                self.assertEqual(value, test_rq[key])
+                assert value == test_rq[key]
         for key, value in sq.items():
             if type(value) == np.ndarray:
-                self.assertTrue(np.allclose(value, test_sq[key]))
+                np.testing.assert_allclose(value, test_sq[key])
             else:
-                self.assertEqual(value, test_sq[key])
+                assert value == test_sq[key]
         for key, value in yw.items():
             if type(value) == np.ndarray:
-                self.assertTrue(np.allclose(value, test_yw[key]))
+                np.testing.assert_allclose(value, test_yw[key])
             else:
-                self.assertEqual(value, test_yw[key])
+                assert value == test_yw[key]
 
     def test_read_radolan_composite(self):
-        filename = 'radolan/misc/raa01-rw_10000-1408030950-dwd---bin.gz'
+        filename = "radolan/misc/raa01-rw_10000-1408030950-dwd---bin.gz"
         rw_file = util.get_wradlib_data_file(filename)
-        test_attrs = {'maxrange': '150 km',
-                      'radarlocations': ['boo', 'ros', 'emd', 'hnr', 'pro',
-                                         'ess', 'asd', 'neu', 'nhb', 'oft',
-                                         'tur', 'isn', 'fbg', 'mem'],
-                      'nrow': 900, 'intervalseconds': 3600,
-                      'precision': 0.1,
-                      'datetime': datetime.datetime(2014, 8, 3, 9, 50),
-                      'ncol': 900, 'radolanversion': '2.13.1',
-                      'producttype': 'RW', 'nodataflag': -9999,
-                      'datasize': 1620000, 'radarid': '10000'}
+        test_attrs = {
+            "maxrange": "150 km",
+            "radarlocations": [
+                "boo",
+                "ros",
+                "emd",
+                "hnr",
+                "pro",
+                "ess",
+                "asd",
+                "neu",
+                "nhb",
+                "oft",
+                "tur",
+                "isn",
+                "fbg",
+                "mem",
+            ],
+            "nrow": 900,
+            "intervalseconds": 3600,
+            "precision": 0.1,
+            "datetime": datetime.datetime(2014, 8, 3, 9, 50),
+            "ncol": 900,
+            "radolanversion": "2.13.1",
+            "producttype": "RW",
+            "nodataflag": -9999,
+            "datasize": 1620000,
+            "radarid": "10000",
+        }
 
         # test for complete file
         data, attrs = io.radolan.read_radolan_composite(rw_file)
-        self.assertEqual(data.shape, (900, 900))
+        assert data.shape == (900, 900)
 
         for key, value in attrs.items():
             if type(value) == np.ndarray:
-                self.assertIn(value.dtype, [np.int32, np.int64])
+                assert value.dtype in [np.int32, np.int64]
             else:
-                self.assertEqual(value, test_attrs[key])
+                assert value == test_attrs[key]
 
         # Do the same for the case where a file handle is passed
         # instead of a file name
         with gzip.open(rw_file) as fh:
             data, attrs = io.radolan.read_radolan_composite(fh)
-            self.assertEqual(data.shape, (900, 900))
+            assert data.shape == (900, 900)
 
         for key, value in attrs.items():
             if type(value) == np.ndarray:
-                self.assertIn(value.dtype, [np.int32, np.int64])
+                assert value.dtype in [np.int32, np.int64]
             else:
-                self.assertEqual(value, test_attrs[key])
+                assert value == test_attrs[key]
 
         # test for loaddata=False
-        data, attrs = io.radolan.read_radolan_composite(rw_file,
-                                                        loaddata=False)
-        self.assertEqual(data, None)
+        data, attrs = io.radolan.read_radolan_composite(rw_file, loaddata=False)
+        assert data is None
         for key, value in attrs.items():
             if type(value) == np.ndarray:
-                self.assertEqual(value.dtype, np.int64)
+                assert value.dtype == np.int64
             else:
-                self.assertEqual(value, test_attrs[key])
-        with self.assertRaises(KeyError):
-            attrs['nodataflag']
+                assert value == test_attrs[key]
+        with pytest.raises(KeyError):
+            attrs["nodataflag"]
 
-        filename = 'radolan/misc/raa01-rx_10000-1408102050-dwd---bin.gz'
+        filename = "radolan/misc/raa01-rx_10000-1408102050-dwd---bin.gz"
         rx_file = util.get_wradlib_data_file(filename)
         data, attrs = io.radolan.read_radolan_composite(rx_file)
 
-        filename = 'radolan/misc/raa00-pc_10015-1408030905-dwd---bin.gz'
+        filename = "radolan/misc/raa00-pc_10015-1408030905-dwd---bin.gz"
         pc_file = util.get_wradlib_data_file(filename)
         data, attrs = io.radolan.read_radolan_composite(pc_file)
 
         # xarray test
-        filename = 'radolan/misc/raa01-rx_10000-1408102050-dwd---bin.gz'
+        filename = "radolan/misc/raa01-rx_10000-1408102050-dwd---bin.gz"
         rx_file = util.get_wradlib_data_file(filename)
-        data, attrs = io.radolan.read_radolan_composite(rx_file,
-                                                        loaddata='xarray')
-        self.assertEqual(data.RX.shape, (900, 900))
-        self.assertEqual(data.dims, {'x': 900, 'y': 900})
-        self.assertEqual(data.RX.dims, ('y', 'x'))
-        self.assertEqual(data.time.values,
-                         np.datetime64('2014-08-10T20:50:00.000000000'))
+        data, attrs = io.radolan.read_radolan_composite(rx_file, loaddata="xarray")
+        assert data.RX.shape == (900, 900)
+        assert data.dims == {"x": 900, "y": 900}
+        assert data.RX.dims == ("y", "x")
+        assert data.time.values == np.datetime64("2014-08-10T20:50:00.000000000")
 
 
-class RainbowTest(unittest.TestCase):
+class TestRainbow:
     def test_read_rainbow(self):
-        filename = 'rainbow/2013070308340000dBuZ.azi'
+        filename = "rainbow/2013070308340000dBuZ.azi"
         rb_file = util.get_wradlib_data_file(filename)
-        with self.assertRaises(IOError):
-            io.rainbow.read_rainbow('test')
+        with pytest.raises(IOError):
+            io.rainbow.read_rainbow("test")
         # Test reading from file name
         rb_dict = io.rainbow.read_rainbow(rb_file)
-        self.assertEqual(rb_dict[u'volume'][u'@datetime'],
-                         u'2013-07-03T08:33:55')
+        assert rb_dict[u"volume"][u"@datetime"] == u"2013-07-03T08:33:55"
         # Test reading from file handle
-        with open(rb_file, 'rb') as rb_fh:
+        with open(rb_file, "rb") as rb_fh:
             rb_dict = io.rainbow.read_rainbow(rb_fh)
-            self.assertEqual(rb_dict[u'volume'][u'@datetime'],
-                             u'2013-07-03T08:33:55')
+            assert rb_dict[u"volume"][u"@datetime"] == u"2013-07-03T08:33:55"
 
     def test_find_key(self):
-        indict = {'A': {'AA': {'AAA': 0, 'X': 1},
-                        'AB': {'ABA': 2, 'X': 3},
-                        'AC': {'ACA': 4, 'X': 5},
-                        'AD': [{'ADA': 4, 'X': 2}]}}
-        outdict = [{'X': 1, 'AAA': 0}, {'X': 5, 'ACA': 4},
-                   {'ABA': 2, 'X': 3}, {'ADA': 4, 'X': 2}]
-        try:
-            self.assertCountEqual(list(io.rainbow.find_key('X', indict)),
-                                  outdict)
-            self.assertCountEqual(list(io.rainbow.find_key('Y', indict)),
-                                  [])
-        except AttributeError:
-            self.assertItemsEqual(list(io.rainbow.find_key('X', indict)),
-                                  outdict)
-            self.assertItemsEqual(list(io.rainbow.find_key('Y', indict)),
-                                  [])
+        indict = {
+            "A": {
+                "AA": {"AAA": 0, "X": 1},
+                "AB": {"ABA": 2, "X": 3},
+                "AC": {"ACA": 4, "X": 5},
+                "AD": [{"ADA": 4, "X": 2}],
+            }
+        }
+        outdict = [
+            {"X": 1, "AAA": 0},
+            {"ABA": 2, "X": 3},
+            {"X": 5, "ACA": 4},
+            {"ADA": 4, "X": 2},
+        ]
+
+        assert list(io.rainbow.find_key("X", indict)) == outdict
+        assert list(io.rainbow.find_key("Y", indict)) == []
 
     def test_decompress(self):
-        dstring = b'very special compressed string'
+        dstring = b"very special compressed string"
         cstring = zlib.compress(dstring)
-        self.assertEqual(io.rainbow.decompress(cstring), dstring)
+        assert io.rainbow.decompress(cstring) == dstring
 
     def test_get_rb_data_layout(self):
-        self.assertEqual(io.rainbow.get_rb_data_layout(8), (1, '>u1'))
-        self.assertEqual(io.rainbow.get_rb_data_layout(16), (2, '>u2'))
-        self.assertEqual(io.rainbow.get_rb_data_layout(32), (4, '>u4'))
-        with self.assertRaises(ValueError):
+        assert io.rainbow.get_rb_data_layout(8) == (1, ">u1")
+        assert io.rainbow.get_rb_data_layout(16) == (2, ">u2")
+        assert io.rainbow.get_rb_data_layout(32) == (4, ">u4")
+        with pytest.raises(ValueError):
             io.rainbow.get_rb_data_layout(128)
 
     def test_get_rb_data_layout_big(self):
         from unittest.mock import patch
-        with patch('sys.byteorder', 'big'):
-            self.assertEqual(io.rainbow.get_rb_data_layout(8), (1, '<u1'))
-            self.assertEqual(io.rainbow.get_rb_data_layout(16), (2, '<u2'))
-            self.assertEqual(io.rainbow.get_rb_data_layout(32), (4, '<u4'))
+
+        with patch("sys.byteorder", "big"):
+            assert io.rainbow.get_rb_data_layout(8) == (1, "<u1")
+            assert io.rainbow.get_rb_data_layout(16) == (2, "<u2")
+            assert io.rainbow.get_rb_data_layout(32) == (4, "<u4")
 
     def test_get_rb_data_attribute(self):
-        xmltodict = util.import_optional('xmltodict')
-        data = xmltodict.parse(('<slicedata time="13:30:05" date="2013-04-26">'
-                                '#<rayinfo refid="startangle" blobid="0" '
-                                'rays="361" depth="16"/> '
-                                '#<rawdata blobid="1" rays="361" type="dBuZ" '
-                                'bins="400" min="-31.5" max="95.5" '
-                                'depth="8"/> #</slicedata>'))
-        data = list(io.rainbow.find_key('@blobid', data))
-        self.assertEqual(io.rainbow.get_rb_data_attribute(data[0],
-                                                          'blobid'), 0)
-        self.assertEqual(io.rainbow.get_rb_data_attribute(data[1],
-                                                          'blobid'), 1)
-        self.assertEqual(io.rainbow.get_rb_data_attribute(data[0],
-                                                          'rays'), 361)
-        self.assertEqual(io.rainbow.get_rb_data_attribute(data[1],
-                                                          'rays'), 361)
-        self.assertEqual(io.rainbow.get_rb_data_attribute(data[1],
-                                                          'bins'), 400)
-        with self.assertRaises(KeyError):
-            io.rainbow.get_rb_data_attribute(data[0], 'Nonsense')
-        self.assertEqual(io.rainbow.get_rb_data_attribute(data[0],
-                                                          'depth'), 16)
+        xmltodict = util.import_optional("xmltodict")
+        data = xmltodict.parse(
+            (
+                '<slicedata time="13:30:05" date="2013-04-26">'
+                '#<rayinfo refid="startangle" blobid="0" '
+                'rays="361" depth="16"/> '
+                '#<rawdata blobid="1" rays="361" type="dBuZ" '
+                'bins="400" min="-31.5" max="95.5" '
+                'depth="8"/> #</slicedata>'
+            )
+        )
+        data = list(io.rainbow.find_key("@blobid", data))
+        assert io.rainbow.get_rb_data_attribute(data[0], "blobid") == 0
+        assert io.rainbow.get_rb_data_attribute(data[1], "blobid") == 1
+        assert io.rainbow.get_rb_data_attribute(data[0], "rays") == 361
+        assert io.rainbow.get_rb_data_attribute(data[1], "rays") == 361
+        assert io.rainbow.get_rb_data_attribute(data[1], "bins") == 400
+        with pytest.raises(KeyError):
+            io.rainbow.get_rb_data_attribute(data[0], "Nonsense")
+        assert io.rainbow.get_rb_data_attribute(data[0], "depth") == 16
 
     def test_get_rb_blob_attribute(self):
-        xmltodict = util.import_optional('xmltodict')
+        xmltodict = util.import_optional("xmltodict")
         xmldict = xmltodict.parse(
-            '<BLOB blobid="0" size="737" compression="qt"></BLOB>')
-        self.assertEqual(io.rainbow.get_rb_blob_attribute(xmldict,
-                                                          'compression'), 'qt')
-        self.assertEqual(io.rainbow.get_rb_blob_attribute(xmldict,
-                                                          'size'), '737')
-        self.assertEqual(io.rainbow.get_rb_blob_attribute(xmldict,
-                                                          'blobid'), '0')
-        with self.assertRaises(KeyError):
-            io.rainbow.get_rb_blob_attribute(xmldict, 'Nonsense')
+            '<BLOB blobid="0" size="737" compression="qt"></BLOB>'
+        )
+        assert io.rainbow.get_rb_blob_attribute(xmldict, "compression") == "qt"
+        assert io.rainbow.get_rb_blob_attribute(xmldict, "size") == "737"
+        assert io.rainbow.get_rb_blob_attribute(xmldict, "blobid") == "0"
+        with pytest.raises(KeyError):
+            io.rainbow.get_rb_blob_attribute(xmldict, "Nonsense")
 
     def test_get_rb_data_shape(self):
-        xmltodict = util.import_optional('xmltodict')
-        data = xmltodict.parse(('<slicedata time="13:30:05" date="2013-04-26">'
-                                '#<rayinfo refid="startangle" blobid="0" '
-                                'rays="361" depth="16"/> #<rawdata blobid="1" '
-                                'rays="361" type="dBuZ" bins="400" '
-                                'min="-31.5" max="95.5" depth="8"/> #<flagmap '
-                                'blobid="2" rows="800" type="dBuZ" '
-                                'columns="400" min="-31.5" max="95.5" '
-                                'depth="6"/> #<defect blobid="3" type="dBuZ" '
-                                'columns="400" min="-31.5" max="95.5" '
-                                'depth="6"/> #<rawdata2 '
-                                'blobid="4" rows="800" type="dBuZ" '
-                                'columns="400" min="-31.5" max="95.5" '
-                                'depth="8"/> #</slicedata>'))
-        data = list(io.rainbow.find_key('@blobid', data))
-        self.assertEqual(io.rainbow.get_rb_data_shape(data[0]), 361)
-        self.assertEqual(io.rainbow.get_rb_data_shape(data[1]), (361, 400))
-        self.assertEqual(io.rainbow.get_rb_data_shape(data[2]), (800, 400, 6))
-        self.assertEqual(io.rainbow.get_rb_data_shape(data[4]), (800, 400))
-        with self.assertRaises(KeyError):
+        xmltodict = util.import_optional("xmltodict")
+        data = xmltodict.parse(
+            (
+                '<slicedata time="13:30:05" date="2013-04-26">'
+                '#<rayinfo refid="startangle" blobid="0" '
+                'rays="361" depth="16"/> #<rawdata blobid="1" '
+                'rays="361" type="dBuZ" bins="400" '
+                'min="-31.5" max="95.5" depth="8"/> #<flagmap '
+                'blobid="2" rows="800" type="dBuZ" '
+                'columns="400" min="-31.5" max="95.5" '
+                'depth="6"/> #<defect blobid="3" type="dBuZ" '
+                'columns="400" min="-31.5" max="95.5" '
+                'depth="6"/> #<rawdata2 '
+                'blobid="4" rows="800" type="dBuZ" '
+                'columns="400" min="-31.5" max="95.5" '
+                'depth="8"/> #</slicedata>'
+            )
+        )
+        data = list(io.rainbow.find_key("@blobid", data))
+        assert io.rainbow.get_rb_data_shape(data[0]) == 361
+        assert io.rainbow.get_rb_data_shape(data[1]) == (361, 400)
+        assert io.rainbow.get_rb_data_shape(data[2]) == (800, 400, 6)
+        assert io.rainbow.get_rb_data_shape(data[4]) == (800, 400)
+        with pytest.raises(KeyError):
             io.rainbow.get_rb_data_shape(data[3])
 
     def test_map_rb_data(self):
-        indata = b'0123456789'
-        outdata8 = np.array([48, 49, 50, 51, 52, 53, 54, 55, 56, 57],
-                            dtype=np.uint8)
-        outdata16 = np.array([12337, 12851, 13365, 13879, 14393],
-                             dtype=np.uint16)
+        indata = b"0123456789"
+        outdata8 = np.array([48, 49, 50, 51, 52, 53, 54, 55, 56, 57], dtype=np.uint8)
+        outdata16 = np.array([12337, 12851, 13365, 13879, 14393], dtype=np.uint16)
         outdata32 = np.array([808530483, 875902519], dtype=np.uint32)
-        self.assertTrue(np.allclose(io.rainbow.map_rb_data(indata, 8),
-                                    outdata8))
-        self.assertTrue(np.allclose(io.rainbow.map_rb_data(indata, 16),
-                                    outdata16))
-        self.assertTrue(np.allclose(io.rainbow.map_rb_data(indata, 32),
-                                    outdata32))
-        flagdata = b'1'
-        self.assertTrue(np.allclose(io.rainbow.map_rb_data(flagdata, 1),
-                                    [0, 0, 1, 1, 0, 0, 0, 1]))
+        np.testing.assert_allclose(io.rainbow.map_rb_data(indata, 8), outdata8)
+        np.testing.assert_allclose(io.rainbow.map_rb_data(indata, 16), outdata16)
+        np.testing.assert_allclose(io.rainbow.map_rb_data(indata, 32), outdata32)
+        flagdata = b"1"
+        np.testing.assert_allclose(
+            io.rainbow.map_rb_data(flagdata, 1), [0, 0, 1, 1, 0, 0, 0, 1]
+        )
 
     def test_get_rb_blob_data(self):
         datastring = b'<BLOB blobid="0" size="737" compression="qt"></BLOB>'
-        with self.assertRaises(EOFError):
+        with pytest.raises(EOFError):
             io.rainbow.get_rb_blob_data(datastring, 1)
 
     def test_get_rb_blob_from_file(self):
-        filename = 'rainbow/2013070308340000dBuZ.azi'
+        filename = "rainbow/2013070308340000dBuZ.azi"
         rb_file = util.get_wradlib_data_file(filename)
         rbdict = io.rainbow.read_rainbow(rb_file, loaddata=False)
-        rbblob = rbdict['volume']['scan']['slice']['slicedata']['rawdata']
+        rbblob = rbdict["volume"]["scan"]["slice"]["slicedata"]["rawdata"]
         # Check reading from file handle
-        with open(rb_file, 'rb') as rb_fh:
+        with open(rb_file, "rb") as rb_fh:
             data = io.rainbow.get_rb_blob_from_file(rb_fh, rbblob)
-            self.assertEqual(data.shape[0], int(rbblob['@rays']))
-            self.assertEqual(data.shape[1], int(rbblob['@bins']))
-            with self.assertRaises(IOError):
-                io.rainbow.get_rb_blob_from_file('rb_fh', rbblob)
+            assert data.shape[0] == int(rbblob["@rays"])
+            assert data.shape[1] == int(rbblob["@bins"])
+            with pytest.raises(IOError):
+                io.rainbow.get_rb_blob_from_file("rb_fh", rbblob)
         # Check reading from file path
         data = io.rainbow.get_rb_blob_from_file(rb_file, rbblob)
-        self.assertEqual(data.shape[0], int(rbblob['@rays']))
-        self.assertEqual(data.shape[1], int(rbblob['@bins']))
-        with self.assertRaises(IOError):
-            io.rainbow.get_rb_blob_from_file('rb_fh', rbblob)
+        assert data.shape[0] == int(rbblob["@rays"])
+        assert data.shape[1] == int(rbblob["@bins"])
+        with pytest.raises(IOError):
+            io.rainbow.get_rb_blob_from_file("rb_fh", rbblob)
 
     def test_get_rb_file_as_string(self):
-        filename = 'rainbow/2013070308340000dBuZ.azi'
+        filename = "rainbow/2013070308340000dBuZ.azi"
         rb_file = util.get_wradlib_data_file(filename)
-        with open(rb_file, 'rb') as rb_fh:
+        with open(rb_file, "rb") as rb_fh:
             rb_string = io.rainbow.get_rb_file_as_string(rb_fh)
-            self.assertTrue(rb_string)
-            with self.assertRaises(IOError):
-                io.rainbow.get_rb_file_as_string('rb_fh')
+            assert rb_string
+            with pytest.raises(IOError):
+                io.rainbow.get_rb_file_as_string("rb_fh")
 
     def test_get_rb_header(self):
-        rb_header = (b'<volume version="5.34.16" '
-                     b'datetime="2013-07-03T08:33:55"'
-                     b' type="azi" owner="RainAnalyzer"> '
-                     b'<scan name="analyzer.azi" time="08:34:00" '
-                     b'date="2013-07-03">')
+        rb_header = (
+            b'<volume version="5.34.16" '
+            b'datetime="2013-07-03T08:33:55"'
+            b' type="azi" owner="RainAnalyzer"> '
+            b'<scan name="analyzer.azi" time="08:34:00" '
+            b'date="2013-07-03">'
+        )
 
         buf = sio.BytesIO(rb_header)
-        with self.assertRaises(IOError):
+        with pytest.raises(IOError):
             io.rainbow.get_rb_header(buf)
 
-        filename = 'rainbow/2013070308340000dBuZ.azi'
+        filename = "rainbow/2013070308340000dBuZ.azi"
         rb_file = util.get_wradlib_data_file(filename)
-        with open(rb_file, 'rb') as rb_fh:
+        with open(rb_file, "rb") as rb_fh:
             rb_header = io.rainbow.get_rb_header(rb_fh)
-            self.assertEqual(rb_header['volume']['@version'], '5.34.16')
+            assert rb_header["volume"]["@version"] == "5.34.16"
 
 
-class RasterTest(unittest.TestCase):
+class TestRaster:
     def test_gdal_create_dataset(self):
         testfunc = io.gdal.gdal_create_dataset
-        tmp = tempfile.NamedTemporaryFile(mode='w+b').name
-        with self.assertRaises(TypeError):
-            testfunc('AIG', tmp)
+        tmp = tempfile.NamedTemporaryFile(mode="w+b").name
+        with pytest.raises(TypeError):
+            testfunc("AIG", tmp)
         from osgeo import gdal
-        with self.assertRaises(TypeError):
-            testfunc('AAIGrid', tmp, cols=10, rows=10, bands=1,
-                     gdal_type=gdal.GDT_Float32)
-        testfunc('GTiff', tmp, cols=10, rows=10, bands=1,
-                 gdal_type=gdal.GDT_Float32)
-        testfunc('GTiff', tmp, cols=10, rows=10, bands=1,
-                 gdal_type=gdal.GDT_Float32, remove=True)
+
+        with pytest.raises(TypeError):
+            testfunc(
+                "AAIGrid", tmp, cols=10, rows=10, bands=1, gdal_type=gdal.GDT_Float32
+            )
+        testfunc("GTiff", tmp, cols=10, rows=10, bands=1, gdal_type=gdal.GDT_Float32)
+        testfunc(
+            "GTiff",
+            tmp,
+            cols=10,
+            rows=10,
+            bands=1,
+            gdal_type=gdal.GDT_Float32,
+            remove=True,
+        )
 
     def test_write_raster_dataset(self):
-        filename = 'geo/bonn_new.tif'
+        filename = "geo/bonn_new.tif"
         geofile = util.get_wradlib_data_file(filename)
         ds = io.gdal.open_raster(geofile)
-        io.gdal.write_raster_dataset(geofile + 'asc', ds, 'AAIGrid')
-        io.gdal.write_raster_dataset(geofile + 'asc', ds, 'AAIGrid',
-                                     remove=True)
-        with self.assertRaises(TypeError):
-            io.gdal.write_raster_dataset(geofile + 'asc1', ds, 'AIG')
+        io.gdal.write_raster_dataset(geofile + "asc", ds, "AAIGrid")
+        io.gdal.write_raster_dataset(geofile + "asc", ds, "AAIGrid", remove=True)
+        with pytest.raises(TypeError):
+            io.gdal.write_raster_dataset(geofile + "asc1", ds, "AIG")
 
     def test_open_raster(self):
-        filename = 'geo/bonn_new.tif'
+        filename = "geo/bonn_new.tif"
         geofile = util.get_wradlib_data_file(filename)
-        io.gdal.open_raster(geofile, 'GTiff')
+        io.gdal.open_raster(geofile, "GTiff")
 
 
-class VectorTest(unittest.TestCase):
+class TestVector:
     def test_open_vector(self):
-        filename = 'shapefiles/agger/agger_merge.shp'
+        filename = "shapefiles/agger/agger_merge.shp"
         geofile = util.get_wradlib_data_file(filename)
         io.gdal.open_vector(geofile)
-        io.gdal.open_vector(geofile, 'ESRI Shapefile')
+        io.gdal.open_vector(geofile, "ESRI Shapefile")
 
 
-class IrisTest(unittest.TestCase):
+class TestIris:
     def test_open_iris(self):
-        filename = 'sigmet/cor-main131125105503.RAW2049'
+        filename = "sigmet/cor-main131125105503.RAW2049"
         sigmetfile = util.get_wradlib_data_file(filename)
         data = io.iris.IrisRawFile(sigmetfile, loaddata=False)
-        self.assertIsInstance(data.rh, io.iris.IrisRecord)
-        self.assertIsInstance(data.fh, np.memmap)
+        assert isinstance(data.rh, io.iris.IrisRecord)
+        assert isinstance(data.fh, np.memmap)
         data = io.iris.IrisRawFile(sigmetfile, loaddata=True)
-        self.assertEqual(data._record_number, 511)
-        self.assertEqual(data.filepos, 3139584)
+        assert data._record_number == 511
+        assert data.filepos == 3139584
 
     def test_read_iris(self):
-        filename = 'sigmet/cor-main131125105503.RAW2049'
+        filename = "sigmet/cor-main131125105503.RAW2049"
         sigmetfile = util.get_wradlib_data_file(filename)
         data = io.iris.read_iris(sigmetfile, loaddata=True, rawdata=True)
-        data_keys = ['product_hdr', 'product_type', 'ingest_header', 'nsweeps',
-                     'nrays', 'nbins', 'data_types', 'data',
-                     'raw_product_bhdrs']
-        product_hdr_keys = ['structure_header', 'product_configuration',
-                            'product_end']
-        ingest_hdr_keys = ['structure_header', 'ingest_configuration',
-                           'task_configuration', 'spare_0', 'gparm',
-                           'reserved']
-        data_types = ['DB_DBZ', 'DB_VEL', 'DB_ZDR', 'DB_KDP', 'DB_PHIDP',
-                      'DB_RHOHV', 'DB_HCLASS']
-        self.assertEqual(list(data.keys()), data_keys)
-        self.assertEqual(list(data['product_hdr'].keys()), product_hdr_keys)
-        self.assertEqual(list(data['ingest_header'].keys()), ingest_hdr_keys)
-        self.assertEqual(data['data_types'], data_types)
+        data_keys = [
+            "product_hdr",
+            "product_type",
+            "ingest_header",
+            "nsweeps",
+            "nrays",
+            "nbins",
+            "data_types",
+            "data",
+            "raw_product_bhdrs",
+        ]
+        product_hdr_keys = ["structure_header", "product_configuration", "product_end"]
+        ingest_hdr_keys = [
+            "structure_header",
+            "ingest_configuration",
+            "task_configuration",
+            "spare_0",
+            "gparm",
+            "reserved",
+        ]
+        data_types = [
+            "DB_DBZ",
+            "DB_VEL",
+            "DB_ZDR",
+            "DB_KDP",
+            "DB_PHIDP",
+            "DB_RHOHV",
+            "DB_HCLASS",
+        ]
+        assert list(data.keys()) == data_keys
+        assert list(data["product_hdr"].keys()) == product_hdr_keys
+        assert list(data["ingest_header"].keys()) == ingest_hdr_keys
+        assert data["data_types"] == data_types
 
-        data_types = ['DB_DBZ', 'DB_VEL']
+        data_types = ["DB_DBZ", "DB_VEL"]
         selected_data = [1, 3, 8]
-        loaddata = {'moment': data_types, 'sweep': selected_data}
+        loaddata = {"moment": data_types, "sweep": selected_data}
         data = io.iris.read_iris(sigmetfile, loaddata=loaddata, rawdata=True)
-        self.assertEqual(list(data['data'][1]['sweep_data'].keys()),
-                         data_types)
-        self.assertEqual(list(data['data'].keys()), selected_data)
+        assert list(data["data"][1]["sweep_data"].keys()) == data_types
+        assert list(data["data"].keys()) == selected_data
 
     def test_IrisRecord(self):
-        filename = 'sigmet/cor-main131125105503.RAW2049'
+        filename = "sigmet/cor-main131125105503.RAW2049"
         sigmetfile = util.get_wradlib_data_file(filename)
         data = io.iris.IrisRecordFile(sigmetfile, loaddata=False)
         # reset record after init
         data.init_record(1)
-        self.assertIsInstance(data.rh, io.iris.IrisRecord)
-        self.assertEqual(data.rh.pos, 0)
-        self.assertEqual(data.rh.recpos, 0)
-        self.assertEqual(data.rh.recnum, 1)
-        rlist = [23, 0, 4, 0, 20, 19, 0, 0, 0, 0,
-                 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        assert isinstance(data.rh, io.iris.IrisRecord)
+        assert data.rh.pos == 0
+        assert data.rh.recpos == 0
+        assert data.rh.recnum == 1
+        rlist = [23, 0, 4, 0, 20, 19, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         np.testing.assert_array_equal(data.rh.read(10, 2), rlist)
-        self.assertEqual(data.rh.pos, 20)
-        self.assertEqual(data.rh.recpos, 10)
+        assert data.rh.pos == 20
+        assert data.rh.recpos == 10
         data.rh.pos -= 20
         np.testing.assert_array_equal(data.rh.read(20, 1), rlist)
         data.rh.recpos -= 10
         np.testing.assert_array_equal(data.rh.read(5, 4), rlist)
 
     def test_decode_bin_angle(self):
-        self.assertEqual(io.iris.decode_bin_angle(20000, 2), 109.86328125)
-        self.assertEqual(io.iris.decode_bin_angle(2000000000, 4),
-                         167.63806343078613)
+        assert io.iris.decode_bin_angle(20000, 2) == 109.86328125
+        assert io.iris.decode_bin_angle(2000000000, 4) == 167.63806343078613
 
     def decode_array(self):
         data = np.arange(0, 11)
-        np.testing.assert_array_equal(io.iris.decode_array(data),
-                                      [0., 1., 2., 3., 4., 5.,
-                                       6., 7., 8., 9., 10.])
-        np.testing.assert_array_equal(io.iris.decode_array(data, offset=1.),
-                                      [1., 2., 3., 4., 5., 6.,
-                                       7., 8., 9., 10., 11.])
-        np.testing.assert_array_equal(io.iris.decode_array(data, scale=0.5),
-                                      [0, 2., 4., 6., 8., 10.,
-                                       12., 14., 16., 18., 20.])
-        np.testing.assert_array_equal(io.iris.decode_array(data, offset=1.,
-                                                           scale=0.5),
-                                      [2., 4., 6., 8., 10., 12.,
-                                       14., 16., 18., 20., 22.])
-        np.testing.assert_array_equal(io.iris.decode_array(data, offset=1.,
-                                                           scale=0.5,
-                                                           offset2=-2.),
-                                      [0, 2., 4., 6., 8., 10.,
-                                       12., 14., 16., 18., 20.])
-        data = np.array([0, 1, 255, 1000, 9096, 22634, 34922, 50000, 65534],
-                        dtype=np.uint16)
-        np.testing.assert_array_equal(io.iris.decode_array(data,
-                                                           scale=1000,
-                                                           tofloat=True),
-                                      [0., 0.001, 0.255, 1., 10., 100.,
-                                       800., 10125.312, 134184.96])
+        np.testing.assert_array_equal(
+            io.iris.decode_array(data),
+            [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
+        )
+        np.testing.assert_array_equal(
+            io.iris.decode_array(data, offset=1.0),
+            [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0],
+        )
+        np.testing.assert_array_equal(
+            io.iris.decode_array(data, scale=0.5),
+            [0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0],
+        )
+        np.testing.assert_array_equal(
+            io.iris.decode_array(data, offset=1.0, scale=0.5),
+            [2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0],
+        )
+        np.testing.assert_array_equal(
+            io.iris.decode_array(data, offset=1.0, scale=0.5, offset2=-2.0),
+            [0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0],
+        )
+        data = np.array(
+            [0, 1, 255, 1000, 9096, 22634, 34922, 50000, 65534], dtype=np.uint16
+        )
+        np.testing.assert_array_equal(
+            io.iris.decode_array(data, scale=1000, tofloat=True),
+            [0.0, 0.001, 0.255, 1.0, 10.0, 100.0, 800.0, 10125.312, 134184.96],
+        )
 
     def test_decode_kdp(self):
         np.testing.assert_array_almost_equal(
-            io.iris.decode_kdp(np.arange(-5, 5, dtype='int8'),
-                               wavelength=10.),
-            [12.243229, 12.880858, 13.551695,
-             14.257469, 15., -0., -15., -14.257469,
-             -13.551695, -12.880858])
+            io.iris.decode_kdp(np.arange(-5, 5, dtype="int8"), wavelength=10.0),
+            [
+                12.243229,
+                12.880858,
+                13.551695,
+                14.257469,
+                15.0,
+                -0.0,
+                -15.0,
+                -14.257469,
+                -13.551695,
+                -12.880858,
+            ],
+        )
 
     def test_decode_phidp(self):
         np.testing.assert_array_almost_equal(
-            io.iris.decode_phidp(np.arange(0, 10, dtype='uint8'),
-                                 scale=254., offset=-1),
-            [-0.70866142, 0., 0.70866142, 1.41732283, 2.12598425, 2.83464567,
-             3.54330709, 4.2519685, 4.96062992, 5.66929134])
+            io.iris.decode_phidp(
+                np.arange(0, 10, dtype="uint8"), scale=254.0, offset=-1
+            ),
+            [
+                -0.70866142,
+                0.0,
+                0.70866142,
+                1.41732283,
+                2.12598425,
+                2.83464567,
+                3.54330709,
+                4.2519685,
+                4.96062992,
+                5.66929134,
+            ],
+        )
 
     def test_decode_phidp2(self):
         np.testing.assert_array_almost_equal(
-            io.iris.decode_phidp2(np.arange(0, 10, dtype='uint16'),
-                                  scale=65534., offset=-1),
-            [-0.00549333, 0., 0.00549333, 0.01098666, 0.01648, 0.02197333,
-             0.02746666, 0.03295999, 0.03845332, 0.04394665])
+            io.iris.decode_phidp2(
+                np.arange(0, 10, dtype="uint16"), scale=65534.0, offset=-1
+            ),
+            [
+                -0.00549333,
+                0.0,
+                0.00549333,
+                0.01098666,
+                0.01648,
+                0.02197333,
+                0.02746666,
+                0.03295999,
+                0.03845332,
+                0.04394665,
+            ],
+        )
 
     def test_decode_sqi(self):
         np.testing.assert_array_almost_equal(
-            io.iris.decode_sqi(np.arange(0, 10, dtype='uint8'),
-                               scale=253., offset=-1),
-            [np.nan, 0., 0.06286946, 0.08891084, 0.1088931, 0.12573892,
-             0.14058039, 0.1539981, 0.16633696, 0.17782169])
+            io.iris.decode_sqi(np.arange(0, 10, dtype="uint8"), scale=253.0, offset=-1),
+            [
+                np.nan,
+                0.0,
+                0.06286946,
+                0.08891084,
+                0.1088931,
+                0.12573892,
+                0.14058039,
+                0.1539981,
+                0.16633696,
+                0.17782169,
+            ],
+        )
 
     def test_decode_time(self):
-        timestring = b'\xd1\x9a\x00\x000\t\xdd\x07\x0b\x00\x19\x00'
-        self.assertEqual(io.iris.decode_time(timestring).isoformat(),
-                         '2013-11-25T11:00:35.352000')
+        timestring = b"\xd1\x9a\x00\x000\t\xdd\x07\x0b\x00\x19\x00"
+        assert (
+            io.iris.decode_time(timestring).isoformat() == "2013-11-25T11:00:35.352000"
+        )
 
     def test_decode_string(self):
-        self.assertEqual(io.iris.decode_string(b'EEST\x00\x00\x00\x00'),
-                         'EEST')
+        assert io.iris.decode_string(b"EEST\x00\x00\x00\x00") == "EEST"
 
     def test__get_fmt_string(self):
-        fmt = '12sHHi12s12s12s6s12s12sHiiiiiiiiii2sH12sHB1shhiihh80s16s12s48s'
-        self.assertEqual(io.iris._get_fmt_string(
-            io.iris.PRODUCT_CONFIGURATION), fmt)
+        fmt = "12sHHi12s12s12s6s12s12sHiiiiiiiiii2sH12sHB1shhiihh80s16s12s48s"
+        assert io.iris._get_fmt_string(io.iris.PRODUCT_CONFIGURATION) == fmt
 
 
-class NetcdfTest(unittest.TestCase):
+class TestNetcdf:
     def test_read_edge_netcdf(self):
-        filename = 'netcdf/edge_netcdf.nc'
+        filename = "netcdf/edge_netcdf.nc"
         edgefile = util.get_wradlib_data_file(filename)
         data, attrs = io.netcdf.read_edge_netcdf(edgefile)
-        data, attrs = io.netcdf.read_edge_netcdf(edgefile,
-                                                 enforce_equidist=True)
+        data, attrs = io.netcdf.read_edge_netcdf(edgefile, enforce_equidist=True)
 
-        filename = 'netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc'
+        filename = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
         ncfile = util.get_wradlib_data_file(filename)
-        with self.assertRaises(Exception):
+        with pytest.raises(Exception):
             io.netcdf.read_edge_netcdf(ncfile)
-        with self.assertRaises(Exception):
-            io.netcdf.read_edge_netcdf('test')
+        with pytest.raises(Exception):
+            io.netcdf.read_edge_netcdf("test")
 
     def test_read_generic_netcdf(self):
-        filename = 'netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc'
+        filename = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
         ncfile = util.get_wradlib_data_file(filename)
         io.netcdf.read_generic_netcdf(ncfile)
-        with self.assertRaises(IOError):
-            io.netcdf.read_generic_netcdf('test')
-        filename = 'sigmet/cor-main131125105503.RAW2049'
+        with pytest.raises(IOError):
+            io.netcdf.read_generic_netcdf("test")
+        filename = "sigmet/cor-main131125105503.RAW2049"
         ncfile = util.get_wradlib_data_file(filename)
-        with self.assertRaises(IOError):
+        with pytest.raises(IOError):
             io.netcdf.read_generic_netcdf(ncfile)
 
-        filename = 'hdf5/IDR66_20100206_111233.vol.h5'
+        filename = "hdf5/IDR66_20100206_111233.vol.h5"
         ncfile = util.get_wradlib_data_file(filename)
         io.netcdf.read_generic_netcdf(ncfile)
 
-        filename = 'netcdf/example_cfradial_ppi.nc'
+        filename = "netcdf/example_cfradial_ppi.nc"
         ncfile = util.get_wradlib_data_file(filename)
         io.netcdf.read_generic_netcdf(ncfile)
 
 
-class XarrayTests(unittest.TestCase):
+class TestXarray:
     @deprecation.fail_if_not_removed
     def test_create_xarray_dataarray(self):
         img = np.zeros((360, 10), dtype=np.float32)
@@ -1029,234 +1343,240 @@ class XarrayTests(unittest.TestCase):
         az = np.arange(0, 360)
         th = np.zeros_like(az)
         proj = georef.projection.epsg_to_osr(4326)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             io.xarray.create_xarray_dataarray(img)
-        with self.assertWarns(DeprecationWarning):
+        with pytest.warns(DeprecationWarning):
             io.xarray.create_xarray_dataarray(img, r, az, th, proj=proj)
 
     def test_iter(self):
-        filename = 'netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc'
+        filename = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
         ncfile = util.get_wradlib_data_file(filename)
         cf = io.xarray.CfRadial(ncfile)
-        self.assertEqual(len(cf), cf.sweep)
-        self.assertEqual(len(cf), 9)
+        assert len(cf) == cf.sweep
+        assert len(cf) == 9
 
     def test_del(self):
-        filename = 'netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc'
+        filename = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
         ncfile = util.get_wradlib_data_file(filename)
         cf = io.xarray.CfRadial(ncfile)
         for k in list(cf):
             del cf[k]
-        self.assertEqual(cf, {})
+        assert cf == {}
 
     def test_read_cfradial(self):
-        sweep_names = ['sweep_1', 'sweep_2', 'sweep_3', 'sweep_4',
-                       'sweep_5', 'sweep_6', 'sweep_7', 'sweep_8',
-                       'sweep_9']
-        fixed_angles = np.array([0.4999, 1.0986, 1.8018, 2.5983, 3.598,
-                                 4.7021,  6.4984, 9.1022, 12.7991])
-        filename = 'netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc'
+        sweep_names = [
+            "sweep_1",
+            "sweep_2",
+            "sweep_3",
+            "sweep_4",
+            "sweep_5",
+            "sweep_6",
+            "sweep_7",
+            "sweep_8",
+            "sweep_9",
+        ]
+        fixed_angles = np.array(
+            [0.4999, 1.0986, 1.8018, 2.5983, 3.598, 4.7021, 6.4984, 9.1022, 12.7991]
+        )
+        filename = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
         ncfile = util.get_wradlib_data_file(filename)
         cf = io.xarray.CfRadial(ncfile)
-        np.testing.assert_array_almost_equal(cf.root.sweep_fixed_angle.values,
-                                             fixed_angles)
+        np.testing.assert_array_almost_equal(
+            cf.root.sweep_fixed_angle.values, fixed_angles
+        )
         cfnames, cfangles = zip(*cf.sweeps)
-        self.assertEqual(sweep_names, list(cfnames))
+        assert sweep_names == list(cfnames)
         np.testing.assert_array_almost_equal(fixed_angles, np.array(cfangles))
-        self.assertEqual(cf.sweep, 9)
-        self.assertSequenceEqual(cf.location, (120.43350219726562,
-                                               22.52669906616211,
-                                               45.00000178813934))
-        self.assertEqual(cf.version, '1.2')
-        self.assertEqual(cf.Conventions, 'CF/Radial instrument_parameters '
-                                         'radar_parameters radar_calibration '
-                                         'geometry_correction')
+        assert cf.sweep == 9
+        assert cf.location == (120.43350219726562, 22.52669906616211, 45.00000178813934)
+        assert cf.version == "1.2"
+        assert cf.Conventions == (
+            "CF/Radial instrument_parameters "
+            "radar_parameters radar_calibration "
+            "geometry_correction"
+        )
 
-        self.assertEqual(repr(cf), repr(cf._sweeps))
+        assert repr(cf) == repr(cf._sweeps)
 
     def test_read_odim(self):
-        fixed_angles = np.array([0.3, 0.9, 1.8, 3.3, 6.])
-        filename = 'hdf5/20130429043000.rad.bewid.pvol.dbzh.scan1.hdf'
+        fixed_angles = np.array([0.3, 0.9, 1.8, 3.3, 6.0])
+        filename = "hdf5/20130429043000.rad.bewid.pvol.dbzh.scan1.hdf"
         h5file = util.get_wradlib_data_file(filename)
         cf = io.xarray.OdimH5(h5file)
-        np.testing.assert_array_almost_equal(cf.root.sweep_fixed_angle.values,
-                                             fixed_angles)
-        filename = 'hdf5/knmi_polar_volume.h5'
+        np.testing.assert_array_almost_equal(
+            cf.root.sweep_fixed_angle.values, fixed_angles
+        )
+        filename = "hdf5/knmi_polar_volume.h5"
         h5file = util.get_wradlib_data_file(filename)
         cf = io.xarray.OdimH5(h5file)
-        with self.assertRaises(AttributeError):
-            cf = io.xarray.OdimH5(h5file, flavour='None')
+        with pytest.raises(AttributeError):
+            cf = io.xarray.OdimH5(h5file, flavour="None")
 
     def test_read_gamic(self):
-        time_cov = ('2014-08-10T18:23:35Z', '2014-08-10T18:24:05Z')
-        filename = 'hdf5/2014-08-10--182000.ppi.mvol'
+        time_cov = ("2014-08-10T18:23:35Z", "2014-08-10T18:24:05Z")
+        filename = "hdf5/2014-08-10--182000.ppi.mvol"
         h5file = util.get_wradlib_data_file(filename)
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             io.xarray.OdimH5(h5file)
-        cf = io.xarray.OdimH5(h5file, flavour='GAMIC')
-        self.assertEqual(str(cf.root.time_coverage_start.values),
-                         time_cov[0])
-        self.assertEqual(str(cf.root.time_coverage_end.values),
-                         time_cov[1])
+        cf = io.xarray.OdimH5(h5file, flavour="GAMIC")
+        assert str(cf.root.time_coverage_start.values) == time_cov[0]
+        assert str(cf.root.time_coverage_end.values) == time_cov[1]
 
-        filename = 'hdf5/2014-06-09--185000.rhi.mvol'
+        filename = "hdf5/2014-06-09--185000.rhi.mvol"
         h5file = util.get_wradlib_data_file(filename)
-        cf = io.xarray.OdimH5(h5file, flavour='GAMIC')
-        cf = io.xarray.OdimH5(h5file, flavour='GAMIC', strict=False)
+        cf = io.xarray.OdimH5(h5file, flavour="GAMIC")
+        cf = io.xarray.OdimH5(h5file, flavour="GAMIC", strict=False)
 
     def test_odim_roundtrip(self):
-        filename = 'hdf5/20130429043000.rad.bewid.pvol.dbzh.scan1.hdf'
+        filename = "hdf5/20130429043000.rad.bewid.pvol.dbzh.scan1.hdf"
         odimfile = util.get_wradlib_data_file(filename)
         cf = io.xarray.OdimH5(odimfile)
-        tmp = tempfile.NamedTemporaryFile(mode='w+b').name
+        tmp = tempfile.NamedTemporaryFile(mode="w+b").name
         cf.to_odim(tmp)
         cf2 = io.xarray.OdimH5(tmp)
         xr.testing.assert_equal(cf.root, cf2.root)
         for i in range(1, 6):
-            key = 'sweep_{}'.format(i)
+            key = "sweep_{}".format(i)
             xr.testing.assert_equal(cf[key], cf2[key])
         # test write after del, file lockage
         del cf2
         cf.to_odim(tmp)
 
     def test_cfradial_roundtrip(self):
-        filename = 'netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc'
+        filename = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
         ncfile = util.get_wradlib_data_file(filename)
         cf = io.xarray.CfRadial(ncfile)
-        tmp = tempfile.NamedTemporaryFile(mode='w+b').name
+        tmp = tempfile.NamedTemporaryFile(mode="w+b").name
         cf.to_cfradial2(tmp)
         cf2 = io.xarray.CfRadial(tmp)
         xr.testing.assert_equal(cf.root, cf2.root)
         for i in range(1, 10):
-            key = 'sweep_{}'.format(i)
+            key = "sweep_{}".format(i)
             xr.testing.assert_equal(cf[key], cf2[key])
         # test write after del, file lockage
         del cf2
         cf.to_cfradial2(tmp)
 
     def test_cfradial_odim_roundtrip(self):
-        filename = 'netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc'
+        filename = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
         ncfile = util.get_wradlib_data_file(filename)
         cf = io.xarray.CfRadial(ncfile)
-        tmp = tempfile.NamedTemporaryFile(mode='w+b').name
+        tmp = tempfile.NamedTemporaryFile(mode="w+b").name
         cf.to_odim(tmp)
         cf2 = io.xarray.OdimH5(tmp)
-        xr.testing.assert_allclose(cf.root.sweep_fixed_angle,
-                                   cf2.root.sweep_fixed_angle)
-        xr.testing.assert_allclose(cf.root.time_coverage_start,
-                                   cf2.root.time_coverage_start)
-        drop = ['longitude', 'latitude', 'altitude', 'sweep_mode']
-        xr.testing.assert_allclose(cf['sweep_1'].drop_vars(drop).sweep_number,
-                                   cf2['sweep_1'].drop_vars(drop).sweep_number)
+        xr.testing.assert_allclose(
+            cf.root.sweep_fixed_angle, cf2.root.sweep_fixed_angle
+        )
+        xr.testing.assert_allclose(
+            cf.root.time_coverage_start, cf2.root.time_coverage_start
+        )
+        drop = ["longitude", "latitude", "altitude", "sweep_mode"]
+        xr.testing.assert_allclose(
+            cf["sweep_1"].drop_vars(drop).sweep_number,
+            cf2["sweep_1"].drop_vars(drop).sweep_number,
+        )
 
-        tmp1 = tempfile.NamedTemporaryFile(mode='w+b').name
+        tmp1 = tempfile.NamedTemporaryFile(mode="w+b").name
         cf2.to_cfradial2(tmp1)
         cf3 = io.xarray.CfRadial(tmp1)
-        xr.testing.assert_allclose(cf.root.time_coverage_start,
-                                   cf3.root.time_coverage_start)
+        xr.testing.assert_allclose(
+            cf.root.time_coverage_start, cf3.root.time_coverage_start
+        )
 
     def test_georeference(self):
-        filename = 'netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc'
+        filename = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
         ncfile = util.get_wradlib_data_file(filename)
         cf = io.xarray.CfRadial(ncfile, georef=True)
-        tmp = tempfile.NamedTemporaryFile(mode='w+b').name
+        tmp = tempfile.NamedTemporaryFile(mode="w+b").name
         cf.to_cfradial2(tmp)
         cf2 = io.xarray.CfRadial(tmp, georef=True)
-        swp1 = cf['sweep_1'].copy()
-        cf['sweep_1'] = cf['sweep_1'].drop_vars(['x', 'y', 'z', 'gr',
-                                                 'rays', 'bins'])
+        swp1 = cf["sweep_1"].copy()
+        cf["sweep_1"] = cf["sweep_1"].drop_vars(["x", "y", "z", "gr", "rays", "bins"])
         cf.georeference()
-        xr.testing.assert_equal(swp1, cf['sweep_1'])
-        xr.testing.assert_equal(swp1, cf2['sweep_1'])
+        xr.testing.assert_equal(swp1, cf["sweep_1"])
+        xr.testing.assert_equal(swp1, cf2["sweep_1"])
 
     def test_root_key_warnings(self):
-        filename = 'netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc'
+        filename = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
         ncfile = util.get_wradlib_data_file(filename)
         cf = io.xarray.CfRadial(ncfile)
-        with self.assertWarns(DeprecationWarning):
-            cf['root']
+        with pytest.warns(DeprecationWarning):
+            cf["root"]
 
     def test_to_odim_warning(self):
-        filename = 'netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc'
+        filename = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
         ncfile = util.get_wradlib_data_file(filename)
         cf = io.xarray.CfRadial(ncfile)
         cf.root = None
-        with self.assertWarns(UserWarning):
-            cf.to_odim('test.h5')
+        with pytest.warns(UserWarning):
+            cf.to_odim("test.h5")
 
     def test_to_cfradial2_warning(self):
-        filename = 'netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc'
+        filename = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
         ncfile = util.get_wradlib_data_file(filename)
         cf = io.xarray.CfRadial(ncfile)
         cf.root = None
-        with self.assertWarns(UserWarning):
-            cf.to_cfradial2('test.nc')
+        with pytest.warns(UserWarning):
+            cf.to_cfradial2("test.nc")
 
     def test_setitem_warning(self):
-        filename = 'netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc'
+        filename = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
         ncfile = util.get_wradlib_data_file(filename)
         cf = io.xarray.CfRadial(ncfile)
-        with self.assertWarns(UserWarning):
-            cf['test'] = None
+        with pytest.warns(UserWarning):
+            cf["test"] = None
 
     def test_odim_errors(self):
-        filename = 'netcdf/edge_netcdf.nc'
+        filename = "netcdf/edge_netcdf.nc"
         ncfile = util.get_wradlib_data_file(filename)
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             io.xarray.OdimH5(ncfile)
 
-        filename = 'netcdf/example_cfradial_ppi.nc'
+        filename = "netcdf/example_cfradial_ppi.nc"
         ncfile = util.get_wradlib_data_file(filename)
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             io.xarray.OdimH5(ncfile)
 
     def test_netcdf4_errors(self):
-        filename = 'hdf5/2014-08-10--182000.ppi.mvol'
+        filename = "hdf5/2014-08-10--182000.ppi.mvol"
         h5file = util.get_wradlib_data_file(filename)
-        with self.assertRaises(AttributeError):
-            io.xarray.CfRadial(h5file, flavour='Cf/Radial3')
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
+            io.xarray.CfRadial(h5file, flavour="Cf/Radial3")
+        with pytest.raises(AttributeError):
             io.xarray.CfRadial(h5file)
 
 
-class DemTest(unittest.TestCase):
-
+class TestDem:
     @unittest.skipIf(sys.platform.startswith("win"), "known break on windows")
     def test_get_srtm(self):
-        targets = ["N51W001", "N51E000", "N51E001",
-                   "N52W001", "N52E000", "N52E001"]
+        targets = ["N51W001", "N51E000", "N51E001", "N52W001", "N52E000", "N52E001"]
         targets = ["%s.hgt.zip" % (f) for f in targets]
 
-        opts = {'region': 'Eurasia'}
+        opts = {"region": "Eurasia"}
         extent = [-0.3, 1.5, 51.4, 52.5]
         datasets = io.dem.get_srtm(extent, merge=False, download=opts)
         filelist = [os.path.basename(d.GetFileList()[0]) for d in datasets]
-        self.assertEqual(targets, filelist)
+        assert targets == filelist
 
-        targets = ["S02E015", "S02E016", "S01E015",
-                   "S01E016", "N00E015", "N00E016"]
+        targets = ["S02E015", "S02E016", "S01E015", "S01E016", "N00E015", "N00E016"]
         targets = ["%s.hgt.zip" % (f) for f in targets]
 
-        opts = {'region': 'Africa'}
+        opts = {"region": "Africa"}
         extent = [15.3, 16.6, -1.4, 0.4]
         datasets = io.dem.get_srtm(extent, merge=False, download=opts)
         filelist = [os.path.basename(d.GetFileList()[0]) for d in datasets]
-        self.assertEqual(targets, filelist)
+        assert targets == filelist
 
         merged = io.dem.get_srtm(extent)
 
-        xsize = (datasets[0].RasterXSize-1)*2+1
-        ysize = (datasets[0].RasterXSize-1)*3+1
-        self.assertEqual(merged.RasterXSize, xsize)
-        self.assertEqual(merged.RasterYSize, ysize)
+        xsize = (datasets[0].RasterXSize - 1) * 2 + 1
+        ysize = (datasets[0].RasterXSize - 1) * 3 + 1
+        assert merged.RasterXSize == xsize
+        assert merged.RasterYSize == ysize
 
         geo = merged.GetGeoTransform()
-        resolution = 3/3600
-        ulcx = 15 - resolution/2
-        ulcy = 1 + resolution/2
+        resolution = 3 / 3600
+        ulcx = 15 - resolution / 2
+        ulcy = 1 + resolution / 2
         geo_ref = [ulcx, resolution, 0, ulcy, 0, -resolution]
         np.testing.assert_array_almost_equal(geo, geo_ref)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
- remove transform functions, which can simply be replaced by `reproject`, 
- update get_earth_projection to work with model-strings, 
- simplify get_radar_projection

ping @egouden While working towards v1.7 I've cleaned up the projection code a bit. If this is in, I'll try to get in your additions from #380. 