### PR TITLE
Add support for radolan HG product

### DIFF
--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -1011,6 +1011,8 @@ class _radolan_file(object):
         if self._dtype is None:
             if self.product in ["RX", "EX", "WX"]:
                 self._dtype = np.dtype(np.uint8)
+            elif self.product in ["HG"]:
+                self._dtype = np.dtype(np.uint32)
             else:
                 self._dtype = np.dtype(np.uint16)
         return self._dtype


### PR DESCRIPTION
As per the official format description, the HG product uses 4 bytes per pixel (which is, allow me to say, entirely unnecessary - given that it encodes only a handful of different precipitation types...).

https://www.dwd.de/DE/leistungen/radarprodukte/formatbeschreibung_hg.pdf

This MR fixes `wrl.io.radolan.read_radolan_composite` for HG products (from https://opendata.dwd.de/weather/radar/composit/hg/), which was failing with `ValueError: cannot reshape array of size 2640000 into shape (1200,1100)` before.