### PR TITLE
MNT: use micromamba/mamba on Azure, mamba on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,13 +20,15 @@ install:
   # Create and activate a conda environment with the wanted Python version
   - "conda config --add channels conda-forge"
   - "conda config --set channel_priority strict"
-  - "conda update --yes --quiet conda"
+  - "conda install --yes mamba"
+  # - "conda update --yes --quiet conda"
   - "conda config --set changeps1 no"
-  - "conda create --yes --quiet -n wradlib python=%PYTHON_VERSION%"
-  - "activate wradlib"
+  # - "conda install --yes mamba"
+  - "mamba create --yes --quiet -n wradlib-tests python=%PYTHON_VERSION% %MKL% gdal numpy scipy matplotlib netcdf4 h5py h5netcdf xarray cartopy deprecation xmltodict coverage codecov pytest pytest-cov pytest-xdist pytest-sugar"
+  - "activate wradlib-test"
 
   # Install wradlib dependecies
-  - "conda install -y -q %MKL% gdal numpy scipy matplotlib netcdf4 h5py h5netcdf xarray cartopy deprecation xmltodict coverage codecov pytest pytest-cov pytest-xdist pytest-sugar"
+  # - "conda install -y -q %MKL% gdal numpy scipy matplotlib netcdf4 h5py h5netcdf xarray cartopy deprecation xmltodict coverage codecov pytest pytest-cov pytest-xdist pytest-sugar"
 
   # Some checks
   - "python -VV"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   - "conda config --set changeps1 no"
   # - "conda install --yes mamba"
   - "mamba create --yes --quiet -n wradlib-tests python=%PYTHON_VERSION% %MKL% gdal numpy scipy matplotlib netcdf4 h5py h5netcdf xarray cartopy deprecation xmltodict coverage codecov pytest pytest-cov pytest-xdist pytest-sugar"
-  - "activate wradlib-test"
+  - "activate wradlib-tests"
 
   # Install wradlib dependecies
   # - "conda install -y -q %MKL% gdal numpy scipy matplotlib netcdf4 h5py h5netcdf xarray cartopy deprecation xmltodict coverage codecov pytest pytest-cov pytest-xdist pytest-sugar"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ jobs:
     vmImage: 'ubuntu-20.04'
   steps:
   - task: UsePythonVersion@0
-  - bash: python -m pip install isort==4.3.21
+  - bash: python -m pip install isort
     displayName: Install isort
-  - bash: isort -rc --check .
+  - bash: isort --check .
     displayName: isort formatting check

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -3,9 +3,10 @@ steps:
 - bash: |
     wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
     ./micromamba shell init -s bash -p ~/micromamba
-    source ~/.bashrc
+    echo "##vso[task.setvariable variable=MAMBA_EXE]$PWD/micromamba"
+    echo "##vso[task.setvariable variable=MAMBA_PREFIX_PATH]~/micromamba"
     echo $MAMBA_EXE
-    echo $MAMBA_PEFIX_PATH
+    echo $MAMBA_PREFIX_PATH
   displayName: Add micromamba to PATH (Linux)
   condition: eq(variables['Agent.OS'], 'Linux')
 
@@ -14,11 +15,10 @@ steps:
     mv bin/micromamba .
     ls -lart
     ./micromamba shell init -s bash -p ~/micromamba
-    cat ~/.bashrc
-    cat ~/micromamba/etc/profile.d/mamba.sh
-    source ~/.bashrc
+    echo "##vso[task.setvariable variable=MAMBA_EXE]$PWD/micromamba"
+    echo "##vso[task.setvariable variable=MAMBA_PREFIX_PATH]~/micromamba"
     echo $MAMBA_EXE
-    echo $MAMBA_PEFIX_PATH
+    echo $MAMBA_PREFIX_PATH
   displayName: Add micromamba to PATH (OS X)
   condition: eq(variables['Agent.OS'], 'Darwin')
 

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -1,29 +1,21 @@
 steps:
 
-- task: Bash@3
-  displayName: Install conda environment
+- bash: |
+    wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
+    ./micromamba shell init -s bash -p ~/micromamba
+    source ~/.bashrc
+    echo $MAMBA_EXE
+    echo $MAMBA_PEFIX_PATH
+  displayName: Add micromamba to PATH (Linux)
   condition: eq(variables['Agent.OS'], 'Linux')
-  inputs:
-    targetType: 'inline'
-    script: |
-      wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
-      ./micromamba shell init -s bash -p ~/micromamba
-      source ~/.bashrc
-    noProfile: false
-    noRc: false
-
-#- bash: |
-#    wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
-#    ./micromamba shell init -s bash -p ~/micromamba
-#    source ~/.bashrc
-#  displayName: Add micromamba to PATH (Linux)
-#  condition: eq(variables['Agent.OS'], 'Linux')
 
 - bash: |
     curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
     mv bin/micromamba ./micromamba
-    ./micromamba shell init -s zsh -p ~/micromamba
-    source ~/.zshrc
+    ./micromamba shell init -s bash -p ~/micromamba
+    source ~/.bashrc
+    echo $MAMBA_EXE
+    echo $MAMBA_PEFIX_PATH
   displayName: Add micromamba to PATH (OS X)
   condition: eq(variables['Agent.OS'], 'Darwin')
 

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -4,9 +4,9 @@ steps:
     wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
     ./micromamba shell init -s bash -p ~/micromamba
     echo "##vso[task.setvariable variable=MAMBA_EXE]$PWD/micromamba"
-    echo "##vso[task.setvariable variable=MAMBA_PREFIX_PATH]~/micromamba"
+    echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]~/micromamba"
     echo $MAMBA_EXE
-    echo $MAMBA_PREFIX_PATH
+    echo $MAMBA_ROOT_PREFIX
   displayName: Add micromamba to PATH (Linux)
   condition: eq(variables['Agent.OS'], 'Linux')
 
@@ -16,9 +16,9 @@ steps:
     ls -lart
     ./micromamba shell init -s bash -p ~/micromamba
     echo "##vso[task.setvariable variable=MAMBA_EXE]$PWD/micromamba"
