### PR TITLE
MNT: add Python 3.9 builds to all CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - GDAL_VERSION="2"
     - python: 3.7
       sudo: required
-      dist: focal
+      dist: xenial
       services: xvfb
       env:
         - WRADLIB_UNITTEST="true"
@@ -25,7 +25,7 @@ matrix:
         - GDAL_VERSION="2"
     - python: 3.8
       sudo: required
-      dist: focal
+      dist: xenial
       services: xvfb
       env:
         - WRADLIB_UNITTEST="true"
@@ -39,7 +39,7 @@ matrix:
         - DEPLOY="true"
     - python: 3.7
       sudo: required
-      dist: focal
+      dist: xenial
       services: xvfb
       env:
         - WRADLIB_UNITTEST="true"
@@ -47,7 +47,7 @@ matrix:
         - GDAL_VERSION="3"
     - python: 3.8
       sudo: required
-      dist: focal
+      dist: xenial
       services: xvfb
       env:
         - WRADLIB_UNITTEST="true"
@@ -55,7 +55,7 @@ matrix:
         - GDAL_VERSION="3"
     - python: 3.9
         sudo: required
-        dist: focal
+        dist: xenial
         services: xvfb
         env:
           - WRADLIB_UNITTEST="true"
@@ -63,7 +63,7 @@ matrix:
           - GDAL_VERSION="3"
     - python: 3.8
       sudo: required
-      dist: focal
+      dist: xenial
       services: xvfb
       env:
         - WRADLIB_NOTEBOOKTEST="true"
@@ -71,7 +71,7 @@ matrix:
         - GDAL_VERSION="3"
     - python: 3.9
         sudo: required
-        dist: focal
+        dist: xenial
         services: xvfb
         env:
           - WRADLIB_NOTEBOOKTEST="true"
@@ -84,10 +84,10 @@ matrix:
           - PYTHON_VERSION="3.8"
           - GDAL_VERSION="3"
       - python: 3.9
-          env:
-            - WRADLIB_NOTEBOOKTEST="true"
-            - PYTHON_VERSION="3.9"
-            - GDAL_VERSION="3"
+        env:
+          - WRADLIB_NOTEBOOKTEST="true"
+          - PYTHON_VERSION="3.9"
+          - GDAL_VERSION="3"
 
 # remove temporarily, it seems it's faster without caching
 #  cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,13 +54,13 @@ matrix:
         - PYTHON_VERSION="3.8"
         - GDAL_VERSION="3"
     - python: 3.9
-        sudo: required
-        dist: xenial
-        services: xvfb
-        env:
-          - WRADLIB_UNITTEST="true"
-          - PYTHON_VERSION="3.9"
-          - GDAL_VERSION="3"
+      sudo: required
+      dist: xenial
+      services: xvfb
+      env:
+        - WRADLIB_UNITTEST="true"
+        - PYTHON_VERSION="3.9"
+        - GDAL_VERSION="3"
     - python: 3.8
       sudo: required
       dist: xenial
@@ -70,13 +70,13 @@ matrix:
         - PYTHON_VERSION="3.8"
         - GDAL_VERSION="3"
     - python: 3.9
-        sudo: required
-        dist: xenial
-        services: xvfb
-        env:
-          - WRADLIB_NOTEBOOKTEST="true"
-          - PYTHON_VERSION="3.9"
-          - GDAL_VERSION="3"
+      sudo: required
+      dist: xenial
+      services: xvfb
+      env:
+        - WRADLIB_NOTEBOOKTEST="true"
+        - PYTHON_VERSION="3.9"
+        - GDAL_VERSION="3"
     allow_failures:
       - python: 3.8
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
         - GDAL_VERSION="2"
     - python: 3.7
       sudo: required
-      dist: xenial
+      dist: focal
       services: xvfb
       env:
         - WRADLIB_UNITTEST="true"
@@ -25,7 +25,7 @@ matrix:
         - GDAL_VERSION="2"
     - python: 3.8
       sudo: required
-      dist: xenial
+      dist: focal
       services: xvfb
       env:
         - WRADLIB_UNITTEST="true"
@@ -39,7 +39,7 @@ matrix:
         - DEPLOY="true"
     - python: 3.7
       sudo: required
-      dist: xenial
+      dist: focal
       services: xvfb
       env:
         - WRADLIB_UNITTEST="true"
@@ -47,26 +47,47 @@ matrix:
         - GDAL_VERSION="3"
     - python: 3.8
       sudo: required
-      dist: xenial
+      dist: focal
       services: xvfb
       env:
         - WRADLIB_UNITTEST="true"
         - PYTHON_VERSION="3.8"
         - GDAL_VERSION="3"
+    - python: 3.9
+        sudo: required
+        dist: focal
+        services: xvfb
+        env:
+          - WRADLIB_UNITTEST="true"
+          - PYTHON_VERSION="3.9"
+          - GDAL_VERSION="3"
     - python: 3.8
       sudo: required
