### PR TITLE
ENH: add RADOLAN xarray backend, rewrite RADOLAN reader

### DIFF
--- a/ci/requirements/notebooktests.txt
+++ b/ci/requirements/notebooktests.txt
@@ -2,6 +2,7 @@ bottleneck
 cartopy
 codecov
 coverage
+dask
 deprecation
 gdal
 h5py

--- a/ci/requirements/unittests.txt
+++ b/ci/requirements/unittests.txt
@@ -2,6 +2,7 @@ bottleneck
 cartopy
 codecov
 coverage
+dask
 deprecation
 gdal
 h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+dask
 deprecation
 gdal
 h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ numpy
 matplotlib
 requests
 scipy
-xarray
+xarray>=0.17.0
 xmltodict

--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,11 @@ def setup_package():
         install_requires=INSTALL_REQUIRES,
         extras_require={"dev": DEVEL_REQUIRES},
         packages=find_packages(),
+        entry_points={
+            "xarray.backends": [
+                "radolan = wradlib.io.backends:RadolanBackendEntrypoint"
+            ]
+        },
     )
 
     setup(**metadata)

--- a/wradlib/io/__init__.py
+++ b/wradlib/io/__init__.py
@@ -11,6 +11,7 @@ for an introduction on how to deal with different file formats.
 .. toctree::
     :maxdepth: 2
 
+.. automodule:: wradlib.io.backends
 .. automodule:: wradlib.io.dem
 .. automodule:: wradlib.io.gdal
 .. automodule:: wradlib.io.hdf
@@ -22,6 +23,7 @@ for an introduction on how to deal with different file formats.
 .. automodule:: wradlib.io.xarray
 """
 
+from .backends import *
 from .dem import *
 from .gdal import *
 from .hdf import *

--- a/wradlib/io/__init__.py
+++ b/wradlib/io/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2020, wradlib developers.
+# Copyright (c) 2011-2021, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 # flake8: noqa
 """

