### PR TITLE
ENH: add CfRadial, ODIM and GAMIC xarray backends

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2020, wradlib developers.
+# Copyright (c) 2011-2021, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """wradlib - An Open Source Library for Weather Radar Data Processing
@@ -193,7 +193,11 @@ def setup_package():
         packages=find_packages(),
         entry_points={
             "xarray.backends": [
-                "radolan = wradlib.io.backends:RadolanBackendEntrypoint"
+                "cfradial1 = wradlib.io.backends:CfRadial1BackendEntrypoint",
+                "cfradial2 = wradlib.io.backends:CfRadial2BackendEntrypoint",
+                "gamic = wradlib.io.backends:GamicBackendEntrypoint",
+                "odim = wradlib.io.backends:OdimBackendEntrypoint",
+                "radolan = wradlib.io.backends:RadolanBackendEntrypoint",
             ]
         },
     )

--- a/wradlib/io/backends.py
+++ b/wradlib/io/backends.py
@@ -6,7 +6,7 @@
 wradlib backends for xarray
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Reading radar data into xarray Datasets using ``xarray.open_dataset``
-and ``xarray.open_mfdataset``
+and ``xarray.open_mfdataset``.
 
 .. autosummary::
    :nosignatures:
@@ -15,25 +15,61 @@ and ``xarray.open_mfdataset``
    {}
 """
 __all__ = [
+    "CfRadial1BackendEntrypoint",
+    "CfRadial2BackendEntrypoint",
+    "GamicBackendEntrypoint",
+    "OdimBackendEntrypoint",
     "RadolanBackendEntrypoint",
 ]
 
 __doc__ = __doc__.format("\n   ".join(__all__))
 
 import io
+import os
+from distutils.version import LooseVersion
 
+import h5netcdf
 import numpy as np
-from xarray.backends.common import AbstractDataStore, BackendArray, BackendEntrypoint
+from xarray import Dataset
+from xarray.backends import NetCDF4DataStore
+from xarray.backends.common import (
+    AbstractDataStore,
+    BackendArray,
+    BackendEntrypoint,
+    find_root_and_group,
+)
 from xarray.backends.file_manager import CachingFileManager, DummyFileManager
-from xarray.backends.locks import SerializableLock, ensure_lock
+from xarray.backends.locks import (
+    SerializableLock,
+    combine_locks,
+    ensure_lock,
+    get_write_lock,
+)
 from xarray.backends.store import StoreBackendEntrypoint
 from xarray.core import indexing
-from xarray.core.utils import Frozen, FrozenDict, close_on_error
+from xarray.core.utils import (
+    Frozen,
+    FrozenDict,
+    close_on_error,
+    is_remote_uri,
+    read_magic_number,
+)
 from xarray.core.variable import Variable
 
-from wradlib.io import radolan
+from wradlib.io.radolan import _radolan_file
+from wradlib.io.xarray import (
+    _assign_data_radial,
+    _assign_data_radial2,
+    _fix_angle,
+    _GamicH5NetCDFMetadata,
+    _get_gamic_variable_name_and_attrs,
+    _get_odim_variable_name_and_attrs,
+    _OdimH5NetCDFMetadata,
+    _reindex_angle,
+)
 
 RADOLAN_LOCK = SerializableLock()
+HDF5_LOCK = SerializableLock()
 
 
 class RadolanArrayWrapper(BackendArray):
@@ -66,7 +102,7 @@ class RadolanDataStore(AbstractDataStore):
 
         if isinstance(filename_or_obj, str):
             manager = CachingFileManager(
-                radolan._radolan_file,
+                _radolan_file,
                 filename_or_obj,
                 lock=lock,
                 kwargs=dict(fillmissing=fillmissing, copy=copy),
@@ -74,9 +110,7 @@ class RadolanDataStore(AbstractDataStore):
         else:
             if isinstance(filename_or_obj, bytes):
                 filename_or_obj = io.BytesIO(filename_or_obj)
-            dataset = radolan._radolan_file(
-                filename_or_obj, fillmissing=fillmissing, copy=copy
-            )
+            dataset = _radolan_file(filename_or_obj, fillmissing=fillmissing, copy=copy)
             manager = DummyFileManager(dataset)
 
         self._manager = manager
@@ -155,4 +189,676 @@ class RadolanBackendEntrypoint(BackendEntrypoint):
                 use_cftime=use_cftime,
                 decode_timedelta=decode_timedelta,
             )
+        return ds
+
+
+class H5NetCDFArrayWrapper(BackendArray):
+    """H5NetCDFArrayWrapper
+
+    adapted from https://github.com/pydata/xarray/
+    """
+
+    __slots__ = ("datastore", "dtype", "shape", "variable_name")
+
+    def __init__(self, variable_name, datastore):
+        self.datastore = datastore
+        self.variable_name = variable_name
+
+        array = self.get_array()
+        self.shape = array.shape
+
+        dtype = array.dtype
+        if dtype is str:
+            # use object dtype because that's the only way in numpy to
+            # represent variable length strings; it also prevents automatic
+            # string concatenation via conventions.decode_cf_variable
+            dtype = np.dtype("O")
+        self.dtype = dtype
+
+    def __setitem__(self, key, value):
+        with self.datastore.lock:
+            data = self.get_array(needs_lock=False)
+            data[key] = value
+            if self.datastore.autoclose:
+                self.datastore.close(needs_lock=False)
+
+    def get_array(self, needs_lock=True):
+        ds = self.datastore._acquire(needs_lock)
+        variable = ds.variables[self.variable_name]
+        return variable
+
+    def __getitem__(self, key):
+        return indexing.explicit_indexing_adapter(
+            key, self.shape, indexing.IndexingSupport.OUTER_1VECTOR, self._getitem
+        )
+
+    def _getitem(self, key):
+        # h5py requires using lists for fancy indexing:
+        # https://github.com/h5py/h5py/issues/992
+        key = tuple(list(k) if isinstance(k, np.ndarray) else k for k in key)
+        with self.datastore.lock:
+            array = self.get_array(needs_lock=False)
+            return array[key]
+
+
+def _get_encoding(self, var):
+    """get encoding from h5netcdf Variable
+
+    adapted from https://github.com/pydata/xarray/
+    """
+    import h5py
+
+    # netCDF4 specific encoding
+    encoding = {
+        "chunksizes": var.chunks,
+        "fletcher32": var.fletcher32,
+        "shuffle": var.shuffle,
+    }
+
+    # Convert h5py-style compression options to NetCDF4-Python
+    # style, if possible
+    if var.compression == "gzip":
+        encoding["zlib"] = True
+        encoding["complevel"] = var.compression_opts
+    elif var.compression is not None:
+        encoding["compression"] = var.compression
+        encoding["compression_opts"] = var.compression_opts
+
+    # save source so __repr__ can detect if it's local or not
+    encoding["source"] = self._filename
+    encoding["original_shape"] = var.shape
+
+    vlen_dtype = h5py.check_dtype(vlen=var.dtype)
+    if vlen_dtype is str:
+        encoding["dtype"] = str
+    elif vlen_dtype is not None:  # pragma: no cover
+        # xarray doesn't support writing arbitrary vlen dtypes yet.
+        pass
+    else:
+        encoding["dtype"] = var.dtype
+    return encoding
+
+
+class OdimSubStore(AbstractDataStore):
+    """Store for reading ODIM data-moments via h5netcdf."""
+
+    def __init__(
+        self,
+        store,
+        group=None,
+        lock=HDF5_LOCK,
+    ):
+
+        if not isinstance(store, OdimStore):
+            raise TypeError(
+                f"Wrong type {type(store)} for parameter store, "
+                f"expected 'OdimStore'."
+            )
+
+        self._manager = store._manager
+        self._group = group
+        self._filename = store.filename
+        self.is_remote = is_remote_uri(self._filename)
+        self.lock = ensure_lock(lock)
+
+    @property
+    def root(self):
+        with self._manager.acquire_context(False) as root:
+            return _OdimH5NetCDFMetadata(root, self._group.lstrip("/"))
+
+    def _acquire(self, needs_lock=True):
+        with self._manager.acquire_context(needs_lock) as root:
+            ds = root[self._group.lstrip("/")]
+        return ds
+
+    @property
+    def ds(self):
+        return self._acquire()
+
+    def open_store_variable(self, name, var):
+
+        dimensions = self.root.get_variable_dimensions(var.dimensions)
+        data = indexing.LazilyOuterIndexedArray(H5NetCDFArrayWrapper(name, self))
+        encoding = _get_encoding(self, var)
+        encoding["group"] = self._group
+        name, attrs = _get_odim_variable_name_and_attrs(name, self.root.what)
+
+        return name, Variable(dimensions, data, attrs, encoding)
+
+    def open_store_coordinates(self):
+        return self.root.coordinates
+
+    def get_variables(self):
+        return FrozenDict(
+            (k1, v1)
+            for k1, v1 in {
+                **dict(
+                    [
+                        self.open_store_variable(k, v)
+                        for k, v in self.ds.variables.items()
+                    ]
+                ),
+            }.items()
+        )
+
+
+class OdimStore(AbstractDataStore):
+    """Store for reading ODIM dataset groups via h5netcdf."""
+
+    def __init__(self, manager, group=None, lock=HDF5_LOCK):
+
+        if isinstance(manager, (h5netcdf.File, h5netcdf.Group)):
+            if group is None:
+                root, group = find_root_and_group(manager)
+            else:
+                if not type(manager) is h5netcdf.File:
+                    raise ValueError(
+                        "must supply a h5netcdf.File if the group "
+                        "argument is provided"
+                    )
+                root = manager
+            manager = DummyFileManager(root)
+
+        self._manager = manager
+        self._group = group
+        self._filename = self.filename
+        self.is_remote = is_remote_uri(self._filename)
+        self.lock = ensure_lock(lock)
+        self._substore = None
+        self._need_time_recalc = False
+
+    @classmethod
+    def open(
+        cls,
+        filename,
+        mode="r",
+        format=None,
+        group=None,
+        lock=None,
+        invalid_netcdf=None,
+        phony_dims=None,
+        decode_vlen_strings=True,
+    ):
+        if isinstance(filename, bytes):
+            raise ValueError(
+                "can't open netCDF4/HDF5 as bytes "
+                "try passing a path or file-like object"
+            )
+        elif isinstance(filename, io.IOBase):
+            magic_number = read_magic_number(filename)
+            if not magic_number.startswith(b"\211HDF\r\n\032\n"):
+                raise ValueError(
+                    f"{magic_number} is not the signature of a valid netCDF file"
+                )
+
+        if format not in [None, "NETCDF4"]:
+            raise ValueError("invalid format for h5netcdf backend")
+
+        kwargs = {"invalid_netcdf": invalid_netcdf}
+        if phony_dims is not None:
+            if LooseVersion(h5netcdf.__version__) >= LooseVersion("0.8.0"):
+                kwargs["phony_dims"] = phony_dims
+            else:
+                raise ValueError(
+                    "h5netcdf backend keyword argument 'phony_dims' needs "
+                    "h5netcdf >= 0.8.0."
+                )
+        if LooseVersion(h5netcdf.__version__) >= LooseVersion(
+            "0.10.0"
+        ) and LooseVersion(h5netcdf.core.h5py.__version__) >= LooseVersion("3.0.0"):
+            kwargs["decode_vlen_strings"] = decode_vlen_strings
+
+        if lock is None:
+            if mode == "r":
+                lock = HDF5_LOCK
+            else:
+                lock = combine_locks([HDF5_LOCK, get_write_lock(filename)])
+
+        manager = CachingFileManager(h5netcdf.File, filename, mode=mode, kwargs=kwargs)
+        return cls(manager, group=group, lock=lock)
+
+    @property
+    def filename(self):
+        with self._manager.acquire_context(False) as root:
+            return root.filename
+
+    @property
+    def substore(self):
+        if self._substore is None:
+            with self._manager.acquire_context(False) as root:
+                subgroups = [
+                    "/".join([self._group, k])
+                    for k in root[self._group].groups
+                    if "data" in k
+                ]
+                substore = []
+                substore.extend(
+                    [
+                        OdimSubStore(
+                            self,
+                            group=group,
+                            lock=self.lock,
+                        )
+                        for group in subgroups
+                    ]
+                )
+                self._substore = substore
+
+        return self._substore
+
+    def open_store_coordinates(self):
+        return self.substore[0].open_store_coordinates()
+
+    def get_variables(self):
+        return FrozenDict(
+            (k1, v1)
+            for k1, v1 in {
+                **dict(
+                    [
+                        (k, v)
+                        for substore in self.substore
+                        for k, v in substore.get_variables().items()
+                    ]
+                ),
+                **self.open_store_coordinates(),
+            }.items()
+        )
+
+    def get_attrs(self):
+        dim, angle = self.substore[0].root.fixed_dim_and_angle
+        attributes = {}
+        attributes["fixed_angle"] = angle.item()
+        return FrozenDict(attributes)
+
+
+class OdimBackendEntrypoint(BackendEntrypoint):
+    def guess_can_open(self, store_spec):
+        try:
+            return read_magic_number(store_spec).startswith(b"\211HDF\r\n\032\n")
+        except TypeError:
+            pass
+
+        try:
+            _, ext = os.path.splitext(store_spec)
+        except TypeError:
+            return False
+
+        return ext in {".hdf5", ".h5"}
+
+    def open_dataset(
+        self,
+        filename_or_obj,
+        *,
+        mask_and_scale=True,
+        decode_times=None,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        format=None,
+        group="dataset1",
+        lock=None,
+        invalid_netcdf=None,
+        phony_dims="access",
+        decode_vlen_strings=True,
+        keep_elevation=False,
+        keep_azimuth=False,
+    ):
+
+        if isinstance(filename_or_obj, io.IOBase):
+            filename_or_obj.seek(0)
+
+        store = OdimStore.open(
+            filename_or_obj,
+            format=format,
+            group=group,
+            lock=lock,
+            invalid_netcdf=invalid_netcdf,
+            phony_dims=phony_dims,
+            decode_vlen_strings=decode_vlen_strings,
+        )
+
+        store_entrypoint = StoreBackendEntrypoint()
+
+        ds = store_entrypoint.open_dataset(
+            store,
+            mask_and_scale=mask_and_scale,
+            decode_times=decode_times,
+            concat_characters=concat_characters,
+            decode_coords=decode_coords,
+            drop_variables=drop_variables,
+            use_cftime=use_cftime,
+            decode_timedelta=decode_timedelta,
+        )
+
+        if decode_coords:
+            ds = ds.pipe(_reindex_angle, store=store)
+
+        if not keep_azimuth:
+            if ds.azimuth.dims[0] == "elevation":
+                ds = ds.assign_coords({"azimuth": ds.azimuth.pipe(_fix_angle)})
+        if not keep_elevation:
+            if ds.elevation.dims[0] == "azimuth":
+                ds = ds.assign_coords({"elevation": ds.elevation.pipe(_fix_angle)})
+
+        return ds
+
+
+# todo: clean-up, move all possible processing into .xarray
+class GamicStore(AbstractDataStore):
+    """Store for reading ODIM dataset groups via h5netcdf."""
+
+    def __init__(self, manager, group=None, lock=HDF5_LOCK):
+
+        if isinstance(manager, (h5netcdf.File, h5netcdf.Group)):
+            if group is None:
+                root, group = find_root_and_group(manager)
+            else:
+                if not type(manager) is h5netcdf.File:
+                    raise ValueError(
+                        "must supply a h5netcdf.File if the group "
+                        "argument is provided"
+                    )
+                root = manager
+            manager = DummyFileManager(root)
+
+        self._manager = manager
+        self._group = group
+        self._filename = self.filename
+        self.is_remote = is_remote_uri(self._filename)
+        self.lock = ensure_lock(lock)
+        self._need_time_recalc = False
+
+    @classmethod
+    def open(
+        cls,
+        filename,
+        mode="r",
+        format=None,
+        group=None,
+        lock=None,
+        invalid_netcdf=None,
+        phony_dims=None,
+        decode_vlen_strings=True,
+    ):
+        if isinstance(filename, bytes):
+            raise ValueError(
+                "can't open netCDF4/HDF5 as bytes "
+                "try passing a path or file-like object"
+            )
+        elif isinstance(filename, io.IOBase):
+            magic_number = read_magic_number(filename)
+            if not magic_number.startswith(b"\211HDF\r\n\032\n"):
+                raise ValueError(
+                    f"{magic_number} is not the signature of a valid netCDF file"
+                )
+
+        if format not in [None, "NETCDF4"]:
+            raise ValueError("invalid format for h5netcdf backend")
+
+        kwargs = {"invalid_netcdf": invalid_netcdf}
+        if phony_dims is not None:
+            if LooseVersion(h5netcdf.__version__) >= LooseVersion("0.8.0"):
+                kwargs["phony_dims"] = phony_dims
+            else:
+                raise ValueError(
+                    "h5netcdf backend keyword argument 'phony_dims' needs "
+                    "h5netcdf >= 0.8.0."
+                )
+        if LooseVersion(h5netcdf.__version__) >= LooseVersion(
+            "0.10.0"
+        ) and LooseVersion(h5netcdf.core.h5py.__version__) >= LooseVersion("3.0.0"):
+            kwargs["decode_vlen_strings"] = decode_vlen_strings
+
+        if lock is None:
+            if mode == "r":
+                lock = HDF5_LOCK
+            else:
+                lock = combine_locks([HDF5_LOCK, get_write_lock(filename)])
+
+        manager = CachingFileManager(h5netcdf.File, filename, mode=mode, kwargs=kwargs)
+        return cls(manager, group=group, lock=lock)
+
+    @property
+    def filename(self):
+        with self._manager.acquire_context(False) as root:
+            return root.filename
+
+    @property
+    def root(self):
+        with self._manager.acquire_context(False) as root:
+            return _GamicH5NetCDFMetadata(root, self._group.lstrip("/"))
+
+    def _acquire(self, needs_lock=True):
+        with self._manager.acquire_context(needs_lock) as root:
+            ds = root[self._group.lstrip("/")]
+        return ds
+
+    @property
+    def ds(self):
+        return self._acquire()
+
+    def open_store_variable(self, name, var):
+        dimensions = self.root.get_variable_dimensions(var.dimensions)
+        data = indexing.LazilyOuterIndexedArray(H5NetCDFArrayWrapper(name, self))
+        encoding = _get_encoding(self, var)
+        encoding["group"] = self._group
+        # cheat attributes
+        if "moment" in name:
+            name, attrs = _get_gamic_variable_name_and_attrs({**var.attrs}, var.dtype)
+        elif "ray_header" in name:
+            return self.root.coordinates(dimensions, data, encoding)
+        else:
+            return {}
+        return {name: Variable(dimensions, data, attrs, encoding)}
+
+    def get_variables(self):
+        return FrozenDict(
+            (k1, v1)
+            for k, v in self.ds.variables.items()
+            for k1, v1 in {
+                **self.open_store_variable(k, v),
+            }.items()
+        )
+
+    def get_attrs(self):
+        dim, angle = self.root.fixed_dim_and_angle
+        attributes = {"fixed_angle": angle.item()}
+        return FrozenDict(attributes)
+
+
+class GamicBackendEntrypoint(BackendEntrypoint):
+    def guess_can_open(self, store_spec):
+        try:
+            return read_magic_number(store_spec).startswith(b"\211HDF\r\n\032\n")
+        except TypeError:
+            pass
+
+        try:
+            _, ext = os.path.splitext(store_spec)
+        except TypeError:
+            return False
+
+        return ext in {".mvol", ".h5"}
+
+    def open_dataset(
+        self,
+        filename_or_obj,
+        *,
+        mask_and_scale=True,
+        decode_times=None,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        format=None,
+        group="scan0",
+        lock=None,
+        invalid_netcdf=None,
+        phony_dims="access",
+        decode_vlen_strings=True,
+        keep_elevation=False,
+        keep_azimuth=False,
+    ):
+
+        if isinstance(filename_or_obj, io.IOBase):
+            filename_or_obj.seek(0)
+
+        store = GamicStore.open(
+            filename_or_obj,
+            format=format,
+            group=group,
+            lock=lock,
+            invalid_netcdf=invalid_netcdf,
+            phony_dims=phony_dims,
+            decode_vlen_strings=decode_vlen_strings,
+        )
+
+        store_entrypoint = StoreBackendEntrypoint()
+
+        ds = store_entrypoint.open_dataset(
+            store,
+            mask_and_scale=mask_and_scale,
+            decode_times=decode_times,
+            concat_characters=concat_characters,
+            decode_coords=decode_coords,
+            drop_variables=drop_variables,
+            use_cftime=use_cftime,
+            decode_timedelta=decode_timedelta,
+        )
+
+        ds = ds.sortby(list(ds.dims.keys())[0])
+
+        if decode_coords:
+            ds = ds.pipe(_reindex_angle, store=store)
+
+        if not keep_azimuth:
+            if ds.azimuth.dims[0] == "elevation":
+                ds = ds.assign_coords({"azimuth": ds.azimuth.pipe(_fix_angle)})
+        if not keep_elevation:
+            if ds.elevation.dims[0] == "azimuth":
+                ds = ds.assign_coords({"elevation": ds.elevation.pipe(_fix_angle)})
+
+        return ds
+
+
+class CfRadial1BackendEntrypoint(BackendEntrypoint):
+    def open_dataset(
+        self,
+        filename_or_obj,
+        *,
+        mask_and_scale=True,
+        decode_times=None,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        format=None,
+        group=None,
+        lock=None,
+    ):
+
+        store = NetCDF4DataStore.open(
+            filename_or_obj,
+            format=format,
+            group=None,
+            lock=lock,
+        )
+
+        store_entrypoint = StoreBackendEntrypoint()
+
+        ds = store_entrypoint.open_dataset(
+            store,
+            mask_and_scale=mask_and_scale,
+            decode_times=decode_times,
+            concat_characters=concat_characters,
+            decode_coords=decode_coords,
+            drop_variables=drop_variables,
+            use_cftime=use_cftime,
+            decode_timedelta=decode_timedelta,
+        )
+
+        if group is not None:
+            ds = _assign_data_radial(ds, sweep=group)[0]
+
+        return ds
+
+
+class CfRadial2BackendEntrypoint(BackendEntrypoint):
+    def open_dataset(
+        self,
+        filename_or_obj,
+        *,
+        mask_and_scale=True,
+        decode_times=False,
+        concat_characters=None,
+        decode_coords=None,
+        drop_variables=None,
+        use_cftime=None,
+        decode_timedelta=None,
+        format=None,
+        group=None,
+        lock=None,
+    ):
+
+        # 1. first open store with group=None
+        # to get the root group and select wanted sweep/group
+        # 2. open store with wanted sweep/group and merge with root
+
+        if isinstance(filename_or_obj, io.IOBase):
+            filename_or_obj.seek(0)
+
+        store = NetCDF4DataStore.open(
+            filename_or_obj,
+            format=format,
+            group=None,
+            lock=lock,
+        )
+
+        if group is not None:
+            variables = store.get_variables()
+            var = Dataset(variables)
+            site = {
+                key: loc
+                for key, loc in var.items()
+                if key in ["longitude", "latitude", "altitude"]
+            }
+            sweep_names = var.sweep_group_name.values
+            idx = np.where(sweep_names == group)
+            fixed_angle = var.sweep_fixed_angle.values[idx].item()
+
+            store.close()
+
+            if isinstance(filename_or_obj, io.IOBase):
+                filename_or_obj.seek(0)
+
+            store = NetCDF4DataStore.open(
+                filename_or_obj,
+                format=format,
+                group=group,
+                lock=lock,
+            )
+
+        store_entrypoint = StoreBackendEntrypoint()
+
+        ds = store_entrypoint.open_dataset(
+            store,
+            mask_and_scale=mask_and_scale,
+            decode_times=decode_times,
+            concat_characters=concat_characters,
+            decode_coords=decode_coords,
+            drop_variables=drop_variables,
+            use_cftime=use_cftime,
+            decode_timedelta=decode_timedelta,
+        )
+
+        if group is not None:
+            ds = ds.assign_coords(site)
+            ds.attrs["fixed_angle"] = fixed_angle
+            ds = _assign_data_radial2(ds)
+            ds = ds.sortby(list(ds.dims.keys())[0])
+
         return ds

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -8,33 +8,37 @@ Xarray powered Data I/O
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Reads data from netcdf-based CfRadial1, CfRadial2 and hdf5-based ODIM_H5 and
-other hdf5-flavours (GAMIC).
+other hdf5-flavours (GAMIC). More radar backends (sigmet, rainbow) will be
+implemented too.
 
-Writes data to CfRadial2 and ODIM_H5 files.
+Writes data to CfRadial2, ODIM_H5 or plain netCDF files.
 
 This reader implementation uses
 
+* `xarray <https://xarray.pydata.org/>`_,
 * `netcdf4 <https://unidata.github.io/netcdf4-python/>`_,
-* `h5py <https://www.h5py.org/>`_,
-* `h5netcdf <https://github.com/shoyer/h5netcdf>`_ and
-* `xarray <https://xarray.pydata.org/>`_.
+* `h5py <https://www.h5py.org/>`_ and
+* `h5netcdf <https://github.com/h5netcdf/h5netcdf>`_.
 
-Currently there are two different approaches.
+Currently there are three different approaches.
+
+The recommended approach makes use of the newly implemented ``xarray.backends.BackendEntrypoint``.
+For every radar source (CfRadial1, CfRadial2, GAMIC, ODIM) a specific backend is
+implemented in wradlib which returns an specific `sweep` as ``xarray.Dataset``.
+Convenience functions (eg. ``wradlib.io.open_radar_dataset``) are available to read
+volume data into shallow ``wradlib.io.RadarVolume``-wrapper.
+
+The following two approaches are not recommended and will be removed from the codebase
+in wradlib v 2.0.0.
 
 In the first approach the data is claimed using netcdf4-Dataset in a diskless
-non-persistent mode::
+non-persistent mode as follows::
 
-    nch = nc.Dataset(filename, diskless=True, persist=False)
+    vol = io.xarray.OdimH5(ncfile)
+    # or
+    vol = io.xarray.CfRadial(ncfile)
 
-Further the different netcdf/hdf groups are accessed via xarray open_dataset
-and the NetCDF4DataStore::
-
-    xr.open_dataset(xr.backends.NetCDF4DataStore(nch), mask_and_scale=True)
-
-For hdf5 data scaling/masking properties will be added to the datasets before
-decoding. For GAMIC data compound data will be read via h5py.
-
-The data structure holds one or many ['sweep_X'] xarray datasets, holding the
+The vol data structure holds one or many ['sweep_X'] xarray datasets, containing the
 sweep data. The root group xarray dataset which corresponds to the
 CfRadial2 root-group is available via the `.root`-object.
 
@@ -74,11 +78,23 @@ Warning
 """
 __all__ = [
     "WradlibVariable",
+    "RadarVolume",
+    "open_cfradial1_dataset",
+    "open_cfradial1_mfdataset",
+    "open_cfradial2_dataset",
+    "open_cfradial2_mfdataset",
+    "open_gamic_dataset",
+    "open_gamic_mfdataset",
+    "open_odim_dataset",
+    "open_odim_mfdataset",
+    "open_radar_dataset",
+    "open_radar_mfdataset",
     "XRadVol",
     "CfRadial",
     "OdimH5",
     "to_cfradial2",
     "to_odim",
+    "to_netcdf",
     "open_odim",
     "XRadSweep",
     "XRadMoment",
@@ -91,7 +107,9 @@ __doc__ = __doc__.format("\n   ".join(__all__))
 import collections
 import datetime as dt
 import glob
+import io
 import os
+import re
 import warnings
 from distutils.version import LooseVersion
 
@@ -103,6 +121,7 @@ import netCDF4 as nc
 import numpy as np
 import xarray as xr
 from xarray.backends.api import combine_by_coords
+from xarray.core.variable import Variable
 
 from wradlib import version
 from wradlib.georef import xarray
@@ -751,11 +770,11 @@ class OdimAccessor(object):
 
 
 def to_cfradial2(volume, filename, timestep=None):
-    """Save XRadVol/XRadVolume to CfRadial2.0 compliant file.
+    """Save RadarVolume/XRadVol/XRadVolume to CfRadial2.0 compliant file.
 
     Parameters
     ----------
-    volume : XRadVol/XRadVolume object
+    volume : RadarVolume/XRadVol/XRadVolume object
     filename : str
         output filename
     timestep : int
@@ -767,10 +786,15 @@ def to_cfradial2(volume, filename, timestep=None):
     root.attrs["version"] = "2.0"
     root.to_netcdf(filename, mode="w", group="/")
     for idx, key in enumerate(root.sweep_group_name.values):
-        try:
+        if isinstance(volume, (OdimH5, CfRadial)):
             swp = volume[key]
-        except TypeError:
+        elif isinstance(volume, XRadVolume):
             swp = volume[idx][timestep].data
+        else:
+            ds = volume[idx]
+            if "time" not in ds.dims:
+                ds = ds.expand_dims("time")
+            swp = ds.isel(time=timestep)
         swp.load()
         dims = list(swp.dims)
         dims.remove("range")
@@ -780,16 +804,17 @@ def to_cfradial2(volume, filename, timestep=None):
         except ValueError:
             swp = swp.drop_vars("time").rename({"rtime": "time"})
             swp = swp.swap_dims({dim0: "time"})
-        swp.drop_vars(["x", "y", "z", "gr", "rays", "bins"], errors="ignore")
+        swp = swp.drop_vars(["x", "y", "z", "gr", "rays", "bins"], errors="ignore")
+        swp = swp.sortby("time")
         swp.to_netcdf(filename, mode="a", group=key)
 
 
 def to_netcdf(volume, filename, timestep=None, keys=None):
-    """Save XRadVolume to netcdf compliant file.
+    """Save RadarVolume/XRadVolume to netcdf compliant file.
 
     Parameters
     ----------
-    volume : XRadVolume object
+    volume : RadarVolume/XRadVolume object
     filename : str
         output filename
     timestep : int, slice
@@ -806,16 +831,22 @@ def to_netcdf(volume, filename, timestep=None, keys=None):
         keys = root.sweep_group_name.values
     for idx, key in enumerate(root.sweep_group_name.values):
         if key in keys:
-            swp = volume[idx].data.isel(time=timestep)
+            try:
+                swp = volume[idx].data.isel(time=timestep)
+            except AttributeError:
+                ds = volume[idx]
+                if "time" not in ds.dims:
+                    ds = ds.expand_dims("time")
+                swp = ds.isel(time=timestep)
             swp.to_netcdf(filename, mode="a", group=key)
 
 
 def to_odim(volume, filename, timestep=0):
-    """Save XRadVol/XRadVolume to ODIM_H5/V2_2 compliant file.
+    """Save RadarVolume/XRadVol/XRadVolume to ODIM_H5/V2_2 compliant file.
 
     Parameters
     ----------
-    volume : XRadVol/XRadVolume object
+    volume : RadarVolume/XRadVol/XRadVolume object
     filename : str
         output filename
     timestep : int
@@ -865,10 +896,17 @@ def to_odim(volume, filename, timestep=0):
     ds_list = ["dataset{}".format(i + 1) for i in range(len(sweepnames))]
     ds_idx = np.argsort(ds_list)
     for idx in ds_idx:
-        try:
+        if isinstance(volume, (OdimH5, CfRadial)):
             ds = volume["sweep_{}".format(idx + 1)]
-        except TypeError:
+        elif isinstance(volume, XRadVolume):
             ds = volume[idx][timestep].data
+            ds = ds.drop_vars("time").rename({"rtime": "time"})
+        else:
+            ds = volume[idx]
+            if "time" not in ds.dims:
+                ds = ds.expand_dims("time")
+            ds = ds.isel(time=timestep, drop=True)
+            ds = ds.rename({"rtime": "time"})
         h5_dataset = h5.create_group(ds_list[idx])
 
         # what group p. 21 ff.
@@ -891,10 +929,7 @@ def to_odim(volume, filename, timestep=0):
         rscale = ds.range.values[1] / 1.0 - ds.range.values[0]
         rstart = (ds.range.values[0] - rscale / 2.0) / 1000.0
         # todo: make this work for RHI's
-        try:
-            a1gate = np.argsort(ds.sortby("time").azimuth.values)[0]
-        except ValueError:
-            a1gate = np.argsort(ds.sortby("rtime").azimuth.values)[0]
+        a1gate = np.argsort(ds.sortby("azimuth").time.values)[0]
         try:
             fixed_angle = ds.fixed_angle
         except AttributeError:
@@ -911,12 +946,17 @@ def to_odim(volume, filename, timestep=0):
 
         # how group, p. 14 ff.
         h5_ds_how = h5_dataset.create_group("how")
-        try:
-            tout = [tx.astype("O") / 1e9 for tx in ds.sortby("azimuth").time]
-        except TypeError:
-            tout = [tx.astype("O") / 1e9 for tx in ds.sortby("azimuth").rtime]
+        tout = [tx.astype("O") / 1e9 for tx in ds.sortby("azimuth").time.values]
+        tout_sorted = sorted(tout)
 
-        difft = np.diff(tout) / 2.0
+        # handle non-uniform times (eg. only second-resolution)
+        if np.count_nonzero(np.diff(tout_sorted)) < (len(tout_sorted) - 1):
+            tout = np.roll(
+                np.linspace(tout_sorted[0], tout_sorted[-1], len(tout)), a1gate
+            )
+            tout_sorted = sorted(tout)
+
+        difft = np.diff(tout_sorted) / 2.0
         difft = np.insert(difft, 0, difft[0])
         azout = ds.sortby("azimuth").azimuth
         diffa = np.diff(azout) / 2.0
@@ -944,6 +984,1182 @@ def to_odim(volume, filename, timestep=0):
         _write_odim_dataspace(ds, h5_dataset)
 
     h5.close()
+
+
+class _OdimH5NetCDFMetadata(object):
+    """Wrapper around OdimH5 data fileobj for easy access of metadata.
+
+    Parameters
+    ----------
+    fileobj : file-like
+        h5netcdf filehandle.
+    group : str
+        odim group to acquire
+
+    Returns
+    -------
+    object : metadata object
+    """
+
+    def __init__(self, fileobj, group):
+        self._root = fileobj
+        self._group = group
+
+    @property
+    def first_dim(self):
+        dim, _ = self._get_fixed_dim_and_angle()
+        return dim
+
+    def get_variable_dimensions(self, dims):
+        dimensions = []
+        for n, _ in enumerate(dims):
+            if n == 0:
+                dimensions.append(self.first_dim)
+            elif n == 1:
+                dimensions.append("range")
+            else:
+                pass
+        return tuple(dimensions)
+
+    @property
+    def coordinates(self):
+        azimuth = self.azimuth
+        elevation = self.elevation
+        a1gate = self.a1gate
+        rtime = self.ray_times
+        dim, angle = self.fixed_dim_and_angle
+        angle_res = np.round(np.nanmedian(np.diff(locals()[dim])), decimals=2)
+
+        dims = ("azimuth", "elevation")
+        if dim == dims[1]:
+            dims = (dims[1], dims[0])
+
+        az_attrs["a1gate"] = a1gate
+
+        if dim == "azimuth":
+            az_attrs["angle_res"] = angle_res
+        else:
+            el_attrs["angle_res"] = angle_res
+
+        sweep_mode = "azimuth_surveillance" if dim == "azimuth" else "rhi"
+
+        rtime_attrs = {
+            "units": "seconds since 1970-01-01T00:00:00Z",
+            "standard_name": "time",
+        }
+
+        range_data, cent_first, bin_range = self.range
+        range_attrs["meters_to_center_of_first_gate"] = cent_first
+        range_attrs["meters_between_gates"] = bin_range
+
+        lon_attrs = dict(
+            long_name="longitude", units="degrees_east", standard_name="longitude"
+        )
+        lat_attrs = dict(
+            long_name="latitude",
+            units="degrees_north",
+            positive="up",
+            standard_name="latitude",
+        )
+        alt_attrs = dict(long_name="altitude", units="meters", standard_name="altitude")
+
+        lon, lat, alt = self.site_coords
+
+        coordinates = dict(
+            azimuth=Variable((dims[0],), azimuth, az_attrs),
+            elevation=Variable((dims[0],), elevation, el_attrs),
+            rtime=Variable((dims[0],), rtime, rtime_attrs),
+            range=Variable(("range",), range_data, range_attrs),
+            time=Variable((), self.time, time_attrs),
+            sweep_mode=Variable((), sweep_mode),
+            longitude=Variable((), lon, lon_attrs),
+            latitude=Variable((), lat, lat_attrs),
+            altitude=Variable((), alt, alt_attrs),
+        )
+        return coordinates
+
+    @property
+    def site_coords(self):
+        return self._get_site_coords()
+
+    @property
+    def time(self):
+        return self._get_time()
+
+    @property
+    def fixed_dim_and_angle(self):
+        return self._get_fixed_dim_and_angle()
+
+    @property
+    def range(self):
+        return self._get_range()
+
+    @property
+    def what(self):
+        return self._get_dset_what()
+
+    def _get_azimuth_how(self):
+        grp = self._group.split("/")[0]
+        startaz = self._root[grp]["how"].attrs["startazA"]
+        stopaz = self._root[grp]["how"].attrs["stopazA"]
+        zero_index = np.where(stopaz < startaz)
+        stopaz[zero_index[0]] += 360
+        azimuth_data = (startaz + stopaz) / 2.0
+        return azimuth_data
+
+    def _get_azimuth_where(self):
+        grp = self._group.split("/")[0]
+        nrays = self._root[grp]["where"].attrs["nrays"]
+        res = 360.0 / nrays
+        azimuth_data = np.arange(res / 2.0, 360.0, res, dtype="float32")
+        return azimuth_data
+
+    def _get_fixed_dim_and_angle(self):
+        grp = self._group.split("/")[0]
+        dim = "elevation"
+
+        # try RHI first
+        angle_keys = ["az_angle", "azangle"]
+        angle = None
+        for ak in angle_keys:
+            angle = self._root[grp]["where"].attrs.get(ak, None)
+            if angle is not None:
+                break
+        if angle is None:
+            dim = "azimuth"
+            angle = self._root[grp]["where"].attrs["elangle"]
+
+        angle = np.round(angle, decimals=1)
+        return dim, angle
+
+    def _get_elevation_how(self):
+        grp = self._group.split("/")[0]
+        startaz = self._root[grp]["how"].attrs["startelA"]
+        stopaz = self._root[grp]["how"].attrs["stopelA"]
+        elevation_data = (startaz + stopaz) / 2.0
+        return elevation_data
+
+    def _get_elevation_where(self):
+        grp = self._group.split("/")[0]
+        nrays = self._root[grp]["where"].attrs["nrays"]
+        elangle = self._root[grp]["where"].attrs["elangle"]
+        elevation_data = np.ones(nrays, dtype="float32") * elangle
+        return elevation_data
+
+    def _get_time_how(self):
+        grp = self._group.split("/")[0]
+        startT = self._root[grp]["how"].attrs["startazT"]
+        stopT = self._root[grp]["how"].attrs["stopazT"]
+        time_data = (startT + stopT) / 2.0
+        return time_data
+
+    def _get_time_what(self, nrays=None):
+        grp = self._group.split("/")[0]
+        what = self._root[grp]["what"].attrs
+        startdate = what["startdate"].item().decode()
+        starttime = what["starttime"].item().decode()
+        enddate = what["enddate"].item().decode()
+        endtime = what["endtime"].item().decode()
+        start = dt.datetime.strptime(startdate + starttime, "%Y%m%d%H%M%S")
+        end = dt.datetime.strptime(enddate + endtime, "%Y%m%d%H%M%S")
+        start = start.replace(tzinfo=dt.timezone.utc).timestamp()
+        end = end.replace(tzinfo=dt.timezone.utc).timestamp()
+        if nrays is None:
+            nrays = self._root[grp]["where"].attrs["nrays"]
+        if start == end:
+            import warnings
+
+            warnings.warn(
+                "WRADLIB: Equal ODIM `starttime` and `endtime` "
+                "values. Can't determine correct sweep start-, "
+                "end- and raytimes.",
+                UserWarning,
+            )
+
+            time_data = np.ones(nrays) * start
+        else:
+            delta = (end - start) / nrays
+            time_data = np.arange(start + delta / 2.0, end, delta)
+            time_data = np.roll(time_data, shift=+self.a1gate)
+        return time_data
+
+    def _get_ray_times(self, nrays=None):
+        try:
+            time_data = self._get_time_how()
+            self._need_time_recalc = False
+        except (AttributeError, KeyError, TypeError):
+            time_data = self._get_time_what(nrays=nrays)
+            self._need_time_recalc = True
+        return time_data
+
+    def _get_range(self):
+        grp = self._group.split("/")[0]
+        where = self._root[grp]["where"].attrs
+        ngates = where["nbins"]
+        range_start = where["rstart"] * 1000.0
+        bin_range = where["rscale"]
+        cent_first = range_start + bin_range / 2.0
+        range_data = np.arange(
+            cent_first, range_start + bin_range * ngates, bin_range, dtype="float32"
+        )
+        return range_data, cent_first, bin_range
+
+    def _get_time(self, point="start"):
+        grp = self._group.split("/")[0]
+        what = self._root[grp]["what"].attrs
+        startdate = what[f"{point}date"].item().decode()
+        starttime = what[f"{point}time"].item().decode()
+        start = dt.datetime.strptime(startdate + starttime, "%Y%m%d%H%M%S")
+        start = start.replace(tzinfo=dt.timezone.utc).timestamp()
+        return start
+
+    def _get_a1gate(self):
+        grp = self._group.split("/")[0]
+        a1gate = self._root[grp]["where"].attrs["a1gate"]
+        return a1gate
+
+    def _get_site_coords(self):
+        lon = self._root["where"].attrs["lon"].item()
+        lat = self._root["where"].attrs["lat"].item()
+        alt = self._root["where"].attrs["height"].item()
+        return lon, lat, alt
+
+    def _get_dset_what(self):
+        attrs = {}
+        what = self._root[self._group]["what"].attrs
+        attrs["scale_factor"] = what["gain"]
+        attrs["add_offset"] = what["offset"]
+        attrs["_FillValue"] = what["nodata"]
+        attrs["_Undetect"] = what["undetect"]
+        attrs["quantity"] = what["quantity"].item().decode()
+        return attrs
+
+    @property
+    def a1gate(self):
+        return self._get_a1gate()
+
+    @property
+    def azimuth(self):
+        try:
+            azimuth = self._get_azimuth_how()
+        except (AttributeError, KeyError, TypeError):
+            azimuth = self._get_azimuth_where()
+        return azimuth
+
+    @property
+    def elevation(self):
+        try:
+            elevation = self._get_elevation_how()
+        except (AttributeError, KeyError, TypeError):
+            elevation = self._get_elevation_where()
+        return elevation
+
+    @property
+    def ray_times(self):
+        return self._get_ray_times()
+
+
+class _GamicH5NetCDFMetadata(object):
+    """Wrapper around OdimH5 data fileobj for easy access of metadata.
+
+    Parameters
+    ----------
+    fileobj : file-like
+        h5netcdf filehandle.
+    group : str
+        odim group to acquire
+
+    Returns
+    -------
+    object : metadata object
+    """
+
+    def __init__(self, fileobj, group):
+        self._root = fileobj
+        self._group = group
+
+    @property
+    def first_dim(self):
+        dim, _ = self._get_fixed_dim_and_angle()
+        return dim
+
+    def get_variable_dimensions(self, dims):
+        dimensions = []
+        for n, _ in enumerate(dims):
+            if n == 0:
+                dimensions.append(self.first_dim)
+            elif n == 1:
+                dimensions.append("range")
+            else:
+                pass
+        return tuple(dimensions)
+
+    def coordinates(self, dimensions, data, encoding):
+
+        ray_header = _get_ray_header_data(dimensions, data, encoding)
+        dim, angle = self.fixed_dim_and_angle
+        angles = ray_header[dim]
+
+        angle_res = np.round(np.nanmedian(np.diff(angles)), decimals=1)
+        dims = ("azimuth", "elevation")
+        if dim == dims[1]:
+            dims = (dims[1], dims[0])
+
+        sort_idx = np.argsort(angles)
+        a1gate = np.argsort(ray_header["rtime"][sort_idx])[0]
+
+        az_attrs["a1gate"] = a1gate
+
+        if dim == "azimuth":
+            az_attrs["angle_res"] = angle_res
+        else:
+            el_attrs["angle_res"] = angle_res
+
+        sweep_mode = "azimuth_surveillance" if dim == "azimuth" else "rhi"
+
+        rtime_attrs = {
+            "units": "seconds since 1970-01-01T00:00:00Z",
+            "standard_name": "time",
+        }
+
+        range_data, cent_first, bin_range = self.range
+        range_attrs["meters_to_center_of_first_gate"] = cent_first
+        range_attrs["meters_between_gates"] = bin_range
+
+        lon_attrs = dict(
+            long_name="longitude", units="degrees_east", standard_name="longitude"
+        )
+        lat_attrs = dict(
+            long_name="latitude",
+            units="degrees_north",
+            positive="up",
+            standard_name="latitude",
+        )
+        alt_attrs = dict(long_name="altitude", units="meters", standard_name="altitude")
+
+        lon, lat, alt = self.site_coords
+
+        coordinates = dict(
+            azimuth=Variable((dims[0],), ray_header["azimuth"], az_attrs),
+            elevation=Variable((dims[0],), ray_header["elevation"], el_attrs),
+            rtime=Variable((dims[0],), ray_header["rtime"], rtime_attrs),
+            range=Variable(("range",), range_data, range_attrs),
+            time=Variable((), self.time, time_attrs),
+            sweep_mode=Variable((), sweep_mode),
+            longitude=Variable((), lon, lon_attrs),
+            latitude=Variable((), lat, lat_attrs),
+            altitude=Variable((), alt, alt_attrs),
+        )
+
+        return coordinates
+
+    @property
+    def site_coords(self):
+        return self._get_site_coords()
+
+    @property
+    def time(self):
+        return self._get_time()
+
+    @property
+    def fixed_dim_and_angle(self):
+        return self._get_fixed_dim_and_angle()
+
+    @property
+    def range(self):
+        return self._get_range()
+
+    @property
+    def what(self):
+        return self._get_dset_what()
+
+    def _get_fixed_dim_and_angle(self):
+        how = self._root[self._group]["how"].attrs
+        dims = {0: "elevation", 1: "azimuth"}
+        try:
+            dim = 1
+            angle = np.round(how[dims[0]], decimals=1)
+        except KeyError:
+            dim = 0
+            angle = np.round(how[dims[1]], decimals=1)
+
+        return dims[dim], angle
+
+    def _get_range(self):
+        how = self._root[self._group]["how"].attrs
+        range_samples = how["range_samples"]
+        range_step = how["range_step"]
+        ngates = how["bin_count"]
+        bin_range = range_step * range_samples
+        cent_first = bin_range / 2.0
+        range_data = np.arange(
+            cent_first,
+            bin_range * ngates,
+            bin_range,
+            dtype="float32",
+        )
+        return range_data, cent_first, bin_range
+
+    def _get_time(self):
+        start = self._root[self._group]["how"].attrs["timestamp"]
+        start = dateutil.parser.parse(start)
+        start = start.replace(tzinfo=dt.timezone.utc).timestamp()
+        return start
+
+    def _get_site_coords(self):
+        lon = self._root["where"].attrs["lon"].item()
+        lat = self._root["where"].attrs["lat"].item()
+        alt = self._root["where"].attrs["height"].item()
+        return lon, lat, alt
+
+
+def _fix_angle(da):
+    # fix elevation outliers
+    if len(set(da.values)) > 1:
+        med = da.median(skipna=True)
+        da = da.where(da == med).fillna(med)
+    return da
+
+
+def _remove_duplicate_rays(ds, store=None):
+    dimname = list(ds.dims)[0]
+    # find exact duplicates and remove
+    _, idx = np.unique(ds[dimname], return_index=True)
+    if len(idx) < len(ds[dimname]):
+        ds = ds.isel({dimname: idx})
+        # if ray_time was erroneously created from wrong dimensions
+        # we need to recalculate it
+        if store and store._need_time_recalc:
+            ray_times = store._get_ray_times(nrays=len(idx))
+            # need to decode only if ds is decoded
+            if "units" in ds.rtime.encoding:
+                ray_times = xr.decode_cf(xr.Dataset({"rtime": ray_times})).rtime
+            ds = ds.assign({"rtime": ray_times})
+    return ds
+
+
+def _reindex_angle(ds, store=None, force=False, tol=0.4):
+    # Todo: The current code assumes to have PPI's of 360deg and RHI's of 90deg,
+    #       make this work also for sectorized measurements
+    # disentangle different functionality
+    full_range = dict(azimuth=360, elevation=90)
+    dimname = list(ds.dims)[0]
+    secname = "elevation"
+    dim = ds[dimname]
+    diff = dim.diff(dimname)
+    # this captures different angle spacing
+    # catches also missing rays and double rays
+    # and other erroneous ray alignments which result in different diff values
+    diffset = set(diff.values)
+    non_uniform_angle_spacing = len(diffset) > 1
+    # this captures missing and additional rays in case the angle differences
+    # are equal
+    non_full_circle = False
+    if not non_uniform_angle_spacing:
+        res = list(diffset)[0]
+        non_full_circle = ((res * ds.dims[dimname]) % full_range[dimname]) != 0
+
+    # fix issues with ray alignment
+    if force | non_uniform_angle_spacing | non_full_circle:
+        # create new array and reindex
+        if store and hasattr(store, "angle_resolution"):
+            res = store.angle_resolution
+        elif hasattr(ds[dimname], "angle_res"):
+            res = ds[dimname].angle_res
+        else:
+            res = diff.median(dimname).values
+        new_rays = int(np.round(full_range[dimname] / res, decimals=0))
+
+        # find exact duplicates and remove
+        ds = _remove_duplicate_rays(ds, store=store)
+
+        # do we have all needed rays?
+        if non_uniform_angle_spacing | len(ds[dimname]) != new_rays:
+            # todo: check if assumption that beam center points to
+            #       multiples of res/2. is correct in any case
+            # it might fail for cfradial1 data which already points to beam centers
+            azr = np.arange(res / 2.0, new_rays * res, res, dtype=diff.dtype)
+            fill_value = {
+                k: np.asarray(v._FillValue).astype(v.dtype)
+                for k, v in ds.items()
+                if hasattr(v, "_FillValue")
+            }
+            # todo: make tolerance parameterizable
+            ds = ds.reindex(
+                {dimname: azr},
+                method="nearest",
+                tolerance=res * tol,
+                fill_value=fill_value,
+            )
+
+        # check other coordinates
+        # check secondary angle coordinate (no nan)
+        # set nan values to reasonable median
+        if hasattr(ds, secname) and np.count_nonzero(np.isnan(ds[secname])):
+            ds[secname] = ds[secname].fillna(ds[secname].median(skipna=True))
+        # todo: rtime is also affected, might need to be treated accordingly
+
+    return ds
+
+
+def _get_h5group_names(filename, engine):
+    if engine == "odim":
+        groupname = "dataset"
+    elif engine == "gamic":
+        groupname = "scan"
+    elif engine == "cfradial2":
+        groupname = "sweep"
+    else:
+        raise ValueError(f"wradlib: unknown engine `{engine}`.")
+    with h5netcdf.File(filename, "r", decode_vlen_strings=True) as fh:
+        groups = ["/".join(["", grp]) for grp in fh.groups if groupname in grp.lower()]
+    if isinstance(filename, io.BytesIO):
+        filename.seek(0)
+    return groups
+
+
+def _get_nc4group_names(filename, engine):
+    if engine == "cfradial2":
+        groupname = "sweep"
+    else:
+        raise ValueError(f"wradlib: unknown engine `{engine}`.")
+    with nc.Dataset(filename, "r") as fh:
+        groups = ["".join(["", grp]) for grp in fh.groups if groupname in grp.lower()]
+    if isinstance(filename, io.BytesIO):
+        filename.seek(0)
+    return groups
+
+
+def _get_odim_variable_name_and_attrs(name, attrs):
+    if "data" in name:
+        name = attrs.pop("quantity")
+        # handle non-standard moment names
+        try:
+            mapping = moments_mapping[name]
+        except KeyError:
+            pass
+        else:
+            attrs.update({key: mapping[key] for key in moment_attrs})
+        attrs[
+            "coordinates"
+        ] = "elevation azimuth range latitude longitude altitude time rtime sweep_mode"
+    return name, attrs
+
+
+def _get_gamic_variable_name_and_attrs(attrs, dtype):
+    name = attrs.pop("moment").lower()
+    try:
+        name = GAMIC_NAMES[name]
+    except KeyError:
+        # ds = ds.drop_vars(mom)
+        pass
+
+    dmax = np.iinfo(dtype).max
+    dmin = np.iinfo(dtype).min
+    minval = attrs.pop("dyn_range_min")
+    maxval = attrs.pop("dyn_range_max")
+    dtype = minval.dtype
+    dyn_range = maxval - minval
+    if maxval != minval:
+        gain = dyn_range / (dmax - 1)
+        minval -= gain
+    else:
+        gain = (dmax - dmin) / dmax
+        minval = dmin
+    gain = gain.astype(dtype)
+    minval = minval.astype(dtype)
+    undetect = np.array([dmin])[0].astype(dtype)
+    attrs["scale_factor"] = gain
+    attrs["add_offset"] = minval
+    attrs["_FillValue"] = undetect
+    attrs["_Undetect"] = undetect
+
+    attrs[
+        "coordinates"
+    ] = "elevation azimuth range latitude longitude altitude time rtime sweep_mode"
+
+    return name, attrs
+
+
+def _get_ray_header_data(dimensions, data, encoding):
+    ray_header = Variable(dimensions, data, {}, encoding)
+
+    azstart = ray_header.values["azimuth_start"]
+    azstop = ray_header.values["azimuth_stop"]
+    zero_index = np.where(azstop < azstart)
+    azstop[zero_index[0]] += 360
+    azimuth = (azstart + azstop) / 2.0
+
+    elstart = ray_header.values["elevation_start"]
+    elstop = ray_header.values["elevation_stop"]
+    elevation = (elstart + elstop) / 2.0
+
+    rtime = ray_header.values["timestamp"] / 1e6
+
+    return dict(azimuth=azimuth, elevation=elevation, rtime=rtime)
+
+
+def _unpack_netcdf_delta_units_ref_date(units):
+    matches = re.match(r"(.+) since (.+)", units)
+    if not matches:
+        raise ValueError(f"invalid time units: {units}")
+    return [s.strip() for s in matches.groups()]
+
+
+def _rewrite_time_reference_units(ds):
+    has_time_reference = "time_reference" in ds.variables
+    if has_time_reference:
+        ref_date = str(ds.variables["time_reference"].data)
+        for v in ds.variables.values():
+            attrs = v.attrs
+            has_time_reference_units = (
+                "units" in attrs
+                and "since" in attrs["units"]
+                and "time_reference" in attrs["units"]
+            )
+            if has_time_reference_units and has_time_reference:
+                delta_units, _ = _unpack_netcdf_delta_units_ref_date(attrs["units"])
+                v.attrs["units"] = " ".join([delta_units, "since", ref_date])
+    return ds
+
+
+def _assign_data_radial(root, sweep="sweep_1"):
+    """Assign from CfRadial1 data structure.
+
+    Parameters
+    ----------
+    root : xarray.Dataset
+        Dataset of CfRadial1 file
+    sweep : str, optional
+        Sweep name to extract, default to first sweep. If None, all sweeps are
+        extracted into a list.
+    """
+    var = root.variables.keys()
+    remove_root = var ^ root_vars
+    remove_root &= var
+    root1 = root.drop_vars(remove_root).rename({"fixed_angle": "sweep_fixed_angle"})
+    sweep_group_name = []
+    for i in range(root1.dims["sweep"]):
+        sweep_group_name.append("sweep_{}".format(i + 1))
+
+    keep_vars = sweep_vars1 | sweep_vars2 | sweep_vars3
+    remove_vars = var ^ keep_vars
+    remove_vars &= var
+    data = root.drop_vars(remove_vars)
+    data.attrs = {}
+    start_idx = data.sweep_start_ray_index.values
+    end_idx = data.sweep_end_ray_index.values
+    data = data.drop_vars({"sweep_start_ray_index", "sweep_end_ray_index"})
+    sweeps = []
+    for i, sw in enumerate(sweep_group_name):
+        if sweep is not None and sweep != sw:
+            continue
+        tslice = slice(start_idx[i], end_idx[i] + 1)
+        ds = data.isel(time=tslice, sweep=slice(i, i + 1)).squeeze("sweep")
+        ds.sweep_mode.load()
+        sweep_mode = ds.sweep_mode.item().decode()
+        dim0 = "elevation" if sweep_mode == "rhi" else "azimuth"
+        ds = ds.swap_dims({"time": dim0})
+        ds = ds.rename({"time": "rtime"})
+
+        ds.attrs["fixed_angle"] = np.round(ds.fixed_angle.item(), decimals=1)
+        time = ds.rtime[0].reset_coords(drop=True)
+        key = [key for key in time.attrs.keys() if "comment" in key][0]
+        del time.attrs[key]
+        coords = {
+            "longitude": root1.longitude,
+            "latitude": root1.latitude,
+            "altitude": root1.altitude,
+            "azimuth": ds.azimuth,
+            "elevation": ds.elevation,
+            "sweep_mode": sweep_mode,
+            "time": time,
+        }
+        ds = ds.assign_coords(**coords)
+        sweeps.append(ds)
+
+    return sweeps
+
+
+def _assign_data_radial2(ds):
+    """Assign from CfRadial2 data structure.
+
+    Parameters
+    ----------
+    ds : Dataset
+
+    """
+    ds.sweep_mode.load()
+    sweep_mode = ds.sweep_mode.item()
+    dim0 = "elevation" if sweep_mode == "rhi" else "azimuth"
+    ds = ds.swap_dims({"time": dim0})
+    ds = ds.rename({"time": "rtime"})
+    time = ds.rtime[0].reset_coords(drop=True).dt.round("S")
+    # todo: check use-case
+    key = [key for key in time.attrs.keys() if "comment" in key]
+    if key:
+        del time.attrs[key[0]]
+    coords = {
+        "azimuth": ds.azimuth,
+        "elevation": ds.elevation,
+        "sweep_mode": sweep_mode,
+        "time": time,
+    }
+    ds = ds.assign_coords(**coords)
+
+    return ds
+
+
+def open_odim_dataset(filename_or_obj, group=None, **kwargs):
+    """Open and decode an ODIM radar sweep or volume from a file or file-like object.
+
+    This function uses :func:`~wradlib.io.open_radar_dataset`` under the hood.
+
+    Parameters
+    ----------
+    filename_or_obj : str, Path, file-like or DataStore
+        Strings and Path objects are interpreted as a path to a local or remote
+        radar file and opened with an appropriate engine.
+    group : str, optional
+        Path to a sweep group in the given file to open.
+
+    Keyword Arguments
+    -----------------
+    **kwargs : optional
+        Additional arguments passed on to :py:func:`xarray.open_dataset`.
+
+    Returns
+    -------
+    dataset : xarray.Dataset | wradlib.io.RadarVolume
+        The newly created radar dataset or radar volume.
+
+    See Also
+    --------
+    wradlib.io.open_odim_mfdataset
+    """
+    raise_on_missing_xarray_backend()
+    kwargs["group"] = group
+    return open_radar_dataset(filename_or_obj, engine="odim", **kwargs)
+
+
+def open_gamic_dataset(filename_or_obj, group=None, **kwargs):
+    """Open and decode an GAMIC radar sweep or volume from a file or file-like object.
+
+    This function uses :func:`~wradlib.io.open_radar_dataset`` under the hood.
+
+    Parameters
+    ----------
+    filename_or_obj : str, Path, file-like or DataStore
+        Strings and Path objects are interpreted as a path to a local or remote
+        radar file and opened with an appropriate engine.
+    group : str, optional
+        Path to a sweep group in the given file to open.
+
+    Keyword Arguments
+    -----------------
+    **kwargs : optional
+        Additional arguments passed on to :py:func:`xarray.open_dataset`.
+
+    Returns
+    -------
+    dataset : xarray.Dataset | wradlib.io.RadarVolume
+        The newly created radar dataset or radar volume.
+
+    See Also
+    --------
+    wradlib.io.open_gamic_mfdataset
+    """
+    raise_on_missing_xarray_backend()
+    kwargs["group"] = group
+    return open_radar_dataset(filename_or_obj, engine="gamic", **kwargs)
+
+
+def open_cfradial1_dataset(filename_or_obj, group=None, **kwargs):
+    """Open and decode an CfRadial1 radar sweep or volume from a file or file-like object.
+
+    This function uses :func:`~wradlib.io.open_radar_dataset`` under the hood.
+
+    Parameters
+    ----------
+    filename_or_obj : str, Path, file-like or DataStore
+        Strings and Path objects are interpreted as a path to a local or remote
+        radar file and opened with an appropriate engine.
+    group : str, optional
+        Path to a sweep group in the given file to open.
+
+    Keyword Arguments
+    -----------------
+    **kwargs : optional
+        Additional arguments passed on to :py:func:`xarray.open_dataset`.
+
+    Returns
+    -------
+    dataset : xarray.Dataset | wradlib.io.RadarVolume
+        The newly created radar dataset or radar volume.
+
+    See Also
+    --------
+    wradlib.io.open_cfradial1_mfdataset
+    """
+    raise_on_missing_xarray_backend()
+    kwargs["group"] = group
+    return open_radar_dataset(filename_or_obj, engine="cfradial1", **kwargs)
+
+
+def open_cfradial2_dataset(filename_or_obj, group=None, **kwargs):
+    """Open and decode an CfRadial2 radar sweep or volume from a file or file-like object.
+
+    This function uses :func:`~wradlib.io.open_radar_dataset`` under the hood.
+
+    Parameters
+    ----------
+    filename_or_obj : str, Path, file-like or DataStore
+        Strings and Path objects are interpreted as a path to a local or remote
+        radar file and opened with an appropriate engine.
+    group : str, optional
+        Path to a sweep group in the given file to open.
+
+    Keyword Arguments
+    -----------------
+    **kwargs : optional
+        Additional arguments passed on to :py:func:`xarray.open_dataset`.
+
+    Returns
+    -------
+    dataset : xarray.Dataset | wradlib.io.RadarVolume
+        The newly created radar dataset or radar volume.
+
+    See Also
+    --------
+    wradlib.io.open_cfradial2_mfdataset
+    """
+    raise_on_missing_xarray_backend()
+    kwargs["group"] = group
+    return open_radar_dataset(filename_or_obj, engine="cfradial2", **kwargs)
+
+
+def open_odim_mfdataset(filename_or_obj, group=None, **kwargs):
+    """Open and decode an ODIM radar sweep or volume from a file or file-like object.
+
+    This function uses :func:`~wradlib.io.open_radar_mfdataset`` under the hood.
+
+    Parameters
+    ----------
+    filename_or_obj : str, Path, file-like or DataStore
+        Strings and Path objects are interpreted as a path to a local or remote
+        radar file and opened with an appropriate engine.
+    group : str, optional
+        Path to a sweep group in the given file to open.
+
+    Keyword Arguments
+    -----------------
+    **kwargs : optional
+        Additional arguments passed on to :py:func:`xarray.open_dataset`.
+
+    Returns
+    -------
+    dataset : xarray.Dataset | wradlib.io.RadarVolume
+        The newly created radar dataset or radar volume.
+
+    See Also
+    --------
+    wradlib.io.open_odim_dataset
+    """
+    raise_on_missing_xarray_backend()
+    kwargs["group"] = group
+    return open_radar_mfdataset(filename_or_obj, engine="odim", **kwargs)
+
+
+def open_gamic_mfdataset(filename_or_obj, group=None, **kwargs):
+    """Open and decode an GAMIC radar sweep or volume from a file or file-like object.
+
+    This function uses :func:`~wradlib.io.open_radar_mfdataset`` under the hood.
+
+    Parameters
+    ----------
+    filename_or_obj : str, Path, file-like or DataStore
+        Strings and Path objects are interpreted as a path to a local or remote
+        radar file and opened with an appropriate engine.
+    group : str, optional
+        Path to a sweep group in the given file to open.
+
+    Keyword Arguments
+    -----------------
+    **kwargs : optional
+        Additional arguments passed on to :py:func:`xarray.open_dataset`.
+
+    Returns
+    -------
+    dataset : xarray.Dataset | wradlib.io.RadarVolume
+        The newly created radar dataset or radar volume.
+
+    See Also
+    --------
+    wradlib.io.open_gamic_dataset
+    """
+    raise_on_missing_xarray_backend()
+    kwargs["group"] = group
+    return open_radar_mfdataset(filename_or_obj, engine="gamic", **kwargs)
+
+
+def open_cfradial1_mfdataset(filename_or_obj, group=None, **kwargs):
+    """Open and decode an CfRadial1 radar sweep or volume from a file or file-like object.
+
+    This function uses :func:`~wradlib.io.open_radar_mfdataset`` under the hood.
+
+    Parameters
+    ----------
+    filename_or_obj : str, Path, file-like or DataStore
+        Strings and Path objects are interpreted as a path to a local or remote
+        radar file and opened with an appropriate engine.
+    group : str, optional
+        Path to a sweep group in the given file to open.
+
+    Keyword Arguments
+    -----------------
+    **kwargs : optional
+        Additional arguments passed on to :py:func:`xarray.open_dataset`.
+
+    Returns
+    -------
+    dataset : xarray.Dataset | wradlib.io.RadarVolume
+        The newly created radar dataset or radar volume.
+
+    See Also
+    --------
+    wradlib.io.open_cfradial1_dataset
+    """
+    raise_on_missing_xarray_backend()
+    kwargs["group"] = group
+    return open_radar_mfdataset(filename_or_obj, engine="cfradial1", **kwargs)
+
+
+def open_cfradial2_mfdataset(filename_or_obj, group=None, **kwargs):
+    """Open and decode an CfRadial2 radar sweep or volume from a file or file-like object.
+
+    This function uses :func:`~wradlib.io.open_radar_mfdataset`` under the hood.
+
+    Parameters
+    ----------
+    filename_or_obj : str, Path, file-like or DataStore
+        Strings and Path objects are interpreted as a path to a local or remote
+        radar file and opened with an appropriate engine.
+    group : str, optional
+        Path to a sweep group in the given file to open.
+
+    Keyword Arguments
+    -----------------
+    **kwargs : optional
+        Additional arguments passed on to :py:func:`xarray.open_dataset`.
+
+    Returns
+    -------
+    dataset : xarray.Dataset | wradlib.io.RadarVolume
+        The newly created radar dataset or radar volume.
+
+    See Also
+    --------
+    wradlib.io.open_cfradial1_dataset
+    """
+    raise_on_missing_xarray_backend()
+    kwargs["group"] = group
+    return open_radar_mfdataset(filename_or_obj, engine="cfradial2", **kwargs)
+
+
+def open_radar_dataset(filename_or_obj, engine=None, **kwargs):
+    """Open and decode a radar sweep or volume from a single file or file-like object.
+
+    This function uses ``xarray.open_dataset`` under the hood. Please refer for
+    details to the documentation of ``xarray.open_dataset``.
+
+    Parameters
+    ----------
+    filename_or_obj : str, Path, file-like or DataStore
+        Strings and Path objects are interpreted as a path to a local or remote
+        radar file and opened with an appropriate engine.
+    engine : {"odim", "gamic", "cfradial1", "cfradial2"}
+        Engine to use when reading files.
+
+    Keyword Arguments
+    -----------------
+    group : str, optional
+        Path to a sweep group in the given file to open.
+    **kwargs : optional
+        Additional arguments passed on to :py:func:`xarray.open_dataset`.
+
+    Returns
+    -------
+    dataset : xarray.Dataset | wradlib.io.RadarVolume
+        The newly created radar dataset or radar volume.
+
+    See Also
+    --------
+    wradlib.io.open_radar_mfdataset
+    """
+    if engine not in ["cfradial1", "cfradial2", "gamic", "odim"]:
+        raise TypeError(f"Missing or unknown `engine` keyword argument '{engine}'.")
+
+    group = kwargs.pop("group", None)
+
+    backend_kwargs = kwargs.pop("backend_kwargs", {})
+
+    if engine == "cfradial1":
+        groups = [None]
+    elif isinstance(group, str):
+        groups = [group]
+    else:
+        if engine == "cfradial2":
+            groups = _get_nc4group_names(filename_or_obj, engine)
+        else:
+            groups = _get_h5group_names(filename_or_obj, engine)
+
+    if engine in ["gamic", "odim"]:
+        keep_azimuth = kwargs.pop("keep_azimuth", False)
+        backend_kwargs["keep_azimuth"] = keep_azimuth
+
+    kwargs["backend_kwargs"] = backend_kwargs
+
+    ds = [
+        xr.open_dataset(filename_or_obj, group=grp, engine=engine, **kwargs)
+        for grp in groups
+    ]
+
+    if engine == "cfradial1":
+        ds = _assign_data_radial(ds[0], sweep=group)
+
+    if group is None:
+        vol = RadarVolume()
+        vol.extend(ds)
+        vol.sort(key=lambda x: x.time.min().values)
+        ds = vol
+    else:
+        ds = ds[0]
+
+    return ds
+
+
+def open_radar_mfdataset(paths, **kwargs):
+    """Open multiple radar files as a single radar sweep dataset or radar volume.
+
+    This function uses ``xarray.open_mfdataset`` under the hood. Please refer for
+    details to the documentation of ``xarray.open_mfdataset``.
+
+    Parameters
+    ----------
+    paths : str or sequence
+        Either a string glob in the form ``"path/to/my/files/*"`` or an explicit list of
+        files to open. Paths can be given as strings or as pathlib Paths. If
+        concatenation along more than one dimension is desired, then ``paths`` must be a
+        nested list-of-lists (see ``xarray.combine_nested`` for details). (A string glob will
+        be expanded to a 1-dimensional list.)
+    chunks : int or dict, optional
+        Dictionary with keys given by dimension names and values given by chunk sizes.
+        In general, these should divide the dimensions of each dataset. If int, chunk
+        each dimension by ``chunks``. By default, chunks will be chosen to load entire
+        input files into memory at once. This has a major impact on performance: please
+        see the full documentation for more details [2]_.
+    concat_dim : str, or list of str, DataArray, Index or None, optional
+        Dimensions to concatenate files along.  You only need to provide this argument
+        if ``combine='by_coords'``, and if any of the dimensions along which you want to
+        concatenate is not a dimension in the original datasets, e.g., if you want to
+        stack a collection of 2D arrays along a third dimension. Set
+        ``concat_dim=[..., None, ...]`` explicitly to disable concatenation along a
+        particular dimension. Default is None, which for a 1D list of filepaths is
+        equivalent to opening the files separately and then merging them with
+        ``xarray.merge``.
+    combine : {"by_coords", "nested"}, optional
+        Whether ``xarray.combine_by_coords`` or ``xarray.combine_nested`` is used to
+        combine all the data. Default is to use ``xarray.combine_by_coords``.
+    engine : {"odim", "gamic", "cfradial1", "cfradial2"}
+        Engine to use when reading files.
+    **kwargs : optional
+        Additional arguments passed on to :py:func:`xarray.open_mfdataset`.
+
+    Returns
+    -------
+    dataset : xarray.Dataset | wradlib.RadarVolume
+
+    See Also
+    --------
+    wradlib.io.open_radar_dataset
+    """
+
+    def _unpack_paths(paths):
+        from pathlib import Path
+
+        out = []
+        for p in paths:
+            if isinstance(p, list):
+                out.append(_unpack_paths(p))
+            else:
+                if isinstance(p, io.BytesIO):
+                    out.append(p)
+                else:
+                    if os.path.isfile(p):
+                        if isinstance(p, Path):
+                            out.append(str(p))
+                        else:
+                            out.append(p)
+                    else:
+                        out.append(sorted(glob.glob(p)))
+        return out
+
+    def _align_paths(paths):
+
+        if isinstance(paths, str):
+            paths = sorted(glob.glob(paths))
+        else:
+            paths = _unpack_paths(paths)
+        patharr = np.array(paths)
+
+        if patharr.ndim == 2 and len(patharr) == 1:
+            patharr = patharr[0]
+
+        return patharr
+
+    patharr = _align_paths(paths)
+
+    def _concat_combine(kwargs, patharr):
+        concat_dim = kwargs.pop("concat_dim", "time")
+        combine = kwargs.pop("combine", "nested")
+        if concat_dim and patharr.ndim > 1:
+            concat_dim = ["time"] + (patharr.ndim - 1) * [None]
+        if concat_dim is None:
+            combine = "by_coords"
+        return concat_dim, combine
+
+    concat_dim, combine = _concat_combine(kwargs, patharr)
+    engine = kwargs.pop("engine")
+
+    group = kwargs.pop("group", None)
+    if group is None:
+        group = _get_h5group_names(patharr.flat[0], engine)
+    elif isinstance(group, str):
+        group = [group]
+    else:
+        pass
+
+    ds = [
+        xr.open_mfdataset(
+            patharr.tolist(),
+            engine=engine,
+            group=grp,
+            concat_dim=concat_dim,
+            combine=combine,
+            **kwargs,
+        )
+        for grp in tqdm(group)
+    ]
+
+    if len(ds) > 1:
+        vol = RadarVolume()
+        vol.extend(ds)
+        vol.sort(key=lambda x: x.time.min().values)
+        ds = vol
+    else:
+        ds = ds[0]
+
+    return ds
 
 
 def _preprocess_moment(ds, mom, non_uniform_shape):
@@ -988,76 +2204,6 @@ def _preprocess_moment(ds, mom, non_uniform_shape):
             ds = ds.pipe(_reindex_angle, mom.parent)
 
     return ds
-
-
-def _reindex_angle(ds, sweep, force=False):
-    # Todo: The current code assumes to have PPI's of 360deg and RHI's of 90deg,
-    #       make this work also for sectorized measurements
-    full_range = dict(azimuth=360, elevation=90)
-    dimname = list(ds.dims)[0]
-    secname = sweep._dim0[1]
-    dim = ds[dimname]
-    diff = dim.diff(dimname)
-    # this captures different angle spacing
-    # catches also missing rays and double rays
-    # and other erroneous ray alignments which result in different diff values
-    diffset = set(diff.values)
-    non_uniform_angle_spacing = len(diffset) > 1
-    # this captures missing and additional rays in case the angle differences
-    # are equal
-    non_full_circle = False
-    if not non_uniform_angle_spacing:
-        res = list(diffset)[0]
-        non_full_circle = ((res * sweep.nrays) % full_range[dimname]) != 0
-
-    # fix issues with ray alignment
-    if force | non_uniform_angle_spacing | non_full_circle:
-        # create new array and reindex
-        res = sweep.angle_resolution
-        new_rays = int(np.round(full_range[dimname] / res, decimals=0))
-
-        # find exact duplicates and remove
-        _, idx = np.unique(ds[dimname], return_index=True)
-        if len(idx) < len(ds[dimname]):
-            ds = ds.isel({dimname: idx})
-            # if ray_time was errouneously created from wrong dimensions
-            # we need to recalculate it
-            if sweep._need_time_recalc:
-                ray_times = sweep._get_ray_times(nrays=len(idx))
-                ray_times = sweep._decode_cf(ray_times)
-                ds = ds.assign({"rtime": ray_times})
-
-        # todo: check if assumption that beam center points to
-        #       multiples of res/2. is correct in any case
-        azr = np.arange(res / 2.0, new_rays * res, res, dtype=diff.dtype)
-        fill_value = {
-            k: np.asarray(v._FillValue).astype(v.dtype)
-            for k, v in ds.items()
-            if hasattr(v, "_FillValue")
-        }
-        # todo: make tolerance parameterizable
-        ds = ds.reindex(
-            {dimname: azr},
-            method="nearest",
-            tolerance=res / 2.5,
-            fill_value=fill_value,
-        )
-        # check other coordinates
-        # check secondary angle coordinate (no nan)
-        # set nan values to reasonable median
-        if hasattr(ds, secname) and np.count_nonzero(np.isnan(ds[secname])):
-            ds[secname] = ds[secname].fillna(ds[secname].median(skipna=True))
-        # todo: rtime is also affected, might need to be treated accordingly
-
-    return ds
-
-
-def _fix_angle(da):
-    # fix elevation outliers
-    if len(set(da.values)) > 1:
-        med = da.median(skipna=True)
-        da = da.where(da == med).fillna(med)
-    return da
 
 
 def _open_mfmoments(
@@ -1267,6 +2413,168 @@ class XRadBase(collections.abc.MutableSequence):
 
     def sort(self, **kwargs):
         self._seq.sort(**kwargs)
+
+
+class RadarVolume(XRadBase):
+    """Class for holding a volume of radar sweeps"""
+
+    def __init__(self, **kwargs):
+        super(RadarVolume, self).__init__()
+        self._data = None
+        self._root = None
+        self._dims = dict(azimuth="elevation", elevation="azimuth")
+
+    def __repr__(self):
+        summary = ["<wradlib.{}>".format(type(self).__name__)]
+        dims = "Dimension(s):"
+        dims_summary = f"sweep: {len(self)}"
+        summary.append("{} ({})".format(dims, dims_summary))
+        dim = list(self[0].dims.keys())[0]
+        angle = f"{self._dims[dim].capitalize()}(s):"
+        angle_summary = [f"{v.attrs['fixed_angle']:.1f}" for v in self]
+        angle_summary = ", ".join(angle_summary)
+        summary.append("{} ({})".format(angle, angle_summary))
+
+        return "\n".join(summary)
+
+    @property
+    def root(self):
+        """Return root object."""
+        if self._root is None:
+            self.assign_root()
+        return self._root
+
+    def assign_root(self):
+        """(Re-)Create root object according CfRadial2 standard"""
+        # assign root variables
+        sweep_group_names = [f"sweep_{i}" for i in range(len(self))]
+
+        sweep_fixed_angles = [ts.attrs["fixed_angle"] for ts in self]
+
+        # extract time coverage
+        times = np.array(
+            [[ts.rtime.values.min(), ts.rtime.values.max()] for ts in self]
+        ).flatten()
+        time_coverage_start = min(times)
+        time_coverage_end = max(times)
+
+        time_coverage_start_str = str(time_coverage_start)[:19] + "Z"
+        time_coverage_end_str = str(time_coverage_end)[:19] + "Z"
+
+        # create root group from scratch
+        root = xr.Dataset()  # data_vars=wrl.io.xarray.global_variables,
+        # attrs=wrl.io.xarray.global_attrs)
+
+        # take first dataset/file for retrieval of location
+        # site = self.site
+
+        # assign root variables
+        root = root.assign(
+            {
+                "volume_number": 0,
+                "platform_type": str("fixed"),
+                "instrument_type": "radar",
+                "primary_axis": "axis_z",
+                "time_coverage_start": time_coverage_start_str,
+                "time_coverage_end": time_coverage_end_str,
+                "latitude": self[0]["latitude"],
+                "longitude": self[0]["longitude"],
+                "altitude": self[0]["altitude"],
+                "sweep_group_name": (["sweep"], sweep_group_names),
+                "sweep_fixed_angle": (["sweep"], sweep_fixed_angles),
+            }
+        )
+
+        # assign root attributes
+        attrs = {}
+        attrs.update(
+            {
+                "version": "None",
+                "title": "None",
+                "institution": "None",
+                "references": "None",
+                "source": "None",
+                "history": "None",
+                "comment": "im/exported using wradlib",
+                "instrument_name": "None",
+            }
+        )
+        # attrs["version"] = self[0].attrs["version"]
+        root = root.assign_attrs(attrs)
+        # todo: pull in only CF attributes
+        root = root.assign_attrs(self[0].attrs)
+        self._root = root
+
+    @property
+    def site(self):
+        """Return coordinates of radar site."""
+        return self[0][["latitude", "longitude", "altitude"]]
+
+    @property
+    def Conventions(self):
+        """Return Conventions string."""
+        try:
+            conv = self[0].attrs["Conventions"]
+        except KeyError:
+            conv = None
+        return conv
+
+    def to_odim(self, filename, timestep=0):
+        """Save volume to ODIM_H5/V2_2 compliant file.
+
+        Parameters
+        ----------
+        filename : str
+            Name of the output file
+        timestep : int
+            timestep of wanted volume
+        """
+        if self.root:
+            to_odim(self, filename, timestep=timestep)
+        else:
+            warnings.warn(
+                "WRADLIB: No OdimH5-compliant data structure " "available. Not saving.",
+                UserWarning,
+            )
+
+    def to_cfradial2(self, filename, timestep=0):
+        """Save volume to CfRadial2 compliant file.
+
+        Parameters
+        ----------
+        filename : str
+            Name of the output file
+        timestep : int
+            timestep wanted volume
+        """
+        if self.root:
+            to_cfradial2(self, filename, timestep=timestep)
+        else:
+            warnings.warn(
+                "WRADLIB: No CfRadial2-compliant data structure "
+                "available. Not saving.",
+                UserWarning,
+            )
+
+    def to_netcdf(self, filename, timestep=None, keys=None):
+        """Save volume to netcdf compliant file.
+
+        Parameters
+        ----------
+        filename : str
+            Name of the output file
+        timestep : int, slice
+            timestep/slice of wanted volume
+        keys : list
+            list of sweep_group_names which should be written to the file
+        """
+        if self.root:
+            to_netcdf(self, filename, keys=keys, timestep=timestep)
+        else:
+            warnings.warn(
+                "WRADLIB: No netcdf-compliant data structure " "available. Not saving.",
+                UserWarning,
+            )
 
 
 class OdimH5GroupAttributeMixin:
@@ -2418,6 +3726,12 @@ class XRadVolume(OdimH5GroupAttributeMixin, XRadBase):
             )
 
 
+@deprecation.deprecated(
+    deprecated_in="1.10",
+    removed_in="2.0",
+    current_version=version.version,
+    details="Use xarray BackendEntrypoint based functionality instead.",
+)
 def collect_by_time(obj):
     """Collect XRadSweep objects having same time
 
@@ -2450,6 +3764,12 @@ def collect_by_time(obj):
     return out
 
 
+@deprecation.deprecated(
+    deprecated_in="1.10",
+    removed_in="2.0",
+    current_version=version.version,
+    details="Use xarray BackendEntrypoint based functionality instead.",
+)
 def collect_by_angle(obj):
     """Collect XRadSweep objects having same angle
 
@@ -2535,6 +3855,12 @@ def _open_odim_sweep(filename, loader, **kwargs):
     return [sweep_cls(handle, k, **kwargs) for k in sweeps]
 
 
+@deprecation.deprecated(
+    deprecated_in="1.10",
+    removed_in="2.0",
+    current_version=version.version,
+    details="Use the appropriate `wradlib.io.open_{engine}_dataset` or `wradlib.io.open_{engine}_mfdataset` function.",
+)
 def open_odim(paths, loader="netcdf4", **kwargs):
     """Open multiple ODIM files as a XRadVolume structure.
 
@@ -2883,6 +4209,12 @@ class XRadVol(collections.abc.MutableMapping):
 class CfRadial(XRadVol):
     """Class for xarray based retrieval of CfRadial data files"""
 
+    @deprecation.deprecated(
+        deprecated_in="1.10",
+        removed_in="2.0",
+        current_version=version.version,
+        details="Use xarray BackendEntrypoint based functionality instead.",
+    )
     def __init__(self, filename=None, flavour=None, **kwargs):
         """Initialize xarray structure from Cf/Radial data structure.
 
@@ -3051,6 +4383,12 @@ class CfRadial(XRadVol):
 class OdimH5(XRadVol):
     """Class for xarray based retrieval of ODIM_H5 data files"""
 
+    @deprecation.deprecated(
+        deprecated_in="1.10",
+        removed_in="2.0",
+        current_version=version.version,
+        details="Use xarray BackendEntrypoint based functionality instead.",
+    )
     def __init__(self, filename=None, flavour=None, **kwargs):
         """Initialize xarray structure from hdf5 data structure.
 

--- a/wradlib/tests/conftest.py
+++ b/wradlib/tests/conftest.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# Copyright (c) 2011-2021, wradlib developers.
+# Distributed under the MIT License. See LICENSE.txt for more info.
+
+import pytest
+
+
+@pytest.fixture(params=["file", "filelike"])
+def file_or_filelike(request):
+    return request.param

--- a/wradlib/tests/test_io_backends.py
+++ b/wradlib/tests/test_io_backends.py
@@ -1,20 +1,32 @@
 # Copyright (c) 2011-2021, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
+import contextlib
+import gc
 import os
+import tempfile
 
+import h5py
 import numpy as np
 import pytest
 import xarray as xr
 
-from wradlib import io
+from wradlib import io, util
 
-from . import get_wradlib_data_file, requires_data, requires_xarray_backend_api
-
-
-@pytest.fixture(params=["file", "filelike"])
-def file_or_filelike(request):
-    return request.param
+from . import (
+    get_wradlib_data_file,
+    has_data,
+    requires_data,
+    requires_xarray_backend_api,
+)
+from .test_io_odim import (  # noqa: F401
+    base_gamic_data,
+    base_odim_data_00,
+    base_odim_data_01,
+    base_odim_data_02,
+    base_odim_data_03,
+    write_group,
+)
 
 
 @pytest.fixture(params=["v1", "v2"])
@@ -68,3 +80,336 @@ def test_radolan_backend(file_or_filelike, xarray_backend_api):
                     (data * 3600.0 / meta["intervalseconds"]),
                     decimal=5,
                 )
+
+
+@contextlib.contextmanager
+def get_measured_volume(file, format, fileobj, **kwargs):
+    # h5file = util.get_wradlib_data_file(file)
+    with get_wradlib_data_file(file, fileobj) as h5file:
+        engine = format.lower()
+        if engine == "odim":
+            open_ = io.xarray.open_odim_dataset
+        if engine == "gamic":
+            open_ = io.xarray.open_gamic_dataset
+        if engine == "cfradial1":
+            open_ = io.xarray.open_cfradial1_dataset
+        if engine == "cfradial2":
+            open_ = io.xarray.open_cfradial2_dataset
+        yield open_(h5file, **kwargs)
+
+
+@contextlib.contextmanager
+def get_synthetic_volume(name, file_or_filelike, **kwargs):
+    tmp_local = tempfile.NamedTemporaryFile(suffix=".h5", prefix=name).name
+    if "gamic" in name:
+        format = "GAMIC"
+    else:
+        format = "ODIM"
+    with h5py.File(str(tmp_local), "w") as f:
+        data = globals()[name]()
+        write_group(f, data)
+    with get_wradlib_data_file(tmp_local, file_or_filelike) as h5file:
+        engine = format.lower()
+        if engine == "odim":
+            open_ = io.xarray.open_odim_dataset
+        if engine == "gamic":
+            open_ = io.xarray.open_gamic_dataset
+        yield open_(h5file, **kwargs)
+
+
+def create_volume_repr(swp, ele, cls):
+    ele = [f"{e:.1f}" for e in ele]
+    repr = "".join(
+        [
+            f"<wradlib.{cls}>\n",
+            f"Dimension(s): (sweep: {swp})\n",
+            f"Elevation(s): ({', '.join(ele)})",
+        ]
+    )
+    return repr
+
+
+class DataVolume:
+    def test_volumes(self, file_or_filelike):
+        with self.get_volume_data(file_or_filelike) as vol:
+            assert isinstance(vol, io.xarray.RadarVolume)
+            repr = create_volume_repr(self.sweeps, self.elevations, type(vol).__name__)
+            print("repr", repr)
+            print(vol.__repr__())
+            assert vol.__repr__() == repr
+            print(vol[0])
+        del vol
+        gc.collect()
+
+    def test_sweeps(self, file_or_filelike):
+        if self.format.lower() in ["gamic", "odim"]:
+            backend_kwargs = dict(keep_azimuth=True)
+        else:
+            backend_kwargs = {}
+        with self.get_volume_data(
+            file_or_filelike, backend_kwargs=backend_kwargs
+        ) as vol:
+            for i, ds in enumerate(vol):
+                assert isinstance(ds, xr.Dataset)
+                assert self.azimuths[i] == ds.dims["azimuth"]
+                assert self.ranges[i] == ds.dims["range"]
+
+    def test_odim_output(self, file_or_filelike):
+        with self.get_volume_data(file_or_filelike) as vol:
+            tmp_local = tempfile.NamedTemporaryFile(suffix=".h5", prefix="odim").name
+            if self.format.lower() == "cfradial2":
+                for i in range(len(vol)):
+                    ds = io.xarray._rewrite_time_reference_units(vol[i])
+                    vol[i] = xr.decode_cf(ds)
+            vol.to_odim(tmp_local)
+        del vol
+        gc.collect()
+
+    def test_cfradial2_output(self, file_or_filelike):
+        with self.get_volume_data(file_or_filelike) as vol:
+            tmp_local = tempfile.NamedTemporaryFile(
+                suffix=".nc", prefix="cfradial"
+            ).name
+            vol.to_cfradial2(tmp_local)
+        del vol
+        gc.collect()
+
+    def test_netcdf_output(self, file_or_filelike):
+        with self.get_volume_data(file_or_filelike) as vol:
+            tmp_local = tempfile.NamedTemporaryFile(
+                suffix=".nc", prefix="cfradial"
+            ).name
+            vol.to_netcdf(tmp_local, timestep=slice(0, None))
+        del vol
+        gc.collect()
+
+
+class MeasuredDataVolume(DataVolume):
+    @contextlib.contextmanager
+    def get_volume_data(self, fileobj, **kwargs):
+        if "cfradial" in self.format.lower() and fileobj == "filelike":
+            pytest.skip("cfradial doesn't work with filelike")
+        with get_measured_volume(self.name, self.format, fileobj, **kwargs) as vol:
+            yield vol
+
+
+class SyntheticDataVolume(DataVolume):
+    @contextlib.contextmanager
+    def get_volume_data(self, fileobj, **kwargs):
+        with get_synthetic_volume(self.name, fileobj, **kwargs) as vol:
+            yield vol
+
+
+@requires_data
+@requires_xarray_backend_api
+class TestKNMIVolume(MeasuredDataVolume):
+    if has_data:
+        name = "hdf5/knmi_polar_volume.h5"
+        format = "ODIM"
+        volumes = 1
+        sweeps = 14
+        moments = ["DBZH"]
+        elevations = [
+            0.3,
+            0.4,
+            0.8,
+            1.1,
+            2.0,
+            3.0,
+            4.5,
+            6.0,
+            8.0,
+            10.0,
+            12.0,
+            15.0,
+            20.0,
+            25.0,
+        ]
+        azimuths = [360] * sweeps
+        ranges = [320, 240, 240, 240, 240, 340, 340, 300, 300, 240, 240, 240, 240, 240]
+
+        data = io.read_generic_hdf5(util.get_wradlib_data_file(name))
+
+        dsdesc = "dataset{}"
+        mdesc = "data{}"
+
+
+@requires_data
+@requires_xarray_backend_api
+class TestGamicVolume(MeasuredDataVolume):
+    if has_data:
+        name = "hdf5/DWD-Vol-2_99999_20180601054047_00.h5"
+        format = "GAMIC"
+        volumes = 1
+        sweeps = 10
+        moments = [
+            "DBZH",
+            "DBZV",
+            "DBTH",
+            "DBTV",
+            "ZDR",
+            "VRADH",
+            "VRADV",
+            "WRADH",
+            "WRADV",
+            "PHIDP",
+            "KDP",
+            "RHOHV",
+        ]
+        elevations = [28.0, 18.0, 14.0, 11.0, 8.2, 6.0, 4.5, 3.1, 1.7, 0.6]
+        azimuths = [360, 360, 360, 360, 360, 360, 360, 360, 360, 360]
+        ranges = [360, 500, 620, 800, 1050, 1400, 1000, 1000, 1000, 1000]
+
+        data = io.read_generic_hdf5(util.get_wradlib_data_file(name))
+
+        dsdesc = "scan{}"
+        mdesc = "moment_{}"
+
+
+@requires_data
+@requires_xarray_backend_api
+class TestCfRadial1Volume(MeasuredDataVolume):
+    if has_data:
+        name = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR.nc"
+        format = "CfRadial1"
+        volumes = 1
+        sweeps = 9
+        moments = [
+            "DBZH",
+            "DBZV",
+            "DBTH",
+            "DBTV",
+            "ZDR",
+            "VRADH",
+            "VRADV",
+            "WRADH",
+            "WRADV",
+            "PHIDP",
+            "KDP",
+            "RHOHV",
+        ]
+        elevations = [0.5, 1.1, 1.8, 2.6, 3.6, 4.7, 6.5, 9.1, 12.8]
+        azimuths = [483, 483, 482, 483, 481, 482, 482, 484, 483]
+        ranges = [996, 996, 996, 996, 996, 996, 996, 996, 996]
+
+        data = io.read_generic_hdf5(util.get_wradlib_data_file(name))
+
+        dsdesc = "sweep{}"
+        mdesc = "moment_{}"
+
+
+@requires_data
+@requires_xarray_backend_api
+class TestCfRadial2Volume(MeasuredDataVolume):
+    if has_data:
+        name = "netcdf/cfrad.20080604_002217_000_SPOL_v36_SUR_cfradial2.nc"
+        format = "CfRadial2"
+        volumes = 1
+        sweeps = 9
+        moments = [
+            "DBZH",
+            "DBZV",
+            "DBTH",
+            "DBTV",
+            "ZDR",
+            "VRADH",
+            "VRADV",
+            "WRADH",
+            "WRADV",
+            "PHIDP",
+            "KDP",
+            "RHOHV",
+        ]
+        elevations = [0.5, 1.1, 1.8, 2.6, 3.6, 4.7, 6.5, 9.1, 12.8]
+        azimuths = [480, 480, 480, 480, 480, 480, 480, 480, 480]
+        ranges = [996, 996, 996, 996, 996, 996, 996, 996, 996]
+
+        data = io.read_generic_hdf5(util.get_wradlib_data_file(name))
+
+        dsdesc = "sweep{}"
+        mdesc = "moment_{}"
+
+
+@requires_xarray_backend_api
+class TestSyntheticOdimVolume01(SyntheticDataVolume):
+    name = "base_odim_data_00"
+    format = "ODIM"
+    volumes = 1
+    sweeps = 2
+    moments = ["DBZH"]
+    elevations = [0.5, 1.5]
+    azimuths = [360, 360]
+    ranges = [100, 100]
+
+    data = globals()[name]()
+
+    dsdesc = "dataset{}"
+    mdesc = "data{}"
+
+
+@requires_xarray_backend_api
+class TestSyntheticOdimVolume02(SyntheticDataVolume):
+    name = "base_odim_data_01"
+    format = "ODIM"
+    volumes = 1
+    sweeps = 2
+    moments = ["DBZH"]
+    elevations = [0.5, 1.5]
+    azimuths = [360, 360]
+    ranges = [100, 100]
+
+    data = globals()[name]()
+
+    dsdesc = "dataset{}"
+    mdesc = "data{}"
+
+
+@requires_xarray_backend_api
+class TestSyntheticOdimVolume03(SyntheticDataVolume):
+    name = "base_odim_data_02"
+    format = "ODIM"
+    volumes = 1
+    sweeps = 2
+    moments = ["DBZH"]
+    elevations = [0.5, 1.5]
+    azimuths = [360, 360]
+    ranges = [100, 100]
+
+    data = globals()[name]()
+
+    dsdesc = "dataset{}"
+    mdesc = "data{}"
+
+
+@requires_xarray_backend_api
+class TestSyntheticOdimVolume04(SyntheticDataVolume):
+    name = "base_odim_data_03"
+    format = "ODIM"
+    volumes = 1
+    sweeps = 2
+    moments = ["DBZH"]
+    elevations = [0.5, 1.5]
+    azimuths = [360, 360]
+    ranges = [100, 100]
+
+    data = globals()[name]()
+
+    dsdesc = "dataset{}"
+    mdesc = "data{}"
+
+
+@requires_xarray_backend_api
+class TestSyntheticGamicVolume01(SyntheticDataVolume):
+    name = "base_gamic_data"
+    format = "GAMIC"
+    volumes = 1
+    sweeps = 2
+    moments = ["DBZH"]
+    elevations = [0.5, 1.5]
+    azimuths = [360, 360]
+    ranges = [100, 100]
+
+    data = globals()[name]()
+
+    dsdesc = "scan{}"
+    mdesc = "moment_{}"


### PR DESCRIPTION
This PR adds an xarray backend for cfradial, odim and gamic data.

Please note, that for this to work, `xarray>=0.17.0` is needed. For the `mfdataset` functions `dask` is needed too.

ODIM_H5 data can be read directly into an xarray dataset like following:

```python
ds = wrl.io.open_odim_dataset(filename_or_obj)
ds = wrl.io.open_odim_mfdataset(flist)

ds = xr.open_dataset(filename_or_obj, engine="odim", group="dataset1")
ds = xr.open_mfdataset(flist, engine="odim", group="dataset1")
```
GAMIC data can be read directly into an xarray dataset like following:

```python
ds = wrl.io.open_gamic_dataset(filename_or_obj)
ds = wrl.io.open_gamic_mfdataset(flist)

ds = xr.open_dataset(filename_or_obj, engine="gamic", group="scan0")
ds = xr.open_mfdataset(flist, engine="gamic", group="scan0")
```
CfRadial1 data can be read directly into an xarray dataset like following:

```python
ds = wrl.io.open_cfradial1_dataset(filename_or_obj)
ds = wrl.io.open_cfradial1_mfdataset(flist)

ds = xr.open_dataset(filename_or_obj, engine="cfradial1", group="sweep_1")
ds = xr.open_mfdataset(flist, engine="cfradial1", group="sweep_1")
```
CfRadial2 data can be read directly into an xarray dataset like following:

```python
ds = wrl.io.open_cfradial2_dataset(filename_or_obj)
ds = wrl.io.open_cfradial2_mfdataset(flist)

ds = xr.open_dataset(filename_or_obj, engine="cfradial2", group="sweep_1")
ds = xr.open_mfdataset(flist, engine="cfradial2", group="sweep_1")
```

Additionally take into account, that the the `wrl.io.open_backend_dataset` and `wrl.io.open_backend_mfdataset` functions can read volume files into `RadarVolume` wrapper. The xarray `open_dataset` and `open_mfdataset` will use the first group ("dataset1", "scan0") for `odim`/`gamic` and the root group for `cfradialN` backends if no group is given.
