### PR TITLE
FIX: only take valid times when output in `to_odim`

### DIFF
--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -950,7 +950,7 @@ def to_odim(volume, filename, timestep=0):
 
         # how group, p. 14 ff.
         h5_ds_how = h5_dataset.create_group("how")
-        tout = [tx.astype("O") / 1e9 for tx in ds.sortby("azimuth").time.values]
+        tout = [tx.astype("O") / 1e9 for tx in ds.sortby("azimuth").time.values[valid_times]]
         tout_sorted = sorted(tout)
 
         # handle non-uniform times (eg. only second-resolution)


### PR DESCRIPTION
the wradlib.io.to_odim function in the xarray.py file crashed because the RadarVolume present contained undefined times for certain azimuths. If only the valid_times are considered, the bug is fixed.

@TiemoMathijssen
I've recreated the PullRequest to point to https://github.com/wradlib/wradlib main-branch instead of your forks main branch. The easiest way to PR a branch is to go to the upstream repo (eg. https://github.com/wradlib/wradlib/pulls) and then use "compare across forks" to select your forks feature branch.