### PR TITLE
FIX: odim xarray reader issues

### DIFF
--- a/wradlib/io/backends.py
+++ b/wradlib/io/backends.py
@@ -477,6 +477,7 @@ class OdimBackendEntrypoint(BackendEntrypoint):
         decode_vlen_strings=True,
         keep_elevation=False,
         keep_azimuth=False,
+        reindex_angle=None,
     ):
 
         if isinstance(filename_or_obj, io.IOBase):
@@ -504,8 +505,8 @@ class OdimBackendEntrypoint(BackendEntrypoint):
             decode_timedelta=decode_timedelta,
         )
 
-        if decode_coords:
-            ds = ds.pipe(_reindex_angle, store=store)
+        if decode_coords and reindex_angle is not False:
+            ds = ds.pipe(_reindex_angle, store=store, tol=reindex_angle)
 
         if not keep_azimuth:
             if ds.azimuth.dims[0] == "elevation":
@@ -654,6 +655,7 @@ class GamicBackendEntrypoint(BackendEntrypoint):
         decode_vlen_strings=True,
         keep_elevation=False,
         keep_azimuth=False,
+        reindex_angle=None,
     ):
 
         if isinstance(filename_or_obj, io.IOBase):
@@ -683,8 +685,8 @@ class GamicBackendEntrypoint(BackendEntrypoint):
 
         ds = ds.sortby(list(ds.dims.keys())[0])
 
-        if decode_coords:
-            ds = ds.pipe(_reindex_angle, store=store)
+        if decode_coords and reindex_angle is not False:
+            ds = ds.pipe(_reindex_angle, store=store, tol=reindex_angle)
 
         if not keep_azimuth:
             if ds.azimuth.dims[0] == "elevation":

--- a/wradlib/io/hdf.py
+++ b/wradlib/io/hdf.py
@@ -55,6 +55,16 @@ def open_odim_dataset(filename_or_obj, group=None, **kwargs):
 
     Keyword Arguments
     -----------------
+    keep_elevation : bool
+        For PPI only. Keep original elevation data if True. Defaults to False,
+        which fixes erroneous elevation data.
+    keep_azimuth : bool
+        For RHI only. Keep original azimuth data if True. Defaults to False,
+        which fixes erroneous azimuth data.
+    reindex_angle : bool | float
+        Defaults to None (reindex angle with tol=0.4deg). If given a floating point
+        number, it is used as tolerance. If False, no reindexing is performed.
+        Only invoked if `decode_coord=True`.
     **kwargs : optional
         Additional arguments passed on to :py:func:`xarray.open_dataset`.
 
@@ -87,6 +97,16 @@ def open_gamic_dataset(filename_or_obj, group=None, **kwargs):
 
     Keyword Arguments
     -----------------
+    keep_elevation : bool
+        For PPI only. Keep original elevation data if True. Defaults to False,
+        which fixes erroneous elevation data.
+    keep_azimuth : bool
+        For RHI only. Keep original azimuth data if True. Defaults to False,
+        which fixes erroneous azimuth data.
+    reindex_angle : bool | float
+        Defaults to None (reindex angle with tol=0.4deg). If given a floating point
+        number, it is used as tolerance. If False, no reindexing is performed.
+        Only invoked if `decode_coord=True`.
     **kwargs : optional
         Additional arguments passed on to :py:func:`xarray.open_dataset`.
 
@@ -119,6 +139,16 @@ def open_odim_mfdataset(filename_or_obj, group=None, **kwargs):
 
     Keyword Arguments
     -----------------
+    keep_elevation : bool
+        For PPI only. Keep original elevation data if True. Defaults to False,
+        which fixes erroneous elevation data.
+    keep_azimuth : bool
+        For RHI only. Keep original azimuth data if True. Defaults to False,
+        which fixes erroneous azimuth data.
+    reindex_angle : bool | float
+        Defaults to None (reindex angle with tol=0.4deg). If given a floating point
+        number, it is used as tolerance. If False, no reindexing is performed.
+        Only invoked if `decode_coord=True`.
     **kwargs : optional
         Additional arguments passed on to :py:func:`xarray.open_dataset`.
 
@@ -151,6 +181,16 @@ def open_gamic_mfdataset(filename_or_obj, group=None, **kwargs):
 
     Keyword Arguments
     -----------------