-      dist: xenial
+      dist: focal
       services: xvfb
       env:
         - WRADLIB_NOTEBOOKTEST="true"
         - PYTHON_VERSION="3.8"
         - GDAL_VERSION="3"
+    - python: 3.9
+        sudo: required
+        dist: focal
+        services: xvfb
+        env:
+          - WRADLIB_NOTEBOOKTEST="true"
+          - PYTHON_VERSION="3.9"
+          - GDAL_VERSION="3"
     allow_failures:
       - python: 3.8
         env:
           - WRADLIB_NOTEBOOKTEST="true"
           - PYTHON_VERSION="3.8"
           - GDAL_VERSION="3"
+      - python: 3.9
+          env:
+            - WRADLIB_NOTEBOOKTEST="true"
+            - PYTHON_VERSION="3.9"
+            - GDAL_VERSION="3"
 
 # remove temporarily, it seems it's faster without caching
 #  cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,6 @@ env:
 matrix:
     fast_finish: true
     include:
-    - python: 3.6
-      env:
-        - WRADLIB_UNITTEST="true"
-        - PYTHON_VERSION="3.6"
-        - GDAL_VERSION="2"
     - python: 3.7
       sudo: required
       dist: xenial
@@ -23,28 +18,15 @@ matrix:
         - WRADLIB_UNITTEST="true"
         - PYTHON_VERSION="3.7"
         - GDAL_VERSION="2"
-    - python: 3.8
+    - python: 3.7
       sudo: required
       dist: xenial
       services: xvfb
       env:
         - WRADLIB_UNITTEST="true"
-        - PYTHON_VERSION="3.8"
-        - GDAL_VERSION="2"
-    - python: 3.6
-      env:
-        - WRADLIB_UNITTEST="true"
-        - PYTHON_VERSION="3.6"
+        - PYTHON_VERSION="3.7"
         - GDAL_VERSION="3"
         - DEPLOY="true"
-    - python: 3.7
-      sudo: required
-      dist: xenial
-      services: xvfb
-      env:
-        - WRADLIB_UNITTEST="true"
-        - PYTHON_VERSION="3.7"
-        - GDAL_VERSION="3"
     - python: 3.8
       sudo: required
       dist: xenial
@@ -60,14 +42,6 @@ matrix:
       env:
         - WRADLIB_UNITTEST="true"
         - PYTHON_VERSION="3.9"
-        - GDAL_VERSION="3"
-    - python: 3.8
-      sudo: required
-      dist: xenial
-      services: xvfb
-      env:
-        - WRADLIB_NOTEBOOKTEST="true"
-        - PYTHON_VERSION="3.8"
         - GDAL_VERSION="3"
     - python: 3.9
       sudo: required
@@ -78,21 +52,11 @@ matrix:
         - PYTHON_VERSION="3.9"
         - GDAL_VERSION="3"
     allow_failures:
-      - python: 3.8
-        env:
-          - WRADLIB_NOTEBOOKTEST="true"
-          - PYTHON_VERSION="3.8"
-          - GDAL_VERSION="3"
       - python: 3.9
         env:
           - WRADLIB_NOTEBOOKTEST="true"
           - PYTHON_VERSION="3.9"
           - GDAL_VERSION="3"
-
-# remove temporarily, it seems it's faster without caching
-#  cache:
-#    directories:
-#      - $HOME/condacache/pkgs
 
 install:
     # test PEP8 compliance first to speed up
@@ -105,11 +69,7 @@ install:
 
 script:
     - if [ "${WRADLIB_UNITTEST}" == "true" ]; then
-        if [ "${PYTHON}" == "3.6" ]; then
-          xvfb-run scripts/run_tests.sh wradlib;
-        else
-          scripts/run_tests.sh wradlib;
-        fi;
+        scripts/run_tests.sh wradlib;
       else
         scripts/run_tests.sh $WRADLIB_NOTEBOOKS;
       fi;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ environment:
   CONDA_PATH: "C:\\Miniconda37-x64"
 
   matrix:
+    - PYTHON_VERSION: "3.9"
     - PYTHON_VERSION: "3.8"
     - PYTHON_VERSION: "3.7"
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,8 @@ jobs:
     matrix:
       py38:
         conda_env: py38
+      py39:
+        conda_env: py39
   pool:
     vmImage: 'ubuntu-20.04'
   steps:
@@ -25,6 +27,9 @@ jobs:
       py38:
         conda_env: py38-notebooks
         notebooks: true
+      py39:
+        conda_env: py39-notebooks
+        notebooks: true
   pool:
     vmImage: 'ubuntu-20.04'
   steps:
@@ -35,6 +40,8 @@ jobs:
     matrix:
       py38:
         conda_env: py38
+      py39:
+        conda_env: py39
   pool:
     vmImage: 'macOS-10.15'
   steps:
@@ -46,6 +53,9 @@ jobs:
       py38:
         conda_env: py38-notebooks
         notebooks: true