-    echo "##vso[task.setvariable variable=MAMBA_PREFIX_PATH]~/micromamba"
+    echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]~/micromamba"
     echo $MAMBA_EXE
-    echo $MAMBA_PREFIX_PATH
+    echo $MAMBA_ROOT_PREFIX
   displayName: Add micromamba to PATH (OS X)
   condition: eq(variables['Agent.OS'], 'Darwin')
 

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -28,6 +28,8 @@ steps:
     Invoke-Webrequest -URI https://micromamba.snakepit.net/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
     C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar.bz2 -aoa
     C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar -ttar -aoa -r Library\bin\micromamba.exe
+    MOVE -Force Library\bin\micromamba.exe micromamba.exe
+    .\micromamba.exe shell init -s powershell -p $HOME/micromamba
     $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
     $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
   displayName: Add micromamba to PATH (Windows)

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -10,8 +10,8 @@ steps:
   condition: eq(variables['Agent.OS'], 'Linux')
 
 - bash: |
-    curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba --strip-components=1
-    # mv bin/micromamba .
+    curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+    mv bin/micromamba .
     ls -lart
     bash micromamba shell init -s bash -p ~/micromamba
     source ~/.bashrc

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -11,7 +11,7 @@ steps:
 
 - bash: |
     curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
-    mv bin/micromamba micromamba
+    mv bin/micromamba .
     ./micromamba shell init -s bash -p ~/micromamba
     source ~/.bashrc
     echo $MAMBA_EXE

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -13,7 +13,9 @@ steps:
     curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
     mv bin/micromamba .
     ls -lart
-    bash micromamba shell init -s bash -p ~/micromamba
+    ./micromamba shell init -s bash -p ~/micromamba
+    cat ~/.bashrc
+    cat ~/micromamba/etc/profile.d/mamba.sh
     source ~/.bashrc
     echo $MAMBA_EXE
     echo $MAMBA_PEFIX_PATH

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -24,18 +24,18 @@ steps:
   displayName: Add micromamba to PATH (OS X)
   condition: eq(variables['Agent.OS'], 'Darwin')
 
-- powershell: |
-    Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-  displayName: Add conda to PATH (Windows)
-  condition: eq(variables['Agent.OS'], 'Windows_NT')
-
 #- powershell: |
-#    Invoke-Webrequest -URI https://micromamba.snakepit.net/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
-#    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar.bz2 -aoa
-#    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar -ttar -aoa -r Library\bin\micromamba.exe
-#    MOVE -Force Library\bin\micromamba.exe micromamba.exe
-#    .\micromamba.exe shell init -s powershell -p $HOME/micromamba
-#    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
-#    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
-#  displayName: Add micromamba to PATH (Windows)
+#    Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+#  displayName: Add conda to PATH (Windows)
 #  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+- powershell: |
+    Invoke-Webrequest -URI https://micromamba.snakepit.net/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
+    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar.bz2 -aoa
+    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar -ttar -aoa -r Library\bin\micromamba.exe
+    MOVE -Force Library\bin\micromamba.exe micromamba.exe
+    .\micromamba.exe shell init -s powershell -p $HOME/micromamba
+    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
+    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
+  displayName: Add micromamba to PATH (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -4,7 +4,9 @@ steps:
     wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
     ./micromamba shell init -s bash -p ~/micromamba
     echo "##vso[task.setvariable variable=MAMBA_EXE]$PWD/micromamba"
-    echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]~/micromamba"
+    #echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]~/micromamba"
+    echo "$(cd "$(~/micromamba "$1")"; pwd -P)/$(basename "$1")"
+    echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]$(cd "$(~/micromamba "$1")"; pwd -P)/$(basename "$1")"
     echo $MAMBA_EXE
     echo $MAMBA_ROOT_PREFIX
   displayName: Add micromamba to PATH (Linux)
@@ -16,7 +18,8 @@ steps:
     ls -lart
     ./micromamba shell init -s bash -p ~/micromamba
     echo "##vso[task.setvariable variable=MAMBA_EXE]$PWD/micromamba"
-    echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]~/micromamba"
+    echo "$(cd "$(~/micromamba "$1")"; pwd -P)/$(basename "$1")"
+    echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]$(cd "$(~/micromamba "$1")"; pwd -P)/$(basename "$1")"
     echo $MAMBA_EXE
     echo $MAMBA_ROOT_PREFIX
   displayName: Add micromamba to PATH (OS X)

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -25,12 +25,17 @@ steps:
   condition: eq(variables['Agent.OS'], 'Darwin')
 
 - powershell: |
-    Invoke-Webrequest -URI https://micromamba.snakepit.net/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
-    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar.bz2 -aoa
-    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar -ttar -aoa -r Library\bin\micromamba.exe
-    MOVE -Force Library\bin\micromamba.exe micromamba.exe
-    .\micromamba.exe shell init -s powershell -p $HOME/micromamba
-    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
-    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
-  displayName: Add micromamba to PATH (Windows)
+    Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+  displayName: Add conda to PATH (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+#- powershell: |
+#    Invoke-Webrequest -URI https://micromamba.snakepit.net/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
+#    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar.bz2 -aoa
+#    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar -ttar -aoa -r Library\bin\micromamba.exe
+#    MOVE -Force Library\bin\micromamba.exe micromamba.exe
+#    .\micromamba.exe shell init -s powershell -p $HOME/micromamba
+#    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
+#    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
+#  displayName: Add micromamba to PATH (Windows)
+#  condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -2,11 +2,9 @@ steps:
 
 - bash: |
     wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
-    ./micromamba shell init -s bash -p ~/micromamba
+    ./micromamba shell init -s bash -p $HOME/micromamba
     echo "##vso[task.setvariable variable=MAMBA_EXE]$PWD/micromamba"
-    #echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]~/micromamba"
-    echo "$(cd "$(~/micromamba "$1")"; pwd -P)/$(basename "$1")"
-    echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]$(cd "$(~/micromamba "$1")"; pwd -P)/$(basename "$1")"
+    echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]$HOME/micromamba"
     echo $MAMBA_EXE
     echo $MAMBA_ROOT_PREFIX
   displayName: Add micromamba to PATH (Linux)
