### PR TITLE
replace np.floor in io.get_srtm function

### DIFF
--- a/wradlib/io/dem.py
+++ b/wradlib/io/dem.py
@@ -118,7 +118,7 @@ def get_srtm(extent, resolution=3, merge=True):
         Raster dataset containing elevation information
     """
 
-    extent = [int(np.floor(x)) for x in extent]
+    extent = [int(np.floor(abs(x)) * np.sign(x)) for x in extent]
     lonmin, lonmax, latmin, latmax = extent
 
     filelist = []


### PR DESCRIPTION
This is in reference to issue #484. Here's the modified wradlib/io/dem.py script to allow terrain computation and SRTM file downloads for site coordinates in NW region.