+      py39:
+        conda_env: py39-notebooks
+        notebooks: true
   pool:
     vmImage: 'macOS-10.15'
   steps:
@@ -56,6 +66,8 @@ jobs:
     matrix:
       py38:
         conda_env: py38
+      py39:
+        conda_env: py39
   pool:
     vmImage: 'windows-latest'
   steps:
@@ -66,6 +78,9 @@ jobs:
     matrix:
       py38:
         conda_env: py38-notebooks
+        notebooks: true
+      py39:
+        conda_env: py39-notebooks
         notebooks: true
   pool:
     vmImage: 'windows-latest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,9 +24,6 @@ jobs:
 - job: Linux_Notebook_Tests
   strategy:
     matrix:
-      py38:
-        conda_env: py38-notebooks
-        notebooks: true
       py39:
         conda_env: py39-notebooks
         notebooks: true
@@ -50,9 +47,6 @@ jobs:
 - job: MacOSX_Notebook_Tests
   strategy:
     matrix:
-      py38:
-        conda_env: py38-notebooks
-        notebooks: true
       py39:
         conda_env: py39-notebooks
         notebooks: true
@@ -76,9 +70,6 @@ jobs:
 - job: Windows_Notebook_Tests
   strategy:
     matrix:
-      py38:
-        conda_env: py38-notebooks
-        notebooks: true
       py39:
         conda_env: py39-notebooks
         notebooks: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,7 @@ jobs:
   - template: ci/azure/unit-tests.yml
 
 - job: Linux_Notebook_Tests
+  continueOnError: true
   strategy:
     matrix:
       py39:
@@ -45,6 +46,7 @@ jobs:
   - template: ci/azure/unit-tests.yml
 
 - job: MacOSX_Notebook_Tests
+  continueOnError: true
   strategy:
     matrix:
       py39:
@@ -68,6 +70,7 @@ jobs:
   - template: ci/azure/unit-tests.yml
 
 - job: Windows_Notebook_Tests
+  continueOnError: true
   strategy:
     matrix:
       py39:

--- a/ci/requirements/py39-notebooks.yml
+++ b/ci/requirements/py39-notebooks.yml
@@ -1,6 +1,7 @@
 name: wradlib-tests
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - python=3.9
   - bottleneck
@@ -13,7 +14,7 @@ dependencies:
   - h5netcdf
   - netCDF4
   - numpy
-  - matplotlib
+  - matplotlib-base
   - pip
   - pytest
   - pytest-cov

--- a/ci/requirements/py39-notebooks.yml
+++ b/ci/requirements/py39-notebooks.yml
@@ -1,0 +1,32 @@
+name: wradlib-tests
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  - bottleneck
+  - cartopy
+  - codecov
+  - coverage
+  - deprecation
+  - gdal
+  - h5py
+  - h5netcdf
+  - netCDF4
+  - numpy
+  - matplotlib
+  - pip
+  - pytest
+  - pytest-cov
+  - pytest-sugar
+  - pytest-xdist
+  - requests
+  - scipy
+  - semver
+  - setuptools
+  - xarray
+  - xmltodict
+  - dask
+  - notebook
+  - nbconvert
+  - psutil
+  - tqdm

--- a/ci/requirements/py39.yml
+++ b/ci/requirements/py39.yml
@@ -1,6 +1,7 @@
 name: wradlib-tests
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - python=3.9
   - bottleneck
@@ -13,7 +14,7 @@ dependencies:
   - h5netcdf
   - netCDF4
   - numpy
-  - matplotlib
+  - matplotlib-base
   - pip
   - pytest
   - pytest-cov

--- a/ci/requirements/py39.yml
+++ b/ci/requirements/py39.yml
@@ -1,0 +1,27 @@
+name: wradlib-tests
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  - bottleneck
+  - cartopy
+  - codecov
+  - coverage
+  - deprecation
+  - gdal
+  - h5py
+  - h5netcdf
+  - netCDF4
+  - numpy
+  - matplotlib
+  - pip
+  - pytest
+  - pytest-cov
+  - pytest-sugar
+  - pytest-xdist
+  - requests
+  - scipy
+  - semver
+  - setuptools
+  - xarray
+  - xmltodict


### PR DESCRIPTION
This changes the current build matrix to:

- Azure:
    - Python 3.8 and 3.9 Unit Test for Linux, MacOSX and Windows (6)
    - Python 3.9 Notebook Tests for Linux, MacOSX and Windows (3)
    - Black Style, Flake8 Lint and Isort checks (3)

- Travis:
    - Python 3.7 Unit Tests using latest GDAL2 (1)
    - Python 3.7, 3.8 and 3.9 Unit Tests using latest GDAL3  (3)
    - Python 3.9 Notebook Tests using latest GDAL3 (1)

- Appveyor:
    - Python 3.7, 3.8 and 3.9 Unit Tests (3)

I think this is a good compromise between test coverage and CI usage.