@@ -16,10 +14,9 @@ steps:
     curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
     mv bin/micromamba .
     ls -lart
-    ./micromamba shell init -s bash -p ~/micromamba
+    ./micromamba shell init -s bash -p $HOME/micromamba
     echo "##vso[task.setvariable variable=MAMBA_EXE]$PWD/micromamba"
-    echo "$(cd "$(~/micromamba "$1")"; pwd -P)/$(basename "$1")"
-    echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]$(cd "$(~/micromamba "$1")"; pwd -P)/$(basename "$1")"
+    echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]$HOME/micromamba"
     echo $MAMBA_EXE
     echo $MAMBA_ROOT_PREFIX
   displayName: Add micromamba to PATH (OS X)

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -10,9 +10,10 @@ steps:
   condition: eq(variables['Agent.OS'], 'Linux')
 
 - bash: |
-    curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
-    mv bin/micromamba .
-    ./micromamba shell init -s bash -p ~/micromamba
+    curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba --strip-components=1
+    # mv bin/micromamba .
+    ls -lart
+    bash micromamba shell init -s bash -p ~/micromamba
     source ~/.bashrc
     echo $MAMBA_EXE
     echo $MAMBA_PEFIX_PATH

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -1,11 +1,23 @@
 steps:
 
-- bash: |
-    wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
-    ./micromamba shell init -s bash -p ~/micromamba
-    source ~/.bashrc
-  displayName: Add micromamba to PATH (Linux)
+- task: Bash@3
+  displayName: Install conda environment
   condition: eq(variables['Agent.OS'], 'Linux')
+  inputs:
+    targetType: 'inline'
+    script: |
+      wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
+      ./micromamba shell init -s bash -p ~/micromamba
+      source ~/.bashrc
+    noProfile: false
+    noRc: false
+
+#- bash: |
+#    wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
+#    ./micromamba shell init -s bash -p ~/micromamba
+#    source ~/.bashrc
+#  displayName: Add micromamba to PATH (Linux)
+#  condition: eq(variables['Agent.OS'], 'Linux')
 
 - bash: |
     curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -7,7 +7,7 @@ steps:
     echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]$HOME/micromamba"
     echo $MAMBA_EXE
     echo $MAMBA_ROOT_PREFIX
-    ls -lart $HOME/micromamba/etc
+    ls -lart $HOME/micromamba/etc/profile.d/
   displayName: Add micromamba to PATH (Linux)
   condition: eq(variables['Agent.OS'], 'Linux')
 
@@ -20,7 +20,7 @@ steps:
     echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]$HOME/micromamba"
     echo $MAMBA_EXE
     echo $MAMBA_ROOT_PREFIX
-    ls -lart $HOME/micromamba/etc
+    ls -lart $HOME/micromamba/etc/profile.d/
   displayName: Add micromamba to PATH (OS X)
   condition: eq(variables['Agent.OS'], 'Darwin')
 

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -7,6 +7,7 @@ steps:
     echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]$HOME/micromamba"
     echo $MAMBA_EXE
     echo $MAMBA_ROOT_PREFIX
+    ls -lart $HOME/micromamba/etc
   displayName: Add micromamba to PATH (Linux)
   condition: eq(variables['Agent.OS'], 'Linux')
 
@@ -19,6 +20,7 @@ steps:
     echo "##vso[task.setvariable variable=MAMBA_ROOT_PREFIX]$HOME/micromamba"
     echo $MAMBA_EXE
     echo $MAMBA_ROOT_PREFIX
+    ls -lart $HOME/micromamba/etc
   displayName: Add micromamba to PATH (OS X)
   condition: eq(variables['Agent.OS'], 'Darwin')
 

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -1,18 +1,25 @@
-# https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/anaconda
 steps:
 
 - bash: |
-    echo "##vso[task.prependpath]$CONDA/bin"
-  displayName: Add conda to PATH (Linux)
+    wget -qO- https://micromamba.snakepit.net/api/micromamba/linux-64/latest | tar -xvj bin/micromamba --strip-components=1
+    ./micromamba shell init -s bash -p ~/micromamba
+    source ~/.bashrc
+  displayName: Add micromamba to PATH (Linux)
   condition: eq(variables['Agent.OS'], 'Linux')
 
 - bash: |
-    echo "##vso[task.prependpath]$CONDA/bin"
-    sudo chown -R $USER $CONDA
-  displayName: Add conda to PATH (OS X)
+    curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
+    mv bin/micromamba ./micromamba
+    ./micromamba shell init -s zsh -p ~/micromamba
+    source ~/.zshrc
+  displayName: Add micromamba to PATH (OS X)
   condition: eq(variables['Agent.OS'], 'Darwin')
 
 - powershell: |
