### PR TITLE
ENH: Iris xarray reader, fix GAMIC reader

### DIFF
--- a/wradlib/io/backends.py
+++ b/wradlib/io/backends.py
@@ -1023,7 +1023,7 @@ class IrisStore(AbstractDataStore):
         data = ing_head[list(ing_head.keys())[0]]
 
         attributes = dict(
-            fixed_angle=data["fixed_angle"],
+            fixed_angle=np.round(data["fixed_angle"], 1),
         )
         # RHI limits
         if self.root.scan_mode == 2:
@@ -1080,6 +1080,8 @@ class IrisBackendEntrypoint(BackendEntrypoint):
         if decode_coords and reindex_angle is not False:
             ds = ds.drop_vars("DB_XHDR", errors="ignore")
             ds = ds.pipe(_reindex_angle, store=store, tol=reindex_angle)
+        else:
+            ds = ds.sortby(store.root.first_dimension)
 
         ds.attrs.pop("elevation_lower_limit", None)
         ds.attrs.pop("elevation_upper_limit", None)

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -185,17 +185,29 @@ def create_xarray_dataarray(*args, **kwargs):
 
 moment_attrs = {"standard_name", "long_name", "units"}
 
+
 iris_mapping = {
     "DB_DBT": "DBTH",
+    "DB_DBT2": "DBTH",
     "DB_DBZ": "DBZH",
+    "DB_DBZ2": "DBZH",
     "DB_VEL": "VRADH",
+    "DB_VEL2": "VRADH",
     "DB_WIDTH": "WRADH",
+    "DB_WIDTH2": "WRADH",
     "DB_ZDR": "ZDR",
+    "DB_ZDR2": "ZDR",
     "DB_KDP": "KDP",
+    "DB_KDP2": "KDP",
     "DB_PHIDP": "PHIDP",
+    "DB_PHIDP2": "PHIDP",
     "DB_SQI": "SQIH",
+    "DB_SQI2": "SQIH",
+    "DB_SNR16": "SNRH",
     "DB_RHOHV": "RHOHV",
+    "DB_RHOHV2": "RHOHV",
 }
+
 
 # CfRadial 2.0 - ODIM_H5 mapping
 moments_mapping = {
@@ -1575,8 +1587,9 @@ def _get_iris_group_names(filename):
     from wradlib.io.iris import _check_iris_file
 
     sid, opener = _check_iris_file(filename)
-    ds = opener(filename, loaddata=False)
-    return list(ds.data.keys())
+    with opener(filename, loaddata=False) as ds:
+        keys = list(ds.data.keys())
+    return keys
 
 
 def _get_odim_variable_name_and_attrs(name, attrs):

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -1612,9 +1612,12 @@ def _get_gamic_variable_name_and_attrs(attrs, dtype):
     name = attrs.pop("moment").lower()
     try:
         name = GAMIC_NAMES[name]
+        mapping = moments_mapping[name]
     except KeyError:
         # ds = ds.drop_vars(mom)
         pass
+    else:
+        attrs.update({key: mapping[key] for key in moment_attrs})
 
     dmax = np.iinfo(dtype).max
     dmin = np.iinfo(dtype).min

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -3231,8 +3231,8 @@ class XRadSweepGamic(XRadSweep):
             else:
                 gain = (dmax - dmin) / dmax
                 minval = dmin
-            gain = gain.astype(dtype)
-            minval = minval.astype(dtype)
+            gain = np.array([gain])[0].astype(dtype)
+            minval = np.array([minval])[0].astype(dtype)
             undetect = np.array([dmin])[0].astype(dtype)
             attrs["scale_factor"] = gain
             attrs["add_offset"] = minval

--- a/wradlib/io/xarray.py
+++ b/wradlib/io/xarray.py
@@ -1826,8 +1826,10 @@ def open_radar_dataset(filename_or_obj, engine=None, **kwargs):
             groups = _get_nc4group_names(filename_or_obj, engine)
         elif engine in ["gamic", "odim"]:
             groups = _get_h5group_names(filename_or_obj, engine)
-        else:
+        elif engine == "iris":
             groups = _get_iris_group_names(filename_or_obj)
+        else:
+            pass
 
     if engine in ["gamic", "odim"]:
         keep_azimuth = kwargs.pop("keep_azimuth", False)

--- a/wradlib/tests/test_io_backends.py
+++ b/wradlib/tests/test_io_backends.py
@@ -330,7 +330,7 @@ class TestCfRadial2Volume(MeasuredDataVolume):
 
 @requires_data
 @requires_xarray_backend_api
-class TestIrisVolume(MeasuredDataVolume):
+class TestIrisVolume01(MeasuredDataVolume):
     if has_data:
         name = "sigmet/cor-main131125105503.RAW2049"
         format = "Iris"
@@ -360,6 +360,39 @@ class TestIrisVolume(MeasuredDataVolume):
         mdesc = "moment_{}"
 
         backend_kwargs = dict(reindex_angle=False)
+
+
+@requires_data
+@requires_xarray_backend_api
+class TestIrisVolume02(MeasuredDataVolume):
+    if has_data:
+        name = "sigmet/SUR210819000227.RAWKPJV"
+        format = "Iris"
+        volumes = 1
+        sweeps = 1
+        moments = [
+            "DBTH",
+            "DBZH",
+            "VRADH",
+            "WRADH",
+            "ZDR",
+            "KDP",
+            "RHOHV",
+            "SQIH",
+            "PHIDP",
+            "DB_HCLASS2",
+            "SNRH",
+        ]
+        elevations = [0.5]
+        azimuths = [360]
+        ranges = [833]
+
+        data = io.read_iris(util.get_wradlib_data_file(name))
+
+        dsdesc = "sweep{}"
+        mdesc = "moment_{}"
+
+        backend_kwargs = dict(reindex_angle=1.0)
 
 
 @requires_xarray_backend_api


### PR DESCRIPTION
- round fixed decimal to one decimal (as other readers do)
- sortby first dimension in any case
- enhance iris_mapping (add more moments)
- add tests
- add cf-attributes in GAMIC reader
- fix if-clause in open_radar_dataset
- fix regression in legacy GAMIC reader