### PR TITLE
FIX: _FillValues and GAMIC dynamic range

### DIFF
--- a/wradlib/io/hdf.py
+++ b/wradlib/io/hdf.py
@@ -250,10 +250,12 @@ def read_gamic_scan(scan, scan_type, wanted_moments):
                 if LooseVersion(h5py.__version__) < LooseVersion("3.0.0"):
                     bin_format = bin_format.decode()
                 if bin_format == "UV8":
-                    div = 256.0
+                    div = 254
                 else:
-                    div = 65536.0
-                mdata = dyn_range_min + mdata * (dyn_range_max - dyn_range_min) / div
+                    div = 65534
+                mdata = (
+                    dyn_range_min + (mdata - 1) * (dyn_range_max - dyn_range_min) / div
+                )
 
                 if scan_type == "PVOL":
                     # rotate accordingly

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -989,16 +989,22 @@ def _reindex_angle(ds, sweep, force=False):
         # todo: check if assumption that beam center points to
         #       multiples of res/2. is correct in any case
         azr = np.arange(res / 2.0, new_rays * res, res, dtype=diff.dtype)
+        fill_value = {
+            k: v._FillValue.astype(v.dtype)
+            for k, v in ds.items()
+            if hasattr(v, "_FillValue")
+        }
+        # todo: make tolerance parameterizable
         ds = ds.reindex(
             {dimname: azr},
             method="nearest",
-            tolerance=res / 4.0,
-            # fill_value=xr.core.dtypes.NA,
+            tolerance=res / 2.5,
+            fill_value=fill_value,
         )
         # check other coordinates
         # check secondary angle coordinate (no nan)
         # set nan values to reasonable median
-        if np.count_nonzero(np.isnan(ds[secname])):
+        if hasattr(ds, secname) and np.count_nonzero(np.isnan(ds[secname])):
             ds[secname] = ds[secname].fillna(ds[secname].median(skipna=True))
         # todo: rtime is also affected, might need to be treated accordingly
 

--- a/wradlib/tests/test_io_odim.py
+++ b/wradlib/tests/test_io_odim.py
@@ -223,11 +223,16 @@ def create_dataset(i, type=None, nrays=360):
     attrs = {}
     attrs["scale_factor"] = what["gain"]
     attrs["add_offset"] = what["offset"]
-    if type == "GAMIC":
-        attrs["add_offset"] -= 0.5
     attrs["_FillValue"] = what["nodata"]
-    attrs["coordinates"] = b"elevation azimuth range"
     attrs["_Undetect"] = what["undetect"]
+
+    if type == "GAMIC":
+        attrs["add_offset"] -= 0.5 + 127.5 / 254
+        attrs["scale_factor"] = 127.5 / 254
+        attrs["_FillValue"] = what["undetect"]
+        attrs["_Undetect"] = what["undetect"]
+
+    attrs["coordinates"] = b"elevation azimuth range"
     ds = xr.Dataset({"DBZH": (["azimuth", "range"], create_data(nrays=nrays), attrs)})
     return ds
 


### PR DESCRIPTION
This PR fixes two issues:

1. apply correct _FIllValues and lessen tolerance when reindexing odim/gamic arrays
    This fixes a bug where data types are wrongly promoted to `float64` when reindexing of arrays is needed. Additionally it fixes problems where reindexing introduces empty rays because of tolerance.
2. correctly unpack gamic hdf5 data
    This fixes a longstanding issue whith unpacking GAMIC hdf5 data . The behaviour in wradlib changed from
    value = **binvalue / 256** * (dyn_range_max - dyn_range_min) + dyn_range_min (UV8)
    value = **binvalue / 65536** * (dyn_range_max - dyn_range_min) + dyn_range_min (UV16)

    to 
    value = **(binvalue - 1) / 254** * (dyn_range_max - dyn_range_min) + dyn_range_min (UV8)
    value = **(binvalue - 1) / 65534** * (dyn_range_max - dyn_range_min) + dyn_range_min (UV16)

    in `read_gamic_hdf`. 
    
    In `open_odim` the behavour changed from:
    
    value = **binvalue / 255** * (dyn_range_max - dyn_range_min) + dyn_range_min (UV8)
    value = **binvalue / 65535** * (dyn_range_max - dyn_range_min) + dyn_range_min (UV16)  

    to  
    value = **(binvalue - 1) / 254** * (dyn_range_max - dyn_range_min) + dyn_range_min (UV8)
    value = **(binvalue - 1) / 65534** * (dyn_range_max - dyn_range_min) + dyn_range_min (UV16)  
    
    This means roughly a difference of 0.5 dBZ and 0.003 dBZ (in case of Reflectivity). For the odim-reader also _FillValue and undetect is set to the correct values.



    
    
   