+    keep_elevation : bool
+        For PPI only. Keep original elevation data if True. Defaults to False,
+        which fixes erroneous elevation data.
+    keep_azimuth : bool
+        For RHI only. Keep original azimuth data if True. Defaults to False,
+        which fixes erroneous azimuth data.
+    reindex_angle : bool | float
+        Defaults to None (reindex angle with tol=0.4deg). If given a floating point
+        number, it is used as tolerance. If False, no reindexing is performed.
+        Only invoked if `decode_coord=True`.
     **kwargs : optional
         Additional arguments passed on to :py:func:`xarray.open_dataset`.
 

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -1449,9 +1449,11 @@ def _remove_duplicate_rays(ds, store=None):
     return ds
 
 
-def _reindex_angle(ds, store=None, force=False, tol=0.4):
+def _reindex_angle(ds, store=None, force=False, tol=None):
     # Todo: The current code assumes to have PPI's of 360deg and RHI's of 90deg,
     #       make this work also for sectorized measurements
+    if tol is True or tol is None:
+        tol = 0.4
     # disentangle different functionality
     full_range = dict(azimuth=360, elevation=90)
     dimname = list(ds.dims)[0]

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -1111,11 +1111,18 @@ class _OdimH5NetCDFMetadata(object):
 
     def _get_azimuth_how(self):
         grp = self._group.split("/")[0]
-        startaz = self._root[grp]["how"].attrs["startazA"]
-        stopaz = self._root[grp]["how"].attrs["stopazA"]
+        how = self._root[grp]["how"].attrs
+        startaz = how["startazA"]
+        stopaz = how.get("stopazA", False)
+        if stopaz is False:
+            # stopazA missing
+            # create from startazA
+            stopaz = np.roll(startaz, -1)
+            stopaz[-1] += 360
         zero_index = np.where(stopaz < startaz)
         stopaz[zero_index[0]] += 360
         azimuth_data = (startaz + stopaz) / 2.0
+        azimuth_data[azimuth_data >= 360] -= 360
         return azimuth_data
 
     def _get_azimuth_where(self):
@@ -1145,9 +1152,13 @@ class _OdimH5NetCDFMetadata(object):
 
     def _get_elevation_how(self):
         grp = self._group.split("/")[0]
-        startaz = self._root[grp]["how"].attrs["startelA"]
-        stopaz = self._root[grp]["how"].attrs["stopelA"]
-        elevation_data = (startaz + stopaz) / 2.0
+        how = self._root[grp]["how"].attrs
+        startaz = how.get("startelA", False)
+        stopaz = how.get("stopelA", False)
+        if startaz is not False and stopaz is not False:
+            elevation_data = (startaz + stopaz) / 2.0
+        else:
+            elevation_data = how.get("elangles")
         return elevation_data
 
     def _get_elevation_where(self):

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -1470,8 +1470,7 @@ def _reindex_angle(ds, store=None, force=False, tol=None):
     dimname = list(ds.dims)[0]
     # sort in any case, to prevent unsorted errors
     ds = ds.sortby(dimname)
-    secname = dict(azimuth="elevation",
-                   elevation="azimuth").get(dimname)
+    secname = dict(azimuth="elevation", elevation="azimuth").get(dimname)
     dim = ds[dimname]
     diff = dim.diff(dimname)
     # this captures different angle spacing

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -1468,7 +1468,10 @@ def _reindex_angle(ds, store=None, force=False, tol=None):
     # disentangle different functionality
     full_range = dict(azimuth=360, elevation=90)
     dimname = list(ds.dims)[0]
-    secname = "elevation"
+    # sort in any case, to prevent unsorted errors
+    ds = ds.sortby(dimname)
+    secname = dict(azimuth="elevation",
+                   elevation="azimuth").get(dimname)
     dim = ds[dimname]
     diff = dim.diff(dimname)
     # this captures different angle spacing

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -1040,7 +1040,6 @@ class _OdimH5NetCDFMetadata(object):
         rtime = self.ray_times
         dim, angle = self.fixed_dim_and_angle
         angle_res = _calculate_angle_res(locals()[dim])
-
         dims = ("azimuth", "elevation")
         if dim == dims[1]:
             dims = (dims[1], dims[0])
@@ -1158,7 +1157,7 @@ class _OdimH5NetCDFMetadata(object):
         if startaz is not False and stopaz is not False:
             elevation_data = (startaz + stopaz) / 2.0
         else:
-            elevation_data = how.get("elangles")
+            elevation_data = how["elangles"]
         return elevation_data
 
     def _get_elevation_where(self):

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -17,7 +17,7 @@ import xarray as xr
 
 from wradlib import georef, io, util, zonalstats
 
-from . import get_wradlib_data_file, requires_data, requires_secrets
+from . import get_wradlib_data_file, requires_data, requires_secrets, requires_xarray_backend_api
 
 
 @pytest.fixture(params=["file", "filelike"])