--- a/wradlib/io/backends.py
+++ b/wradlib/io/backends.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# Copyright (c) 2021, wradlib developers.
+# Distributed under the MIT License. See LICENSE.txt for more info.
+
+"""
+wradlib backends for xarray
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Reading radar data into xarray Datasets using ``xarray.open_dataset``
+and ``xarray.open_mfdataset``
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated/
+
+   {}
+"""
+__all__ = [
+    "RadolanBackendEntrypoint",
+]
+
+__doc__ = __doc__.format("\n   ".join(__all__))
+
+import io
+
+import numpy as np
+from xarray.backends.common import AbstractDataStore, BackendArray, BackendEntrypoint
+from xarray.backends.file_manager import CachingFileManager, DummyFileManager
+from xarray.backends.locks import SerializableLock, ensure_lock
+from xarray.backends.store import StoreBackendEntrypoint
+from xarray.core.indexing import (
+    IndexingSupport,
+    LazilyOuterIndexedArray,
+    explicit_indexing_adapter,
+)
+from xarray.core.utils import Frozen, FrozenDict, close_on_error
+from xarray.core.variable import Variable
+
+from wradlib.io import radolan
+
+RADOLAN_LOCK = SerializableLock()
+
+
+class RadolanArrayWrapper(BackendArray):
+    """Wraps array of RADOLAN data."""
+
+    def __init__(self, datastore, array):
+        self.datastore = datastore
+        self.shape = array.shape
+        self.dtype = array.dtype
+
+    def _getitem(self, key):
+        return self.datastore.ds.data[key]
+
+    def __getitem__(self, key):
+        return explicit_indexing_adapter(
+            key,
+            self.shape,
+            IndexingSupport.BASIC,
+            self._getitem,
+        )
+
+
+class RadolanDataStore(AbstractDataStore):
+    """Implements ``xarray.AbstractDataStore`` read-only API for a RADOLAN files."""
+
+    def __init__(self, filename_or_obj, lock=None, fillmissing=False, copy=False):
+        if lock is None:
+            lock = RADOLAN_LOCK
+        self.lock = ensure_lock(lock)
+
+        if isinstance(filename_or_obj, str):
+            manager = CachingFileManager(
+                radolan._radolan_file,
+                filename_or_obj,
+                lock=lock,
+                kwargs=dict(fillmissing=fillmissing, copy=copy),
+            )
+        else:
+            if isinstance(filename_or_obj, bytes):
+                filename_or_obj = io.BytesIO(filename_or_obj)
+            dataset = radolan._radolan_file(
+                filename_or_obj, fillmissing=fillmissing, copy=copy
+            )
+            manager = DummyFileManager(dataset)
+
+        self._manager = manager
+        self._filename = self.ds.filename
+
+    def _acquire(self, needs_lock=True):
+        with self._manager.acquire_context(needs_lock) as ds:
+            return ds
+
+    @property
+    def ds(self):
+        return self._acquire()
+
+    def open_store_variable(self, name, var):
+        encoding = dict(source=self._filename)
+        if isinstance(var.data, np.ndarray):
+            data = var.data
+        else:
+            data = LazilyOuterIndexedArray(RadolanArrayWrapper(self, var.data))
+        return Variable(var.dimensions, data, var.attributes, encoding)
+
+    def get_variables(self):
+        return FrozenDict(
+            (k, self.open_store_variable(k, v)) for k, v in self.ds.variables.items()
+        )
+
+    def get_attrs(self):
+        return Frozen(self.ds.attributes)
+
+    def get_dimensions(self):
+        return Frozen(self.ds.dimensions)
+
+    def get_encoding(self):
+        dims = self.get_dimensions()
+        encoding = {"unlimited_dims": {k for k, v in dims.items() if v is None}}
+        return encoding
+
+    def close(self, **kwargs):
+        self._manager.close(**kwargs)
+
+
+class RadolanBackendEntrypoint(BackendEntrypoint):
+    """Xarray BackendEntrypoint for RADOLAN data."""
+
+    def open_dataset(
+        self,
+        filename_or_obj,
+        *,
+        mask_and_scale=True,
+        decode_times=True,
+        concat_characters=True,
+        decode_coords=True,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        lock=None,
+        fillmissing=False,
+        copy=False,
+    ):
+
+        store = RadolanDataStore(
+            filename_or_obj,
+            lock=lock,
+            fillmissing=fillmissing,
+            copy=copy,
+        )
+        store_entrypoint = StoreBackendEntrypoint()
+        with close_on_error(store):
+            ds = store_entrypoint.open_dataset(
+                store,
+                mask_and_scale=mask_and_scale,
+                decode_times=decode_times,
+                concat_characters=concat_characters,
+                decode_coords=decode_coords,
+                drop_variables=drop_variables,
+                use_cftime=use_cftime,
+                decode_timedelta=decode_timedelta,
+            )
+        return ds

--- a/wradlib/io/backends.py
+++ b/wradlib/io/backends.py
@@ -27,11 +27,7 @@ from xarray.backends.common import AbstractDataStore, BackendArray, BackendEntry
 from xarray.backends.file_manager import CachingFileManager, DummyFileManager
 from xarray.backends.locks import SerializableLock, ensure_lock
 from xarray.backends.store import StoreBackendEntrypoint
-from xarray.core.indexing import (
-    IndexingSupport,
-    LazilyOuterIndexedArray,
-    explicit_indexing_adapter,
-)
+from xarray.core import indexing
 from xarray.core.utils import Frozen, FrozenDict, close_on_error
 from xarray.core.variable import Variable
 
@@ -52,10 +48,10 @@ class RadolanArrayWrapper(BackendArray):
         return self.datastore.ds.data[key]
 
     def __getitem__(self, key):