-    Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-  displayName: Add conda to PATH (Windows)
+    Invoke-Webrequest -URI https://micromamba.snakepit.net/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
+    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar.bz2 -aoa
+    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar -ttar -aoa -r Library\bin\micromamba.exe
+    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
+    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
+  displayName: Add micromamba to PATH (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -24,18 +24,18 @@ steps:
   displayName: Add micromamba to PATH (OS X)
   condition: eq(variables['Agent.OS'], 'Darwin')
 
-#- powershell: |
-#    Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-#  displayName: Add conda to PATH (Windows)
-#  condition: eq(variables['Agent.OS'], 'Windows_NT')
-
 - powershell: |
-    Invoke-Webrequest -URI https://micromamba.snakepit.net/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
-    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar.bz2 -aoa
-    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar -ttar -aoa -r Library\bin\micromamba.exe
-    MOVE -Force Library\bin\micromamba.exe micromamba.exe
-    .\micromamba.exe shell init -s powershell -p $HOME/micromamba
-    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
-    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
-  displayName: Add micromamba to PATH (Windows)
+    Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+  displayName: Add conda to PATH (Windows)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+#- powershell: |
+#    Invoke-Webrequest -URI https://micromamba.snakepit.net/api/micromamba/win-64/latest -OutFile micromamba.tar.bz2
+#    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar.bz2 -aoa
+#    C:\PROGRA~1\7-Zip\7z.exe x micromamba.tar -ttar -aoa -r Library\bin\micromamba.exe
+#    MOVE -Force Library\bin\micromamba.exe micromamba.exe
+#    .\micromamba.exe shell init -s powershell -p $HOME/micromamba
+#    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
+#    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
+#  displayName: Add micromamba to PATH (Windows)
+#  condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/ci/azure/add-conda-to-path.yml
+++ b/ci/azure/add-conda-to-path.yml
@@ -11,7 +11,7 @@ steps:
 
 - bash: |
     curl -Ls https://micromamba.snakepit.net/api/micromamba/osx-64/latest | tar -xvj bin/micromamba
-    mv bin/micromamba ./micromamba
+    mv bin/micromamba micromamba
     ./micromamba shell init -s bash -p ~/micromamba
     source ~/.bashrc
     echo $MAMBA_EXE

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -12,6 +12,11 @@ steps:
     script: |
       cat ~/.bashrc
       source ~/.bashrc
+      echo $MAMBA_EXE
+      echo $MAMBA_ROOT_PREFIX
+      ls -lart /home/vsts/
+      ls -lart /home/vsts/work
+      ls -lart /home/vsts/work/1/s/
       micromamba activate
       echo "micromamba version $(micromamba --version)"
       micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -18,11 +18,15 @@ steps:
     $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
     $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
     $Env:MAMBA_EXE
+    echo $env:CENV
     get-childitem -file
     .\micromamba.exe --help
+
     # .\micromamba.exe create --yes --strict-channel-priority --file ${{ parameters.env_file }}
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
+  env:
+    Cenv: ${{ parameters.env_file }}
 
 - bash: |
     echo $MAMBA_EXE

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -19,9 +19,10 @@ steps:
     $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
     $Env:MAMBA_EXE
     echo $env:CENV
+    echo $env:CONDA_ENV
     get-childitem -file
     .\micromamba.exe --help
-    .\micromamba.exe create --yes --strict-channel-priority --file $env:CENV
+    .\micromamba.exe "create --yes --strict-channel-priority --file $PWD\$env:CENV"
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
   env:

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -14,8 +14,9 @@ steps:
   displayName: Install conda environment (Linux, OSX)
   condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
 
-- bash: |
-    .\micromamba.exe
+- powershell: |
+    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
+    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
     .\micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -22,11 +22,11 @@ steps:
     echo $env:CONDA_ENV
     get-childitem -file
     .\micromamba.exe --help
-    .\micromamba.exe "create --yes --strict-channel-priority --file $PWD\$env:CENV"
+    .\micromamba.exe "create --yes --strict-channel-priority --file $PWD\$env:CENV\$env:CONDA_ENV.yml
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
   env:
-    Cenv: ci\requirements\$CONDA_ENV.yml
+    Cenv: ci\requirements
 
 - bash: |
     echo $MAMBA_EXE

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -21,8 +21,9 @@ steps:
 - bash: |
     export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
     export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
+    source /home/vsts/micromamba/etc/profile.d/mamba.sh
     ls -lart /home/vsts/micromamba/envs
-    /home/vsts/work/1/s/micromamba activate /home/vsts/micromamba/envs/wradlib-tests
+    micromamba activate wradlib-tests
     python -m pip install --no-deps -e .
   displayName: Install wradlib
 
@@ -38,7 +39,10 @@ steps:
   displayName: Install wradlib-notebooks
 
 - bash: |
-    /home/vsts/work/1/s/micromamba activate wradlib-tests
-    /home/vsts/work/1/s/micromamba list
+    export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
+    export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
+    source /home/vsts/micromamba/etc/profile.d/mamba.sh
+    micromamba activate wradlib-tests
+    micromamba list
     python -c "import wradlib; print(wradlib.version.full_version)"
   displayName: Version info

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -5,26 +5,24 @@ steps:
 
 - template: add-conda-to-path.yml
 
-- task: Bash@3
-  displayName: Install conda environment
-  inputs:
-    targetType: 'inline'
-    script: |
-      echo $MAMBA_EXE
-      echo $MAMBA_ROOT_PREFIX
-      #export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
-      #export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
-      source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
-      micromamba activate
-      micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
-    noProfile: false
-    noRc: false
+- bash: |
+    echo $MAMBA_EXE
+    echo $MAMBA_ROOT_PREFIX
+    source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
+    micromamba activate
+    micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
+  displayName: Install conda environment (Linux, OSX)
+  condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
+
+- bash: |
+    .\micromamba.exe
+    .\micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
+  displayName: Install conda environment (Windows_NT)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - bash: |
     echo $MAMBA_EXE
     echo $MAMBA_ROOT_PREFIX
-    #export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
-    #export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
     source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
     micromamba activate wradlib-tests
     python -m pip install --no-deps -e .
@@ -44,8 +42,6 @@ steps:
 - bash: |
     echo $MAMBA_EXE
     echo $MAMBA_ROOT_PREFIX
-    #export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
-    #export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
     source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
     micromamba activate wradlib-tests
     micromamba list

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -21,8 +21,7 @@ steps:
     echo $env:CENV
     get-childitem -file
     .\micromamba.exe --help
-
-    # .\micromamba.exe create --yes --strict-channel-priority --file ${{ parameters.env_file }}
+    .\micromamba.exe create --yes --strict-channel-priority --file $env:CENV
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
   env:

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -12,6 +12,8 @@ steps:
     script: |
       export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
       export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
+      /home/vsts/work/1/s/micromamba activate /home/vsts/micromamba
+      echo "$(which micromamba)"
       /home/vsts/work/1/s/micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
     noProfile: false
     noRc: false
@@ -19,6 +21,7 @@ steps:
 - bash: |
     export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
     export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
+    ls -lart /home/vsts/micromamba
     /home/vsts/work/1/s/micromamba activate wradlib-tests
     python -m pip install --no-deps -e .
   displayName: Install wradlib

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -19,6 +19,7 @@ steps:
     $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
     $Env:MAMBA_EXE
     get-childitem -file
+    .\micromamba.exe --help
     # .\micromamba.exe create --yes --strict-channel-priority --file ${{ parameters.env_file }}
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -25,7 +25,7 @@ steps:
     echo $MAMBA_ROOT_PREFIX
     #export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
     #export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
-    source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.shs -lart /home/vsts/micromamba/envs
+    source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
     micromamba activate wradlib-tests
     python -m pip install --no-deps -e .
   displayName: Install wradlib

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -10,25 +10,30 @@ steps:
     echo "micromamba version $(micromamba --version)"
     micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
   displayName: Install conda dependencies
+  noRc: false
 
 - bash: |
     micromamba activate wradlib-tests
     python -m pip install --no-deps -e .
   displayName: Install wradlib
+  noRc: false
 
 - bash: |
     git clone --depth 1 https://github.com/wradlib/wradlib-data.git data
     echo "##vso[task.setvariable variable=WRADLIB_DATA]$PWD/data"
   condition: eq(variables.test_data, true)
   displayName: Install wradlib-data
+  noRc: false
 
 - bash: |
     git clone --depth 1 https://github.com/wradlib/wradlib-notebooks.git notebooks
   condition: eq(variables.notebooks, true)
   displayName: Install wradlib-notebooks
+  noRc: false
 
 - bash: |
     micromamba activate wradlib-tests
     micromamba list
     python -c "import wradlib; print(wradlib.version.full_version)"
   displayName: Version info
+  noRc: false

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -17,7 +17,9 @@ steps:
 - powershell: |
     $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
     $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
-    .\micromamba.exe create --yes --strict-channel-priority --file ${{ parameters.env_file }}
+    $Env:MAMBA_EXE
+    get-childitem -file
+    # .\micromamba.exe create --yes --strict-channel-priority --file ${{ parameters.env_file }}
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -14,28 +14,28 @@ steps:
   displayName: Install conda environment (Linux, OSX)
   condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
 
-#- bash: |
-#    source activate base
-#    conda config --add channels conda-forge
-#    conda config --set channel_priority strict
-#    conda install --yes mamba
-#    mamba env create -n wradlib-tests --file ${{ parameters.env_file }}
-#  displayName: Install conda environment (Windows_NT)
-#  condition: eq(variables['Agent.OS'], 'Windows_NT')
-
-- powershell: |
-    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
-    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
-    $Env:MAMBA_EXE
-    echo $env:CENV
-    echo $env:CONDA_ENV
-    get-childitem -file
-    .\micromamba.exe --help
-    .\micromamba.exe create -v --yes --strict-channel-priority --file $PWD\$env:CENV\$env:CONDA_ENV.yml
+- bash: |
+    source activate base
+    conda config --add channels conda-forge
+    conda config --set channel_priority strict
+    conda install --yes mamba
+    mamba env create -n wradlib-tests --file ${{ parameters.env_file }}
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
-  env:
-    Cenv: ci\requirements
+
+#- powershell: |
+#    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
+#    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
+#    $Env:MAMBA_EXE
+#    echo $env:CENV
+#    echo $env:CONDA_ENV
+#    get-childitem -file
+#    .\micromamba.exe --help
+#    .\micromamba.exe create -v --yes --strict-channel-priority --file $PWD\$env:CENV\$env:CONDA_ENV.yml
+#  displayName: Install conda environment (Windows_NT)
+#  condition: eq(variables['Agent.OS'], 'Windows_NT')
+#  env:
+#    Cenv: ci\requirements
 
 - bash: |
     echo $MAMBA_EXE

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -14,28 +14,28 @@ steps:
   displayName: Install conda environment (Linux, OSX)
   condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
 
-- bash: |
-    source activate base
-    conda config --add channels conda-forge
-    conda config --set channel_priority strict
-    conda install --yes mamba
-    mamba env create -n wradlib-tests --file ${{ parameters.env_file }}
-  displayName: Install conda environment (Windows_NT)
-  condition: eq(variables['Agent.OS'], 'Windows_NT')
-
-#- powershell: |
-#    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
-#    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
-#    $Env:MAMBA_EXE
-#    echo $env:CENV
-#    echo $env:CONDA_ENV
-#    get-childitem -file
-#    .\micromamba.exe --help
-#    .\micromamba.exe create --yes --strict-channel-priority --file $PWD\$env:CENV\$env:CONDA_ENV.yml
+#- bash: |
+#    source activate base
+#    conda config --add channels conda-forge
+#    conda config --set channel_priority strict
+#    conda install --yes mamba
+#    mamba env create -n wradlib-tests --file ${{ parameters.env_file }}
 #  displayName: Install conda environment (Windows_NT)
 #  condition: eq(variables['Agent.OS'], 'Windows_NT')
-#  env:
-#    Cenv: ci\requirements
+
+- powershell: |
+    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
+    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
+    $Env:MAMBA_EXE
+    echo $env:CENV
+    echo $env:CONDA_ENV
+    get-childitem -file
+    .\micromamba.exe --help
+    .\micromamba.exe create -v --yes --strict-channel-priority --file $PWD\$env:CENV\$env:CONDA_ENV.yml
+  displayName: Install conda environment (Windows_NT)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+  env:
+    Cenv: ci\requirements
 
 - bash: |
     echo $MAMBA_EXE

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -12,17 +12,17 @@ steps:
     script: |
       export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
       export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
-      /home/vsts/work/1/s/micromamba activate /home/vsts/micromamba
-      echo "$(which micromamba)"
-      /home/vsts/work/1/s/micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
+      source /home/vsts/micromamba/etc/profile.d/mamba.sh
+      micromamba activate
+      micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
     noProfile: false
     noRc: false
 
 - bash: |
     export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
     export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
-    ls -lart /home/vsts/micromamba
-    /home/vsts/work/1/s/micromamba activate wradlib-tests
+    ls -lart /home/vsts/micromamba/envs
+    /home/vsts/work/1/s/micromamba activate /home/vsts/micromamba/envs/wradlib-tests
     python -m pip install --no-deps -e .
   displayName: Install wradlib
 

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -14,19 +14,28 @@ steps:
   displayName: Install conda environment (Linux, OSX)
   condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
 
-- powershell: |
-    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
-    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
-    $Env:MAMBA_EXE
-    echo $env:CENV
-    echo $env:CONDA_ENV
-    get-childitem -file
-    .\micromamba.exe --help
-    .\micromamba.exe create --yes --strict-channel-priority --file $PWD\$env:CENV\$env:CONDA_ENV.yml
+- bash: |
+    source activate base
+    conda config --add channels conda-forge
+    conda config --set channel_priority strict
+    conda install --yes mamba
+    mamba env create -n wradlib-tests --file ${{ parameters.env_file }}
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
-  env:
-    Cenv: ci\requirements
+
+#- powershell: |
+#    $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
+#    $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
+#    $Env:MAMBA_EXE
+#    echo $env:CENV
+#    echo $env:CONDA_ENV
+#    get-childitem -file
+#    .\micromamba.exe --help
+#    .\micromamba.exe create --yes --strict-channel-priority --file $PWD\$env:CENV\$env:CONDA_ENV.yml
+#  displayName: Install conda environment (Windows_NT)
+#  condition: eq(variables['Agent.OS'], 'Windows_NT')
+#  env:
+#    Cenv: ci\requirements
 
 - bash: |
     echo $MAMBA_EXE
@@ -34,7 +43,15 @@ steps:
     source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
     micromamba activate wradlib-tests
     python -m pip install --no-deps -e .
-  displayName: Install wradlib
+  displayName: Install wradlib (Linux, OSX)
+  condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
+
+- bash: |
+    source activate wradlib-tests
+    python -m pip install --no-deps -e .
+  displayName: Install wradlib (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
 
 - bash: |
     git clone --depth 1 https://github.com/wradlib/wradlib-data.git data
@@ -54,4 +71,14 @@ steps:
     micromamba activate wradlib-tests
     micromamba list
     python -c "import wradlib; print(wradlib.version.full_version)"
-  displayName: Version info
+  displayName: Version info (Linux, OSX)
+  condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
+
+- bash: |
+    source activate wradlib-tests
+    conda info -a
+    conda list
+  displayName: Version info (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -21,7 +21,8 @@ steps:
     echo $env:CENV
     get-childitem -file
     .\micromamba.exe --help
-    .\micromamba.exe create --yes --strict-channel-priority --file $env:CENV
+    .\micromamba.exe activate
+    # .\micromamba.exe create --yes --strict-channel-priority --file $env:CENV
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
   env:

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -12,14 +12,18 @@ steps:
     script: |
       cat ~/.bashrc
       source ~/.bashrc
+      export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
+      export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
       echo $MAMBA_EXE
       echo $MAMBA_ROOT_PREFIX
       ls -lart /home/vsts/
+      ls -lart /home/vsts/micromamba/etc/profile.d/mamba.sh
       ls -lart /home/vsts/work
       ls -lart /home/vsts/work/1/s/
-      $MAMBA_EXE --version
-      $MAMBA_EXE activate
-      $MAMBA_EXE create --yes --strict-channel-priority --file ${{ parameters.env_file }}
+      echo $PATH
+      /home/vsts/work/1/s/micromamba --version
+      /home/vsts/work/1/s/micromamba activate
+      /home/vsts/work/1/s/micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
     noProfile: false
     noRc: false
 

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -10,25 +10,16 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      cat ~/.bashrc
-      source ~/.bashrc
       export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
       export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
-      echo $MAMBA_EXE
-      echo $MAMBA_ROOT_PREFIX
-      ls -lart /home/vsts/
-      ls -lart /home/vsts/micromamba/etc/profile.d/mamba.sh
-      ls -lart /home/vsts/work
-      ls -lart /home/vsts/work/1/s/
-      echo $PATH
-      /home/vsts/work/1/s/micromamba --version
-      /home/vsts/work/1/s/micromamba activate
       /home/vsts/work/1/s/micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
     noProfile: false
     noRc: false
 
 - bash: |
-    micromamba activate wradlib-tests
+    export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
+    export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
+    /home/vsts/work/1/s/micromamba activate wradlib-tests
     python -m pip install --no-deps -e .
   displayName: Install wradlib
 
@@ -44,7 +35,7 @@ steps:
   displayName: Install wradlib-notebooks
 
 - bash: |
-    micromamba activate wradlib-tests
-    micromamba list
+    /home/vsts/work/1/s/micromamba activate wradlib-tests
+    /home/vsts/work/1/s/micromamba list
     python -c "import wradlib; print(wradlib.version.full_version)"
   displayName: Version info

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -10,6 +10,8 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
+      cat ~/.bashrc
+      source ~/.bashrc
       micromamba activate
       echo "micromamba version $(micromamba --version)"
       micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -22,7 +22,7 @@ steps:
     echo $env:CONDA_ENV
     get-childitem -file
     .\micromamba.exe --help
-    .\micromamba.exe "create --yes --strict-channel-priority --file $PWD\$env:CENV\$env:CONDA_ENV.yml
+    .\micromamba.exe create --yes --strict-channel-priority --file $PWD\$env:CENV\$env:CONDA_ENV.yml
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
   env:

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -17,9 +17,9 @@ steps:
       ls -lart /home/vsts/
       ls -lart /home/vsts/work
       ls -lart /home/vsts/work/1/s/
-      micromamba activate
-      echo "micromamba version $(micromamba --version)"
-      micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
+      $MAMBA_EXE --version
+      $MAMBA_EXE activate
+      $MAMBA_EXE create --yes --strict-channel-priority --file ${{ parameters.env_file }}
     noProfile: false
     noRc: false
 

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -6,15 +6,13 @@ steps:
 - template: add-conda-to-path.yml
 
 - bash: |
-    source activate base
-    conda config --add channels conda-forge
-    conda config --set channel_priority strict
-    conda install --yes mamba
-    mamba env create -n wradlib-tests --file ${{ parameters.env_file }}
+    micromamba activate
+    echo "micromamba version $(micromamba --version)"
+    micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
   displayName: Install conda dependencies
 
 - bash: |
-    source activate wradlib-tests
+    micromamba activate wradlib-tests
     python -m pip install --no-deps -e .
   displayName: Install wradlib
 
@@ -30,8 +28,7 @@ steps:
   displayName: Install wradlib-notebooks
 
 - bash: |
-    source activate wradlib-tests
-    conda info -a
-    conda list
+    micromamba activate wradlib-tests
+    micromamba list
     python -c "import wradlib; print(wradlib.version.full_version)"
   displayName: Version info

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -5,35 +5,34 @@ steps:
 
 - template: add-conda-to-path.yml
 
-- bash: |
-    micromamba activate
-    echo "micromamba version $(micromamba --version)"
-    micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
-  displayName: Install conda dependencies
-  noRc: false
+- task: Bash@3
+  inputs:
+    targetType: 'inline'
+      script: |
+        micromamba activate
+        echo "micromamba version $(micromamba --version)"
+        micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
+      noProfile: false
+      noRc: false
 
 - bash: |
     micromamba activate wradlib-tests
     python -m pip install --no-deps -e .
   displayName: Install wradlib
-  noRc: false
 
 - bash: |
     git clone --depth 1 https://github.com/wradlib/wradlib-data.git data
     echo "##vso[task.setvariable variable=WRADLIB_DATA]$PWD/data"
   condition: eq(variables.test_data, true)
   displayName: Install wradlib-data
-  noRc: false
 
 - bash: |
     git clone --depth 1 https://github.com/wradlib/wradlib-notebooks.git notebooks
   condition: eq(variables.notebooks, true)
   displayName: Install wradlib-notebooks
-  noRc: false
 
 - bash: |
     micromamba activate wradlib-tests
     micromamba list
     python -c "import wradlib; print(wradlib.version.full_version)"
   displayName: Version info
-  noRc: false

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -10,19 +10,22 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
-      export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
-      source /home/vsts/micromamba/etc/profile.d/mamba.sh
+      echo $MAMBA_EXE
+      echo $MAMBA_ROOT_PREFIX
+      #export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
+      #export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
+      source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
       micromamba activate
       micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
     noProfile: false
     noRc: false
 
 - bash: |
-    export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
-    export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
-    source /home/vsts/micromamba/etc/profile.d/mamba.sh
-    ls -lart /home/vsts/micromamba/envs
+    echo $MAMBA_EXE
+    echo $MAMBA_ROOT_PREFIX
+    #export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
+    #export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
+    source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.shs -lart /home/vsts/micromamba/envs
     micromamba activate wradlib-tests
     python -m pip install --no-deps -e .
   displayName: Install wradlib
@@ -39,9 +42,11 @@ steps:
   displayName: Install wradlib-notebooks
 
 - bash: |
-    export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
-    export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
-    source /home/vsts/micromamba/etc/profile.d/mamba.sh
+    echo $MAMBA_EXE
+    echo $MAMBA_ROOT_PREFIX
+    #export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
+    #export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
+    source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
     micromamba activate wradlib-tests
     micromamba list
     python -c "import wradlib; print(wradlib.version.full_version)"

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -6,14 +6,15 @@ steps:
 - template: add-conda-to-path.yml
 
 - task: Bash@3
+  displayName: Install conda environment
   inputs:
     targetType: 'inline'
-      script: |
-        micromamba activate
-        echo "micromamba version $(micromamba --version)"
-        micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
-      noProfile: false
-      noRc: false
+    script: |
+      micromamba activate
+      echo "micromamba version $(micromamba --version)"
+      micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
+    noProfile: false
+    noRc: false
 
 - bash: |
     micromamba activate wradlib-tests

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -21,12 +21,11 @@ steps:
     echo $env:CENV
     get-childitem -file
     .\micromamba.exe --help
-    .\micromamba.exe activate
-    # .\micromamba.exe create --yes --strict-channel-priority --file $env:CENV
+    .\micromamba.exe create --yes --strict-channel-priority --file $env:CENV
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
   env:
-    Cenv: ${{ parameters.env_file }}
+    Cenv: ci\requirements\$CONDA_ENV.yml
 
 - bash: |
     echo $MAMBA_EXE

--- a/ci/azure/install.yml
+++ b/ci/azure/install.yml
@@ -17,7 +17,7 @@ steps:
 - powershell: |
     $Env:MAMBA_ROOT_PREFIX=(Join-Path -Path $HOME -ChildPath micromamba)
     $Env:MAMBA_EXE=(Join-Path -Path (Get-Location) -ChildPath micromamba.exe)
-    .\micromamba create --yes --strict-channel-priority --file ${{ parameters.env_file }}
+    .\micromamba.exe create --yes --strict-channel-priority --file ${{ parameters.env_file }}
   displayName: Install conda environment (Windows_NT)
   condition: eq(variables['Agent.OS'], 'Windows_NT')
 

--- a/ci/azure/notebook-tests.yml
+++ b/ci/azure/notebook-tests.yml
@@ -3,7 +3,10 @@ steps:
 - template: install.yml
 
 - bash: |
-    source activate wradlib-tests
+    export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
+    export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
+    source /home/vsts/micromamba/etc/profile.d/mamba.sh
+    micromamba activate wradlib-tests
     pytest --verbose --tb=long --doctest-modules --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs notebooks
   displayName: Run tests
 

--- a/ci/azure/notebook-tests.yml
+++ b/ci/azure/notebook-tests.yml
@@ -3,9 +3,9 @@ steps:
 - template: install.yml
 
 - bash: |
-    export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
-    export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
-    source /home/vsts/micromamba/etc/profile.d/mamba.sh
+    echo $MAMBA_EXE
+    echo $MAMBA_ROOT_PREFIX
+    source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
     micromamba activate wradlib-tests
     pytest --verbose --tb=long --doctest-modules --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs notebooks
   displayName: Run tests

--- a/ci/azure/notebook-tests.yml
+++ b/ci/azure/notebook-tests.yml
@@ -8,7 +8,15 @@ steps:
     source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
     micromamba activate wradlib-tests
     pytest --verbose --tb=long --doctest-modules --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs notebooks
-  displayName: Run tests
+  displayName: Run tests (Linux, OSX)
+  condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
+
+- bash: |
+    source activate wradlib-tests
+    pytest --verbose --tb=long --doctest-modules --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs notebooks
+  displayName: Run tests (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
 
 - bash: |
     bash <(curl -s https://codecov.io/bash)

--- a/ci/azure/unit-tests.yml
+++ b/ci/azure/unit-tests.yml
@@ -3,9 +3,9 @@ steps:
 - template: install.yml
 
 - bash: |
-    export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
-    export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
-    source /home/vsts/micromamba/etc/profile.d/mamba.sh
+    echo $MAMBA_EXE
+    echo $MAMBA_ROOT_PREFIX
+    source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
     micromamba activate wradlib-tests
     pytest --verbose --doctest-modules --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs wradlib
   displayName: Run tests

--- a/ci/azure/unit-tests.yml
+++ b/ci/azure/unit-tests.yml
@@ -8,7 +8,14 @@ steps:
     source $MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh
     micromamba activate wradlib-tests
     pytest --verbose --doctest-modules --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs wradlib
-  displayName: Run tests
+  displayName: Run tests (Linux, OSX)
+  condition: or(eq(variables['Agent.OS'], 'Darwin'), eq(variables['Agent.OS'], 'Linux'))
+
+- bash: |
+    source activate wradlib-tests
+    pytest --verbose --doctest-modules --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs wradlib
+  displayName: Run tests (Windows)
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
 
 - bash: |
     bash <(curl -s https://codecov.io/bash)

--- a/ci/azure/unit-tests.yml
+++ b/ci/azure/unit-tests.yml
@@ -3,7 +3,10 @@ steps:
 - template: install.yml
 
 - bash: |
-    source activate wradlib-tests
+    export MAMBA_EXE="/home/vsts/work/1/s/micromamba"
+    export MAMBA_ROOT_PREFIX="/home/vsts/micromamba"
+    source /home/vsts/micromamba/etc/profile.d/mamba.sh
+    micromamba activate wradlib-tests
     pytest --verbose --doctest-modules --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs wradlib
   displayName: Run tests
 

--- a/ci/requirements/py38-notebooks.yml
+++ b/ci/requirements/py38-notebooks.yml
@@ -1,6 +1,7 @@
 name: wradlib-tests
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - python=3.8
   - bottleneck
@@ -13,7 +14,7 @@ dependencies:
   - h5netcdf
   - netCDF4
   - numpy
-  - matplotlib
+  - matplotlib-base
   - pip
   - pytest
   - pytest-cov

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -1,6 +1,7 @@
 name: wradlib-tests
 channels:
   - conda-forge
+  - defaults
 dependencies:
   - python=3.8
   - bottleneck

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -14,7 +14,7 @@ dependencies:
   - h5netcdf
   - netCDF4
   - numpy
-  - matplotlib
+  - matplotlib-base
   - pip
   - pytest
   - pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ def setup_package():
     # rewrite version file
     VERSION = write_version_py()
 
-    from setuptools import setup, find_packages
+    from setuptools import find_packages, setup
 
     with open("requirements.txt", "r") as f:
         INSTALL_REQUIRES = [rq for rq in f.read().split("\n") if rq != ""]

--- a/wradlib/__init__.py
+++ b/wradlib/__init__.py
@@ -6,6 +6,7 @@
 wradlib
 =======
 
+isort:skip_file
 """
 
 # Detect if we're being called as part of wradlib's setup procedure

--- a/wradlib/tests/test_vis.py
+++ b/wradlib/tests/test_vis.py
@@ -190,6 +190,7 @@ class TestMiscPlot:
         vis.plot_scan_strategy(ranges, elevs, site, terrain=True)
         vis.plot_scan_strategy(ranges, elevs, site, cg=True, terrain=True)
 
+    @pytest.mark.skipif(sys.platform.startswith("win"), reason="known break on windows")
     def test_plot_plan_and_vert(self):
         x = np.arange(0, 10)
         y = np.arange(0, 10)

--- a/wradlib/tests/test_vis.py
+++ b/wradlib/tests/test_vis.py
@@ -7,7 +7,8 @@ import tempfile
 from distutils.version import LooseVersion
 
 import matplotlib as mpl
-mpl.use('Agg')
+
+mpl.use("Agg")
 import matplotlib.pyplot as pl
 import numpy as np
 import pytest
@@ -15,9 +16,6 @@ import pytest
 from wradlib import georef, util, vis
 
 from . import requires_data
-
-#pl.interactive(True)  # noqa
-
 
 cartopy = util.import_optional("cartopy")
 
@@ -191,7 +189,6 @@ class TestMiscPlot:
         vis.plot_scan_strategy(ranges, elevs, site, terrain=True)
         vis.plot_scan_strategy(ranges, elevs, site, cg=True, terrain=True)
 
-    @pytest.mark.skipif(sys.platform.startswith("win"), reason="known break on windows")
     def test_plot_plan_and_vert(self):
         x = np.arange(0, 10)
         y = np.arange(0, 10)

--- a/wradlib/tests/test_vis.py
+++ b/wradlib/tests/test_vis.py
@@ -7,6 +7,7 @@ import tempfile
 from distutils.version import LooseVersion
 
 import matplotlib as mpl
+mpl.use('Agg')
 import matplotlib.pyplot as pl
 import numpy as np
 import pytest
@@ -15,7 +16,7 @@ from wradlib import georef, util, vis
 
 from . import requires_data
 
-pl.interactive(True)  # noqa
+#pl.interactive(True)  # noqa
 
 
 cartopy = util.import_optional("cartopy")

--- a/wradlib/tests/test_vis.py
+++ b/wradlib/tests/test_vis.py
@@ -6,9 +6,9 @@ import sys
 import tempfile
 from distutils.version import LooseVersion
 
-import matplotlib as mpl
+import matplotlib as mpl  # isort:skip
 
-mpl.use("Agg")
+mpl.use("Agg")  # noqa: E402
 import matplotlib.pyplot as pl
 import numpy as np
 import pytest

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -957,6 +957,7 @@ def despeckle(data, n=3, copy=False):
 
 def show_versions(file=None):
     import sys
+
     import xarray as xr
 
     if file is None:


### PR DESCRIPTION
- use micromamba on Azure for Linux and OSX builds
- use conda/mamba on Azure for Windows builds
- use conda/mamba on Appveyor
- only use matplotlib-base to not pull in PyQt/Qt 
- update isort to latest release
- fix plot backend issues in tests