@@ -375,6 +375,57 @@ class TestHDF5:
         bbox = zonalstats.get_bbox(lon, lat)
 
         io.hdf.read_trmm(trmm_2a23_file, trmm_2a25_file, bbox)
+
+    @requires_data
+    @requires_xarray_backend_api
+    @pytest.mark.parametrize("opener", [io.hdf.open_odim_dataset, io.hdf.open_odim_mfdataset])
+    def test_open_odim_functions(self, opener):
+        filename = "hdf5/knmi_polar_volume.h5"
+        with get_wradlib_data_file(filename, "file") as odim_file:
+            ds = opener(odim_file)
+            assert isinstance(ds, io.xarray.RadarVolume)
+            for d in ds:
+                assert isinstance(d, xr.Dataset)
+            ds = opener(odim_file, group="dataset1")
+            assert isinstance(ds, xr.Dataset)
+            ds = opener(odim_file, reindex_angle=False)
+            assert isinstance(ds, io.RadarVolume)
+            for d in ds:
+                assert isinstance(d, xr.Dataset)
+            ds = opener(odim_file, reindex_angle=True)
+            assert isinstance(ds, io.RadarVolume)
+            for d in ds:
+                assert isinstance(d, xr.Dataset)
+            ds = opener(odim_file, reindex_angle=0.4)
+            assert isinstance(ds, io.RadarVolume)
+            for d in ds:
+                assert isinstance(d, xr.Dataset)
+
+    @requires_data
+    @requires_xarray_backend_api
+    @pytest.mark.parametrize("opener",
+                             [io.hdf.open_gamic_dataset, io.hdf.open_gamic_mfdataset])
+    def test_open_gamic_functions(self, opener):
+        filename = "hdf5/DWD-Vol-2_99999_20180601054047_00.h5"
+        with get_wradlib_data_file(filename, "file") as gamic_file:
+            ds = opener(gamic_file)
+            assert isinstance(ds, io.xarray.RadarVolume)
+            for d in ds:
+                assert isinstance(d, xr.Dataset)
+            ds = opener(gamic_file, group="scan0")
+            assert isinstance(ds, xr.Dataset)
+            ds = opener(gamic_file, reindex_angle=False)
+            assert isinstance(ds, io.RadarVolume)
+            for d in ds:
+                assert isinstance(d, xr.Dataset)
+            ds = opener(gamic_file, reindex_angle=True)
+            assert isinstance(ds, io.RadarVolume)
+            for d in ds:
+                assert isinstance(d, xr.Dataset)
+            ds = opener(gamic_file, reindex_angle=0.4)
+            assert isinstance(ds, io.RadarVolume)
+            for d in ds:
+                assert isinstance(d, xr.Dataset)
 
 
 class TestRadolan:

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -17,7 +17,12 @@ import xarray as xr
 
 from wradlib import georef, io, util, zonalstats
 
-from . import get_wradlib_data_file, requires_data, requires_secrets, requires_xarray_backend_api
+from . import (
+    get_wradlib_data_file,
+    requires_data,
+    requires_secrets,
+    requires_xarray_backend_api,
+)
 
 
 @pytest.fixture(params=["file", "filelike"])
@@ -378,7 +383,9 @@ class TestHDF5:
 
     @requires_data
     @requires_xarray_backend_api
-    @pytest.mark.parametrize("opener", [io.hdf.open_odim_dataset, io.hdf.open_odim_mfdataset])
+    @pytest.mark.parametrize(
+        "opener", [io.hdf.open_odim_dataset, io.hdf.open_odim_mfdataset]
+    )
     def test_open_odim_functions(self, opener):
         filename = "hdf5/knmi_polar_volume.h5"
         with get_wradlib_data_file(filename, "file") as odim_file:
@@ -403,8 +410,9 @@ class TestHDF5:
 
     @requires_data
     @requires_xarray_backend_api
-    @pytest.mark.parametrize("opener",
-                             [io.hdf.open_gamic_dataset, io.hdf.open_gamic_mfdataset])
+    @pytest.mark.parametrize(
+        "opener", [io.hdf.open_gamic_dataset, io.hdf.open_gamic_mfdataset]
+    )
     def test_open_gamic_functions(self, opener):
         filename = "hdf5/DWD-Vol-2_99999_20180601054047_00.h5"
         with get_wradlib_data_file(filename, "file") as gamic_file:


### PR DESCRIPTION
- add `reindex_angle` kwarg/backend_kwarg to `open_odim_dataset`/`open_gamic_dataset` readers
- correctly read ODIM_H5 V2.1 angle metadata
- correctly set secondary angle name in `_reindex_angle` -function

closes: #513 and #514 