-        return explicit_indexing_adapter(
+        return indexing.explicit_indexing_adapter(
             key,
             self.shape,
-            IndexingSupport.BASIC,
+            indexing.IndexingSupport.BASIC,
             self._getitem,
         )
 
@@ -99,7 +95,7 @@ class RadolanDataStore(AbstractDataStore):
         if isinstance(var.data, np.ndarray):
             data = var.data
         else:
-            data = LazilyOuterIndexedArray(RadolanArrayWrapper(self, var.data))
+            data = indexing.LazilyOuterIndexedArray(RadolanArrayWrapper(self, var.data))
         return Variable(var.dimensions, data, var.attributes, encoding)
 
     def get_variables(self):

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -73,6 +73,7 @@ Warning
    {}
 """
 __all__ = [
+    "WradlibVariable",
     "XRadVol",
     "CfRadial",
     "OdimH5",
@@ -117,6 +118,46 @@ except ImportError:
             "instead."
         )
         return val
+
+
+def raise_on_missing_xarray_backend():
+    """Raise errors if functionality isn't available."""
+    if LooseVersion(xr.__version__) < LooseVersion("0.17.0"):
+        raise ImportError(
+            f"'xarray>=0.17.0' needed to perform this operation. "
+            f"'xarray={xr.__version__}'  available.",
+        )
+    else:
+        xarray_backend_api = os.environ.get("XARRAY_BACKEND_API", None)
+        if xarray_backend_api is None:
+            os.environ["XARRAY_BACKEND_API"] = "v2"
+        else:
+            if xarray_backend_api != "v2":
+                raise ValueError(
+                    "Environment variable `XARRAY_BACKEND_API='v2'` needed to perform "
+                    "this operation. "
+                )
+
+
+class WradlibVariable(object):
+    """Minimal variable wrapper."""
+
+    def __init__(self, dims, data, attrs):
+        self._dimensions = dims
+        self._data = data
+        self._attrs = attrs
+
+    @property
+    def dimensions(self):
+        return self._dimensions
+
+    @property
+    def data(self):
+        return self._data
+
+    @property
+    def attributes(self):
+        return self._attrs
 
 
 @deprecation.deprecated(

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2020, wradlib developers.
+# Copyright (c) 2011-2021, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 
@@ -1175,14 +1175,7 @@ def _open_mfmoments(
         getattr_ = getattr
 
     if single_file:
-        datasets = [
-            open_(
-                store(ds0, group=p.ncpath, lock=lock, autoclose=None),
-                engine=engine,
-                **open_kwargs,
-            )
-            for p in moments
-        ]
+        datasets = [open_(store(ds0, group=p.ncpath)) for p in moments]
     else:
         fileid = []
         for p in moments:
@@ -1192,16 +1185,7 @@ def _open_mfmoments(
                 p = p.ncfile
             fileid.append(p)
         datasets = [
-            open_(
-                store(
-                    f,
-                    group=p.ncpath,
-                    lock=lock,
-                    autoclose=None,
-                ),
-                engine=engine,
-                **open_kwargs,
-            )
+            open_(store(f, group=p.ncpath), **open_kwargs)
             for f, p in zip(fileid, moments)
         ]
     if LooseVersion(xr.__version__) <= LooseVersion("0.16.2"):
@@ -2067,11 +2051,8 @@ class XRadSweepGamic(XRadSweep):
         else:
             ds0 = self.ncfile
 
-        ds = xr.open_dataset(
-            store(ds0, self.ncpath, lock=None, autoclose=None),
-            engine=self.engine,
-            chunks=self.chunks,
-        )
+        ds = xr.open_dataset(store(ds0, self.ncpath), chunks=self.chunks)
+
         ds = ds.drop_vars("ray_header", errors="ignore")
         for mom in self:
             mom_name = mom.ncpath.split("/")[-1]

--- a/wradlib/tests/__init__.py
+++ b/wradlib/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2020, wradlib developers.
+# Copyright (c) 2011-2021, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 # flake8: noqa
 """
@@ -6,9 +6,15 @@ wradlib_tests
 =============
 
 """
+import contextlib
+import io
 import os
+from distutils.version import LooseVersion
 
 import pytest
+from xarray import __version__ as xr_version
+
+from wradlib import util
 
 has_data = os.environ.get("WRADLIB_DATA", False)
 requires_data = pytest.mark.skipif(
@@ -21,3 +27,22 @@ requires_secrets = pytest.mark.skipif(
     not has_secrets,
     reason="requires 'WRADLIB_EARTHDATA_USER' and 'WRADLIB_EARTHDATA_PASS' environment variable set.",
 )
+
+requires_xarray_backend_api = pytest.mark.skipif(
+    (LooseVersion(xr_version) < LooseVersion("0.17.0")),
+    reason="requires xarray version 0.17.0",
+)
+
+
+@contextlib.contextmanager
+def get_wradlib_data_file(file, file_or_filelike):
+    datafile = util.get_wradlib_data_file(file)
+    if file_or_filelike == "filelike":
+        _open = open
+        if datafile[-3:] == ".gz":
+            gzip = util.import_optional("gzip")
+            _open = gzip.open
+        with _open(datafile, mode="r+b") as f:
+            yield io.BytesIO(f.read())
+    else:
+        yield datafile

--- a/wradlib/tests/test_io_backends.py
+++ b/wradlib/tests/test_io_backends.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2011-2021, wradlib developers.
+# Distributed under the MIT License. See LICENSE.txt for more info.
+
+import os
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from wradlib import io
+
+from . import get_wradlib_data_file, requires_data, requires_xarray_backend_api
+
+
+@pytest.fixture(params=["file", "filelike"])
+def file_or_filelike(request):
+    return request.param
+
+
+@pytest.fixture(params=["v1", "v2"])
+def xarray_backend_api(request, monkeypatch):
+    monkeypatch.setenv("XARRAY_BACKEND_API", request.param)
+    return request.param
+
+
+@requires_data
+@requires_xarray_backend_api
+def test_radolan_backend(file_or_filelike, xarray_backend_api):
+    filename = "radolan/misc/raa01-rw_10000-1408030950-dwd---bin.gz"
+    test_attrs = {
+        "radarlocations": [
+            "boo",
+            "ros",
+            "emd",
+            "hnr",
+            "pro",
+            "ess",
+            "asd",
+            "neu",
+            "nhb",
+            "oft",
+            "tur",
+            "isn",
+            "fbg",
+            "mem",
+        ],
+        "radolanversion": "2.13.1",
+        "radarid": "10000",
+    }
+    with get_wradlib_data_file(filename, file_or_filelike) as rwfile:
+        if xarray_backend_api == "v1":
+            with pytest.raises(ValueError):
+                with io.radolan.open_radolan_dataset(rwfile, engine="radolan") as ds:
+                    pass
+        else:
+            data, meta = io.read_radolan_composite(rwfile)
+            data[data == -9999.0] = np.nan
+            with xr.open_dataset(rwfile, engine="radolan") as ds:
+                assert ds["RW"].encoding["dtype"] == np.uint16
+                if file_or_filelike == "file":
+                    assert ds["RW"].encoding["source"] == os.path.abspath(rwfile)
+                else:
+                    assert ds["RW"].encoding["source"] == "None"
+                assert ds.attrs == test_attrs
+                assert ds["RW"].shape == (900, 900)
+                np.testing.assert_almost_equal(
+                    ds["RW"].values,
+                    (data * 3600.0 / meta["intervalseconds"]),
+                    decimal=5,
+                )

--- a/wradlib/tests/test_io_odim.py
+++ b/wradlib/tests/test_io_odim.py
@@ -3,7 +3,6 @@
 
 import contextlib
 import gc
-import io as sio
 
 import h5py
 import numpy as np
@@ -12,7 +11,12 @@ import xarray as xr
 
 from wradlib import io, util
 
-from . import has_data, requires_data
+from . import get_wradlib_data_file, has_data, requires_data
+
+
+@pytest.fixture(params=["file", "filelike"])
+def file_or_filelike(request):
+    return request.param
 
 
 def create_a1gate(i):
@@ -248,25 +252,6 @@ def create_coords(i, nrays=360):
         }
     )
     return ds
-
-
-@pytest.fixture(params=["file", "filelike"])
-def file_or_filelike(request):
-    return request.param
-
-
-@contextlib.contextmanager
-def get_wradlib_data_file(file, file_or_filelike):
-    datafile = util.get_wradlib_data_file(file)
-    if file_or_filelike == "filelike":
-        _open = open
-        if datafile[-3:] == ".gz":
-            gzip = util.import_optional("gzip")
-            _open = gzip.open
-        with _open(datafile, mode="r+b") as f:
-            yield sio.BytesIO(f.read())
-    else:
-        yield datafile
 
 
 @contextlib.contextmanager

--- a/wradlib/tests/test_io_odim.py
+++ b/wradlib/tests/test_io_odim.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2011-2020, wradlib developers.
+# Copyright (c) 2011-2021, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import contextlib


### PR DESCRIPTION
This improves the radolan reader slightly and adds a xarray backend for radolan.

RADOLAN data can be read directly into an xarray dataset like following:

```python
ds = wrl.io.open_radolan_dataset(filename_or_obj)
ds = wrl.io.open_radolan_mfdataset(flist)

ds = xr.open_dataset(filename_or_obj, engine="radolan")
ds = xr.open_mfdataset(flist, engine="radolan")
```
Please note, that for this to work, `xarray>=0.17.0` is needed. For the `mfdataset` functions `dask` is needed too.

Update: This PR also aligns store/open_dataset to the new backend handling
