### PR TITLE
ENH: Optionalize dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
       run: |
         echo $WRADLIB_DATA
         export WRADLIB_DATA=`realpath $WRADLIB_DATA`
-        pytest -n auto --dist loadfile --verbose --doctest-modules --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs wradlib
+        pytest -n auto --dist loadfile --verbose --doctest-modules --doctest-plus --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs wradlib
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1.2.1
       with:
@@ -153,7 +153,7 @@ jobs:
       run: |
         echo $WRADLIB_DATA
         export WRADLIB_DATA=`python -c "import os, sys; print(os.path.realpath(sys.argv[1]))" $WRADLIB_DATA`
-        pytest -n auto --verbose --doctest-modules --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs wradlib
+        pytest -n auto --verbose --doctest-modules --doctest-plus --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs wradlib
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1.2.1
       with:
@@ -221,7 +221,7 @@ jobs:
         run: |
           eval "$(./micromamba shell hook -s bash)"
           micromamba activate wradlib-tests
-          pytest -n auto --verbose --doctest-modules --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs wradlib
+          pytest -n auto --verbose --doctest-modules --doctest-plus --durations=15 --cov-report xml:coverage.xml --cov=wradlib --pyargs wradlib
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.2.1
         with:

--- a/ci/requirements/notebooktests.txt
+++ b/ci/requirements/notebooktests.txt
@@ -18,6 +18,7 @@ pip
 psutil
 pytest
 pytest-cov
+pytest-doctestplus
 pytest-sugar
 pytest-xdist
 requests

--- a/ci/requirements/notebooktests.txt
+++ b/ci/requirements/notebooktests.txt
@@ -27,5 +27,5 @@ semver
 setuptools
 tqdm
 wetterdienst
-xarray
+xarray>=0.17.0,<0.20
 xmltodict

--- a/ci/requirements/unittests.txt
+++ b/ci/requirements/unittests.txt
@@ -20,5 +20,5 @@ requests
 scipy
 semver
 setuptools
-xarray
+xarray>=0.17.0,<0.20
 xmltodict

--- a/ci/requirements/unittests.txt
+++ b/ci/requirements/unittests.txt
@@ -13,6 +13,7 @@ matplotlib-base
 pip
 pytest
 pytest-cov
+pytest-doctestplus
 pytest-sugar
 pytest-xdist
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,5 @@
-dask
 deprecation
-gdal
-h5py
-h5netcdf
-netCDF4
-numpy
 matplotlib
-requests
+numpy
 scipy
 xarray>=0.17.0
-xmltodict

--- a/requirements_devel.txt
+++ b/requirements_devel.txt
@@ -4,6 +4,7 @@ nbconvert
 nbformat
 pytest
 pytest-cov
+pytest-doctestplus
 pytest-sugar
 pytest-xdist
 semver

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,0 +1,7 @@
+dask
+gdal
+h5netcdf
+h5py
+netCDF4
+requests
+xmltodict

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -7,9 +7,9 @@ set -e
 if [[ "$TRAVIS" == "true" ]]; then
     # export location of .coveragerc
     export COVERAGE_PROCESS_START=$WRADLIB_BUILD_DIR/.coveragerc
-    coverage run -m pytest --verbose --doctest-modules --durations=15 --pyargs $1
+    coverage run -m pytest --verbose --doctest-modules --doctest-plus --durations=15 --pyargs $1
     coverage combine
     coverage xml
 else
-    pytest --verbose --doctest-modules --durations=15 --pyargs $1
+    pytest --verbose --doctest-modules --doctest-plus --durations=15 --pyargs $1
 fi

--- a/setup.py
+++ b/setup.py
@@ -173,8 +173,13 @@ def setup_package():
     with open("requirements.txt", "r") as f:
         INSTALL_REQUIRES = [rq for rq in f.read().split("\n") if rq != ""]
 
+    with open("requirements_optional.txt", "r") as f:
+        OPTIONAL_REQUIRES = [rq for rq in f.read().split("\n") if rq != ""]
+
     with open("requirements_devel.txt", "r") as f:
         DEVEL_REQUIRES = [rq for rq in f.read().split("\n") if rq != ""]
+
+    INSTALL_REQUIRES += OPTIONAL_REQUIRES
 
     metadata = dict(
         name=NAME,
@@ -189,7 +194,9 @@ def setup_package():
         classifiers=CLASSIFIERS,
         platforms=PLATFORMS,
         install_requires=INSTALL_REQUIRES,
-        extras_require={"dev": DEVEL_REQUIRES},
+        extras_require=dict(
+            dev=DEVEL_REQUIRES,
+        ),
         packages=find_packages(),
         entry_points={
             "xarray.backends": [

--- a/wradlib/georef/polar.py
+++ b/wradlib/georef/polar.py
@@ -23,12 +23,14 @@ __all__ = [
     "maximum_intensity_projection",
 ]
 __doc__ = __doc__.format("\n   ".join(__all__))
+__doctest_requires__ = {"spherical*": ["osgeo"]}
 
 import warnings
 
 import numpy as np
 
 from wradlib.georef import misc, projection
+from wradlib.util import has_import, import_optional
 
 
 def spherical_to_xyz(
@@ -100,7 +102,11 @@ def spherical_to_xyz(
             "+b={b:f} +units=m +no_defs"
         ).format(lon=sitecoords[0], lat=sitecoords[1], a=re, b=re)
 
-    rad = projection.proj4_to_osr(projstr)
+    osr = import_optional("osgeo.osr")
+    if has_import(osr):
+        rad = projection.proj4_to_osr(projstr)
+    else:
+        rad = projstr
 
     r = np.asanyarray(r)
     theta = np.asanyarray(theta)

--- a/wradlib/georef/projection.py
+++ b/wradlib/georef/projection.py
@@ -30,7 +30,12 @@ __doc__ = __doc__.format("\n   ".join(__all__))
 from distutils.version import LooseVersion
 
 import numpy as np
-from osgeo import gdal, ogr, osr
+
+from wradlib.util import import_optional
+
+gdal = import_optional("osgeo.gdal")
+ogr = import_optional("osgeo.ogr")
+osr = import_optional("osgeo.osr")
 
 
 def create_osr(projname, **kwargs):

--- a/wradlib/georef/raster.py
+++ b/wradlib/georef/raster.py
@@ -31,10 +31,14 @@ __all__ = [
 __doc__ = __doc__.format("\n   ".join(__all__))
 
 import numpy as np
-from osgeo import gdal, gdal_array, osr
 
 import wradlib
 from wradlib import georef
+from wradlib.util import import_optional
+
+gdal = import_optional("osgeo.gdal")
+gdal_array = import_optional("osgeo.gdal_array")
+osr = import_optional("osgeo.osr")
 
 
 def _pixel_coordinates(nx, ny, mode):

--- a/wradlib/georef/rect.py
+++ b/wradlib/georef/rect.py
@@ -21,13 +21,15 @@ __all__ = [
     "grid_to_polyvert",
 ]
 __doc__ = __doc__.format("\n   ".join(__all__))
+__doctest_requires__ = {"get_radolan_grid": ["osgeo"]}
 
 import numpy as np
 
 from wradlib.georef import projection
+from wradlib.util import has_import, import_optional
 
 
-def get_radolan_coords(lon, lat, trig=False):
+def get_radolan_coords(lon, lat, trig=None):
     """
     Calculates x,y coordinates of radolan grid from lon, lat
 
@@ -46,8 +48,12 @@ def get_radolan_coords(lon, lat, trig=False):
         `trig` is recommended to be False, however, the two ways of
         computation are expected to be equivalent.
     """
-
+    osr = import_optional("osgeo.osr")
+    # use trig if osgeo.osr is not available
+    if trig is None:
+        trig = not has_import(osr)
     if trig:
+
         # calculation of x_0 and y_0 coordinates of radolan grid
         # as described in the format description
         phi_0 = np.radians(60)

--- a/wradlib/georef/vector.py
+++ b/wradlib/georef/vector.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2020, wradlib developers.
+# Copyright (c) 2011-2021, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -32,12 +32,17 @@ __doc__ = __doc__.format("\n   ".join(__all__))
 import warnings
 
 import numpy as np
-from osgeo import gdal, ogr, osr
 
 from wradlib.georef import projection
+from wradlib.util import has_import, import_optional
 
-ogr.UseExceptions()
-gdal.UseExceptions()
+gdal = import_optional("osgeo.gdal")
+ogr = import_optional("osgeo.ogr")
+osr = import_optional("osgeo.osr")
+
+if has_import(gdal):
+    ogr.UseExceptions()
+    gdal.UseExceptions()
 
 
 def get_vector_points(geom):

--- a/wradlib/georef/xarray.py
+++ b/wradlib/georef/xarray.py
@@ -20,9 +20,11 @@ import collections
 
 import numpy as np
 import xarray as xr
-from osgeo import osr
 
 from wradlib.georef import polar
+from wradlib.util import has_import, import_optional
+
+osr = import_optional("osgeo.osr")
 
 
 def as_xarray_dataarray(data, dims, coords):
@@ -178,7 +180,7 @@ def georeference_dataset(obj, **kwargs):
     r, az = np.meshgrid(obj["range"], obj["azimuth"])
 
     # GDAL OSR, convert to this proj
-    if isinstance(proj, osr.SpatialReference):
+    if has_import(osr) and isinstance(proj, osr.SpatialReference):
         xyz = polar.spherical_to_proj(
             r, az, obj["elevation"], site, proj=proj, re=re, ke=ke
         )

--- a/wradlib/io/backends.py
+++ b/wradlib/io/backends.py
@@ -228,8 +228,7 @@ class H5NetCDFArrayWrapper(BackendArray):
 
     def get_array(self, needs_lock=True):
         ds = self.datastore._acquire(needs_lock)
-        variable = ds.variables[self.variable_name]
-        return variable
+        return ds.variables[self.variable_name]
 
     def __getitem__(self, key):
         return indexing.explicit_indexing_adapter(
@@ -290,7 +289,7 @@ class OdimSubStore(AbstractDataStore):
         self,
         store,
         group=None,
-        lock=HDF5_LOCK,
+        lock=False,
     ):
 
         if not isinstance(store, OdimStore):
@@ -349,13 +348,13 @@ class OdimSubStore(AbstractDataStore):
 class OdimStore(AbstractDataStore):
     """Store for reading ODIM dataset groups via h5netcdf."""
 
-    def __init__(self, manager, group=None, lock=HDF5_LOCK):
+    def __init__(self, manager, group=None, lock=False):
 
         if isinstance(manager, (h5netcdf.File, h5netcdf.Group)):
             if group is None:
                 root, group = find_root_and_group(manager)
             else:
-                if not type(manager) is h5netcdf.File:
+                if type(manager) is not h5netcdf.File:
                     raise ValueError(
                         "must supply a h5netcdf.File if the group "
                         "argument is provided"
@@ -410,7 +409,7 @@ class OdimStore(AbstractDataStore):
             if has_import(dask):
                 lock = HDF5_LOCK
             else:
-                lock = combine_locks([HDF5_LOCK, get_write_lock(filename)])
+                lock = False
 
         manager = CachingFileManager(h5netcdf.File, filename, mode=mode, kwargs=kwargs)
         return cls(manager, group=group, lock=lock)
@@ -536,13 +535,13 @@ class OdimBackendEntrypoint(BackendEntrypoint):
 class GamicStore(AbstractDataStore):
     """Store for reading ODIM dataset groups via h5netcdf."""
 
-    def __init__(self, manager, group=None, lock=HDF5_LOCK):
+    def __init__(self, manager, group=None, lock=False):
 
         if isinstance(manager, (h5netcdf.File, h5netcdf.Group)):
             if group is None:
                 root, group = find_root_and_group(manager)
             else:
-                if not type(manager) is h5netcdf.File:
+                if type(manager) is not h5netcdf.File:
                     raise ValueError(
                         "must supply a h5netcdf.File if the group "
                         "argument is provided"
@@ -596,7 +595,7 @@ class GamicStore(AbstractDataStore):
             if has_import(dask):
                 lock = HDF5_LOCK
             else:
-                lock = combine_locks([HDF5_LOCK, get_write_lock(filename)])
+                lock = False
 
         manager = CachingFileManager(h5netcdf.File, filename, mode=mode, kwargs=kwargs)
         return cls(manager, group=group, lock=lock)
@@ -791,6 +790,7 @@ class CfRadial2BackendEntrypoint(BackendEntrypoint):
             filename_or_obj,
             format=format,
             group=None,
+            lock=False,
         )
 
         if group is not None:
@@ -814,6 +814,7 @@ class CfRadial2BackendEntrypoint(BackendEntrypoint):
                 filename_or_obj,
                 format=format,
                 group=group,
+                lock=False,
             )
 
         store_entrypoint = StoreBackendEntrypoint()

--- a/wradlib/io/gdal.py
+++ b/wradlib/io/gdal.py
@@ -22,7 +22,10 @@ __doc__ = __doc__.format("\n   ".join(__all__))
 
 import os
 
-from osgeo import gdal, osr
+from wradlib.util import import_optional
+
+osr = import_optional("osgeo.osr")
+gdal = import_optional("osgeo.gdal")
 
 
 def open_vector(filename, driver=None, layer=0):
@@ -116,7 +119,7 @@ def read_safnwc(filename):
 
 
 def gdal_create_dataset(
-    drv, name, cols=0, rows=0, bands=0, gdal_type=gdal.GDT_Unknown, remove=False
+    drv, name, cols=0, rows=0, bands=0, gdal_type=None, remove=False
 ):
     """Creates GDAL.DataSet object.
 
@@ -143,6 +146,9 @@ def gdal_create_dataset(
     out : :py:class:`gdal:osgeo.gdal.Dataset`
         gdal.Dataset
     """
+    if gdal_type is None:
+        gdal_type = gdal.GDT_Unknown
+
     driver = gdal.GetDriverByName(drv)
     metadata = driver.GetMetadata()
 

--- a/wradlib/io/hdf.py
+++ b/wradlib/io/hdf.py
@@ -29,8 +29,6 @@ __doc__ = __doc__.format("\n   ".join(__all__))
 import datetime as dt
 from distutils.version import LooseVersion
 
-import h5py
-import netCDF4 as nc
 import numpy as np
 
 from wradlib.io.xarray import (
@@ -38,6 +36,10 @@ from wradlib.io.xarray import (
     open_radar_mfdataset,
     raise_on_missing_xarray_backend,
 )
+from wradlib.util import import_optional
+
+h5py = import_optional("h5py")
+nc = import_optional("netCDF4")
 
 
 def open_odim_dataset(filename_or_obj, group=None, **kwargs):

--- a/wradlib/io/netcdf.py
+++ b/wradlib/io/netcdf.py
@@ -26,7 +26,6 @@ import collections
 import contextlib
 import datetime as dt
 
-import netCDF4 as nc
 import numpy as np
 
 from wradlib.io.xarray import (
@@ -34,6 +33,9 @@ from wradlib.io.xarray import (
     open_radar_mfdataset,
     raise_on_missing_xarray_backend,
 )
+from wradlib.util import import_optional
+
+nc = import_optional("netCDF4")
 
 
 @contextlib.contextmanager

--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -1226,4 +1226,6 @@ def open_radolan_mfdataset(paths, **kwargs):
         copy=kwargs.pop("copy", False),
     )
     kwargs["backend_kwargs"] = backend_kwargs
+    if kwargs.get("concat_dim", False):
+        kwargs["combine"] = "nested"
     return xr.open_mfdataset(paths, engine="radolan", **kwargs)

--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -473,7 +473,7 @@ def parse_dwd_composite_header(header):
                 out["ncol"] = int(dimstrings[1])
             if k == "LV":
                 lv = header[v[0] : v[1]].split()
-                out["nlevel"] = np.int(lv[0])
+                out["nlevel"] = int(lv[0])
                 out["level"] = np.array(lv[1:]).astype("float")
             if k == "MS":
                 locationstring = header[v[0] :].strip().split("<")[1].split(">")[0]

--- a/wradlib/tests/__init__.py
+++ b/wradlib/tests/__init__.py
@@ -46,3 +46,71 @@ def get_wradlib_data_file(file, file_or_filelike):
             yield io.BytesIO(f.read())
     else:
         yield datafile
+
+
+dask = util.import_optional("dask")
+netCDF4 = util.import_optional("netCDF4")
+h5py = util.import_optional("h5py")
+h5netcdf = util.import_optional("h5netcdf")
+gdal = util.import_optional("osgeo.gdal")
+ogr = util.import_optional("osgeo.ogr")
+osr = util.import_optional("osgeo.osr")
+mpl = util.import_optional("matplotlib")
+cartopy = util.import_optional("cartopy")
+requests = util.import_optional("requests")
+xmltodict = util.import_optional("xmltodict")
+
+
+requires_dask = pytest.mark.skipif(
+    not util.has_import(dask),
+    reason="requires dask.",
+)
+
+requires_xmltodict = pytest.mark.skipif(
+    not util.has_import(xmltodict),
+    reason="requires xmltodict.",
+)
+
+requires_requests = pytest.mark.skipif(
+    not util.has_import(requests),
+    reason="requires requests.",
+)
+
+requires_matplotlib = pytest.mark.skipif(
+    not util.has_import(mpl),
+    reason="requires matplotlib.",
+)
+
+requires_cartopy = pytest.mark.skipif(
+    not util.has_import(cartopy),
+    reason="requires cartopy.",
+)
+
+requires_netcdf = pytest.mark.skipif(
+    not util.has_import(netCDF4),
+    reason="requires netCDF4.",
+)
+
+requires_h5netcdf = pytest.mark.skipif(
+    not util.has_import(h5netcdf),
+    reason="requires h5netcdf.",
+)
+
+requires_h5py = pytest.mark.skipif(
+    not util.has_import(h5py),
+    reason="requires h5py.",
+)
+
+requires_gdal = pytest.mark.skipif(
+    not util.has_import(gdal),
+    reason="requires gdal.",
+)
+
+if not util.has_import(gdal):
+    has_geos = False
+else:
+    has_geos = util.has_geos()
+
+requires_geos = pytest.mark.skipif(
+    not has_geos, reason="GDAL missing, or GDAL without GEOS"
+)

--- a/wradlib/tests/test_clutter.py
+++ b/wradlib/tests/test_clutter.py
@@ -4,10 +4,11 @@
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import numpy as np
+import pytest
 
 from wradlib import clutter, georef, io, ipol, util
 
-from . import has_data, requires_data
+from . import requires_data, requires_gdal, requires_h5py, requires_netcdf
 
 
 # -------------------------------------------------------------------------------
@@ -53,25 +54,30 @@ class TestHistoCut:
         clutter.histo_cut(yearsum)
 
 
-class TestClassifyEchoFuzzyTest:
-    if has_data:
-        rhofile = util.get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-R.nc")
-        phifile = util.get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-P.nc")
-        reffile = util.get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-Z.nc")
-        dopfile = util.get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-V.nc")
-        zdrfile = util.get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-D.nc")
-        mapfile = util.get_wradlib_data_file("hdf5/TAG_cmap_sweeps" "_0204050607.hdf5")
-        # We need to organize our data as a dictionary
-        dat = {}
-        dat["rho"], attrs_rho = io.read_edge_netcdf(rhofile)
-        dat["phi"], attrs_phi = io.read_edge_netcdf(phifile)
-        dat["ref"], attrs_ref = io.read_edge_netcdf(reffile)
-        dat["dop"], attrs_dop = io.read_edge_netcdf(dopfile)
-        dat["zdr"], attrs_zdr = io.read_edge_netcdf(zdrfile)
-        dat["map"] = io.from_hdf5(mapfile)[0][0]
+@pytest.fixture(scope="class")
+def fuzzy_data():
+    rhofile = util.get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-R.nc")
+    phifile = util.get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-P.nc")
+    reffile = util.get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-Z.nc")
+    dopfile = util.get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-V.nc")
+    zdrfile = util.get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-D.nc")
+    mapfile = util.get_wradlib_data_file("hdf5/TAG_cmap_sweeps" "_0204050607.hdf5")
+    # We need to organize our data as a dictionary
+    dat = {}
+    dat["rho"], attrs_rho = io.read_edge_netcdf(rhofile)
+    dat["phi"], attrs_phi = io.read_edge_netcdf(phifile)
+    dat["ref"], attrs_ref = io.read_edge_netcdf(reffile)
+    dat["dop"], attrs_dop = io.read_edge_netcdf(dopfile)
+    dat["zdr"], attrs_zdr = io.read_edge_netcdf(zdrfile)
+    dat["map"] = io.from_hdf5(mapfile)[0][0]
+    yield dat
 
+
+class TestClassifyEchoFuzzyTest:
     @requires_data
-    def test_classify_echo_fuzzy(self):
+    @requires_netcdf
+    @requires_h5py
+    def test_classify_echo_fuzzy(self, fuzzy_data):
         weights = {
             "zdr": 0.4,
             "rho": 0.4,
@@ -80,65 +86,73 @@ class TestClassifyEchoFuzzyTest:
             "dop": 0.1,
             "map": 0.5,
         }
-        clutter.classify_echo_fuzzy(self.dat, weights=weights, thresh=0.5)
+        clutter.classify_echo_fuzzy(fuzzy_data, weights=weights, thresh=0.5)
+
+
+@pytest.fixture(scope="class")
+def cloudtype_data():
+    # read the radar volume scan
+    filename = "hdf5/20130429043000.rad.bewid.pvol.dbzh.scan1.hdf"
+    filename = util.get_wradlib_data_file(filename)
+    pvol = io.read_opera_hdf5(filename)
+    nrays = int(pvol["dataset1/where"]["nrays"])
+    nbins = int(pvol["dataset1/where"]["nbins"])
+    val = pvol["dataset%d/data1/data" % (1)]
+    gain = float(pvol["dataset1/data1/what"]["gain"])
+    offset = float(pvol["dataset1/data1/what"]["offset"])
+    val = val * gain + offset
+    rscale = int(pvol["dataset1/where"]["rscale"])
+    elangle = pvol["dataset%d/where" % (1)]["elangle"]
+    coord = georef.sweep_centroids(nrays, rscale, nbins, elangle)
+    sitecoords = (
+        pvol["where"]["lon"],
+        pvol["where"]["lat"],
+        pvol["where"]["height"],
+    )
+
+    coord, proj_radar = georef.spherical_to_xyz(
+        coord[..., 0],
+        coord[..., 1],
+        coord[..., 2],
+        sitecoords,
+        re=6370040.0,
+        ke=4.0 / 3.0,
+    )
+    filename = "hdf5/SAFNWC_MSG3_CT___201304290415_BEL_________.h5"
+    filename = util.get_wradlib_data_file(filename)
+    sat_gdal = io.read_safnwc(filename)
+    val_sat = georef.read_gdal_values(sat_gdal)
+    coord_sat = georef.read_gdal_coordinates(sat_gdal)
+    proj_sat = georef.read_gdal_projection(sat_gdal)
+    coord_sat = georef.reproject(
+        coord_sat, projection_source=proj_sat, projection_target=proj_radar
+    )
+    coord_radar = coord
+    interp = ipol.Nearest(
+        coord_sat[..., 0:2].reshape(-1, 2), coord_radar[..., 0:2].reshape(-1, 2)
+    )
+    val_sat = interp(val_sat.ravel()).reshape(val.shape)
+    timelag = 9 * 60
+    wind = 10
+    error = np.absolute(timelag) * wind
+    dat = dict(val=val, val_sat=val_sat, rscale=rscale, error=error)
+    yield dat
 
 
 class TestFilterCloudtype:
-    if has_data:
-        # read the radar volume scan
-        filename = "hdf5/20130429043000.rad.bewid.pvol.dbzh.scan1.hdf"
-        filename = util.get_wradlib_data_file(filename)
-        pvol = io.read_opera_hdf5(filename)
-        nrays = int(pvol["dataset1/where"]["nrays"])
-        nbins = int(pvol["dataset1/where"]["nbins"])
-        val = pvol["dataset%d/data1/data" % (1)]
-        gain = float(pvol["dataset1/data1/what"]["gain"])
-        offset = float(pvol["dataset1/data1/what"]["offset"])
-        val = val * gain + offset
-        rscale = int(pvol["dataset1/where"]["rscale"])
-        elangle = pvol["dataset%d/where" % (1)]["elangle"]
-        coord = georef.sweep_centroids(nrays, rscale, nbins, elangle)
-        sitecoords = (
-            pvol["where"]["lon"],
-            pvol["where"]["lat"],
-            pvol["where"]["height"],
-        )
-
-        coord, proj_radar = georef.spherical_to_xyz(
-            coord[..., 0],
-            coord[..., 1],
-            coord[..., 2],
-            sitecoords,
-            re=6370040.0,
-            ke=4.0 / 3.0,
-        )
-        filename = "hdf5/SAFNWC_MSG3_CT___201304290415_BEL_________.h5"
-        filename = util.get_wradlib_data_file(filename)
-        sat_gdal = io.read_safnwc(filename)
-        val_sat = georef.read_gdal_values(sat_gdal)
-        coord_sat = georef.read_gdal_coordinates(sat_gdal)
-        proj_sat = georef.read_gdal_projection(sat_gdal)
-        coord_sat = georef.reproject(
-            coord_sat, projection_source=proj_sat, projection_target=proj_radar
-        )
-        coord_radar = coord
-        interp = ipol.Nearest(
-            coord_sat[..., 0:2].reshape(-1, 2), coord_radar[..., 0:2].reshape(-1, 2)
-        )
-        val_sat = interp(val_sat.ravel()).reshape(val.shape)
-        timelag = 9 * 60
-        wind = 10
-        error = np.absolute(timelag) * wind
-
     @requires_data
-    def test_filter_cloudtype(self):
-        nonmet = clutter.filter_cloudtype(
-            self.val, self.val_sat, scale=self.rscale, smoothing=self.error
-        )
+    @requires_gdal
+    @requires_h5py
+    def test_filter_cloudtype(self, cloudtype_data):
+        val = cloudtype_data["val"]
+        val_sat = cloudtype_data["val_sat"]
+        rscale = cloudtype_data["rscale"]
+        error = cloudtype_data["error"]
+        nonmet = clutter.filter_cloudtype(val, val_sat, scale=rscale, smoothing=error)
         nclutter = np.sum(nonmet)
         assert nclutter == 8141
         nonmet = clutter.filter_cloudtype(
-            self.val, self.val_sat, scale=self.rscale, smoothing=self.error, low=True
+            val, val_sat, scale=rscale, smoothing=error, low=True
         )
         nclutter = np.sum(nonmet)
         assert nclutter == 17856

--- a/wradlib/tests/test_dp.py
+++ b/wradlib/tests/test_dp.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from scipy import integrate
 
-from wradlib import dp
+from wradlib import dp, util
 
 
 @pytest.fixture(params=["lstsq", "cov", "matrix_inv", "lanczos_conv", "lanczos_dot"])
@@ -211,8 +211,12 @@ class TestKDPFromPHIDP:
         )
         np.testing.assert_array_almost_equal(out, out0, decimal=4)
 
+    def test_linear_despeckle_deprecated(self, ndespeckle):
+        with pytest.warns(DeprecationWarning):
+            dp.linear_despeckle(self.phidp_raw0, ndespeckle=ndespeckle, copy=True)
+
     def test_linear_despeckle(self, ndespeckle):
-        dp.linear_despeckle(self.phidp_raw0, ndespeckle=ndespeckle, copy=True)
+        util.despeckle(self.phidp_raw0, n=ndespeckle, copy=True)
 
     def test_unfold_phi_naive(self):
         dp.unfold_phi_naive(self.phidp_raw0, self.rho)

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -1138,7 +1138,9 @@ class TestRadolan:
         data = io.radolan.open_radolan_mfdataset(rw_file)
         assert data.RW.shape == (900, 900)
 
-        data = io.radolan.open_radolan_mfdataset(rw_file[:-23] + "*", concat_dim="time")
+        data = io.radolan.open_radolan_mfdataset(
+            rw_file[:-23] + "*.gz", concat_dim="time"
+        )
         assert data.RW.shape == (2, 900, 900)
         assert data.dims == {"x": 900, "y": 900, "time": 2}
         assert data.RW.dims == ("time", "y", "x")

--- a/wradlib/tests/test_io_backends.py
+++ b/wradlib/tests/test_io_backends.py
@@ -198,10 +198,6 @@ class MeasuredDataVolume(DataVolume):
         ) as vol:
             yield vol
 
-    @property
-    def data(self):
-        return io.read_generic_hdf5(util.get_wradlib_data_file(self.name))
-
 
 class SyntheticDataVolume(DataVolume):
     @contextlib.contextmanager

--- a/wradlib/tests/test_io_odim.py
+++ b/wradlib/tests/test_io_odim.py
@@ -1032,9 +1032,9 @@ class TestKNMIVolume(MeasuredDataVolume):
         dsdesc = "dataset{}"
         mdesc = "data{}"
 
-        @property
-        def data(self):
-            return io.read_generic_hdf5(util.get_wradlib_data_file(self.name))
+    @property
+    def data(self):
+        return io.read_generic_hdf5(util.get_wradlib_data_file(self.name))
 
 
 @requires_data

--- a/wradlib/tests/test_ipol.py
+++ b/wradlib/tests/test_ipol.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2020, wradlib developers.
+# Copyright (c) 2011-2021, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import warnings
@@ -9,6 +9,8 @@ import numpy as np
 import pytest
 
 from wradlib import georef, ipol
+
+from . import requires_gdal
 
 
 class TestInterpolation:
@@ -381,6 +383,7 @@ class TestRectGridInterpolation:
         np.testing.assert_allclose(res0, res1)
         np.testing.assert_allclose(res0a, res1)
 
+    @requires_gdal
     def test_QuadriArea(self):
         grid2 = self.grid2 + (-0.01, 0.01)
         ip = ipol.QuadriArea(grid2, self.grid)

--- a/wradlib/tests/test_verify.py
+++ b/wradlib/tests/test_verify.py
@@ -1,50 +1,89 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2020, wradlib developers.
+# Copyright (c) 2011-2021, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
+
+from dataclasses import dataclass
 
 import numpy as np
 import pytest
 
 from wradlib import georef, verify
 
+from . import requires_gdal
+
+
+@pytest.fixture
+def pol_data():
+    @dataclass(init=False, repr=False, eq=False)
+    class Data:
+        r = np.arange(1, 100, 10)
+        az = np.arange(0, 360, 90)
+        site = (9.7839, 48.5861)
+        proj = georef.epsg_to_osr(31467)
+        # Coordinates of the rain gages in Gauss-Krueger 3 coordinates
+        x, y = (np.array([3557880, 3557890]), np.array([5383379, 5383375]))
+
+        np.random.seed(42)
+        data = np.random.random((len(az), len(r)))
+
+    yield Data
+
 
 class TestPolarNeighbours:
-    r = np.arange(1, 100, 10)
-    az = np.arange(0, 360, 90)
-    site = (9.7839, 48.5861)
-    proj = georef.epsg_to_osr(31467)
-    # Coordinates of the rain gages in Gauss-Krueger 3 coordinates
-    x, y = (np.array([3557880, 3557890]), np.array([5383379, 5383375]))
-
-    np.random.seed(42)
-    data = np.random.random((len(az), len(r)))
-
-    def test___init__(self):
+    @requires_gdal
+    def test___init__(self, pol_data):
         verify.PolarNeighbours(
-            self.r, self.az, self.site, self.proj, self.x, self.y, nnear=9
+            pol_data.r,
+            pol_data.az,
+            pol_data.site,
+            pol_data.proj,
+            pol_data.x,
+            pol_data.y,
+            nnear=9,
         )
 
-    def test_extract(self):
+    @requires_gdal
+    def test_extract(self, pol_data):
         pn = verify.PolarNeighbours(
-            self.r, self.az, self.site, self.proj, self.x, self.y, nnear=4
+            pol_data.r,
+            pol_data.az,
+            pol_data.site,
+            pol_data.proj,
+            pol_data.x,
+            pol_data.y,
+            nnear=4,
         )
-        neighbours = pn.extract(self.data)
+        neighbours = pn.extract(pol_data.data)
         res0 = np.array([0.59241457, 0.04645041, 0.51423444, 0.19967378])
         res1 = np.array([0.04645041, 0.59241457, 0.51423444, 0.19967378])
         np.testing.assert_allclose(neighbours[0], res0)
         np.testing.assert_allclose(neighbours[1], res1)
 
-    def test_get_bincoords(self):
+    @requires_gdal
+    def test_get_bincoords(self, pol_data):
         pn = verify.PolarNeighbours(
-            self.r, self.az, self.site, self.proj, self.x, self.y, nnear=4
+            pol_data.r,
+            pol_data.az,
+            pol_data.site,
+            pol_data.proj,
+            pol_data.x,
+            pol_data.y,
+            nnear=4,
         )
         bx, by = pn.get_bincoords()
         np.testing.assert_allclose(bx[0], 3557908.88665658, rtol=1e-6)
         np.testing.assert_allclose(by[0], 5383452.639404042, rtol=1e-6)
 
-    def test_get_bincoords_at_points(self):
+    @requires_gdal
+    def test_get_bincoords_at_points(self, pol_data):
         pn = verify.PolarNeighbours(
-            self.r, self.az, self.site, self.proj, self.x, self.y, nnear=4
+            pol_data.r,
+            pol_data.az,
+            pol_data.site,
+            pol_data.proj,
+            pol_data.x,
+            pol_data.y,
+            nnear=4,
         )
         bx, by = pn.get_bincoords_at_points()
         resx0 = np.array(
@@ -67,25 +106,37 @@ class TestPolarNeighbours:
         np.testing.assert_allclose(by[1], resy1, rtol=1e-6)
 
 
+@pytest.fixture
+def err_data():
+    @dataclass(init=False, repr=False, eq=False)
+    class Data:
+        np.random.seed(42)
+        obs = np.random.uniform(0, 10, 100)
+        est = np.random.uniform(0, 10, 100)
+        non = np.zeros(100) * np.nan
+
+    yield Data
+
+
 class TestErrorMetrics:
-    np.random.seed(42)
-    obs = np.random.uniform(0, 10, 100)
-    est = np.random.uniform(0, 10, 100)
-    non = np.zeros(100) * np.nan
+    # np.random.seed(42)
+    # obs = np.random.uniform(0, 10, 100)
+    # est = np.random.uniform(0, 10, 100)
+    # non = np.zeros(100) * np.nan
 
-    def test___init__(self):
-        self.metrics = verify.ErrorMetrics(self.obs, self.est)
+    def test___init__(self, err_data):
+        self.metrics = verify.ErrorMetrics(err_data.obs, err_data.est)
         with pytest.raises(ValueError):
-            verify.ErrorMetrics(self.obs, self.est[:10])
+            verify.ErrorMetrics(err_data.obs, err_data.est[:10])
 
-    def test___init__warn(self):
+    def test___init__warn(self, err_data):
         with pytest.warns(UserWarning):
-            verify.ErrorMetrics(self.obs, self.non)
+            verify.ErrorMetrics(err_data.obs, err_data.non)
 
-    def test_all_metrics(self):
-        metrics = verify.ErrorMetrics(self.obs, self.est)
+    def test_all_metrics(self, err_data):
+        metrics = verify.ErrorMetrics(err_data.obs, err_data.est)
         metrics.all()
 
-    def test_pprint(self):
-        metrics = verify.ErrorMetrics(self.obs, self.est)
+    def test_pprint(self, err_data):
+        metrics = verify.ErrorMetrics(err_data.obs, err_data.est)
         metrics.pprint()

--- a/wradlib/tests/test_vis.py
+++ b/wradlib/tests/test_vis.py
@@ -1,54 +1,91 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2020, wradlib developers.
+# Copyright (c) 2011-2021, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
-import sys
 import tempfile
+from dataclasses import dataclass
 from distutils.version import LooseVersion
 
-import matplotlib as mpl  # isort:skip
-
-mpl.use("Agg")  # noqa: E402
-import matplotlib.pyplot as pl
 import numpy as np
 import pytest
 
 from wradlib import georef, util, vis
 
-from . import requires_data, requires_secrets
+from . import (
+    cartopy,
+    mpl,
+    requires_cartopy,
+    requires_data,
+    requires_gdal,
+    requires_matplotlib,
+    requires_secrets,
+)
 
-cartopy = util.import_optional("cartopy")
+if not isinstance(mpl, util.OptionalModuleStub):
+    mpl.use("Agg")
+
+pl = util.import_optional("matplotlib.pyplot")
 
 
+@pytest.fixture
+def pol_data():
+    @dataclass(init=False, repr=False, eq=False)
+    class Data:
+        img = np.zeros((360, 10), dtype=np.float32)
+        img[2, 2] = 10  # isolated pixel
+        img[5, 6:8] = 10  # line
+        img[20, :] = 5  # spike
+        img[60:120, 2:7] = 11  # precip field
+        r = np.arange(0, 100000, 10000)
+        az = np.arange(0, 360)
+        el = np.arange(0, 90)
+        th = np.zeros_like(az)
+        az1 = np.ones_like(el) * 225
+        img = img
+        da_ppi = georef.create_xarray_dataarray(img, r, az, th)
+        da_rhi = georef.create_xarray_dataarray(img[0:90], r, az1, el)
+
+    yield Data
+
+
+@pytest.fixture
+def prj_data():
+    @dataclass(init=False, repr=False, eq=False)
+    class Data:
+        img = np.zeros((360, 10), dtype=np.float32)
+        img[2, 2] = 10  # isolated pixel
+        img[5, 6:8] = 10  # line
+        img[20, :] = 5  # spike
+        img[60:120, 2:7] = 11  # precip field
+        r = np.arange(0, 100000, 10000)
+        az = np.arange(0, 360)
+        el = np.arange(0, 90)
+        th = np.zeros_like(az)
+        az1 = np.ones_like(el) * 225
+        img = img
+        proj = georef.create_osr("dwd-radolan")
+        da_ppi = georef.create_xarray_dataarray(img, r, az, th)
+        da_ppi = georef.georeference_dataset(da_ppi, proj=None)
+        da_rhi = georef.create_xarray_dataarray(img[0:90], r, az1, el)
+        da_rhi = georef.georeference_dataset(da_rhi, proj=None)
+
+    yield Data
+
+
+@requires_matplotlib
 class TestPolarPlot:
-    img = np.zeros((360, 10), dtype=np.float32)
-    img[2, 2] = 10  # isolated pixel
-    img[5, 6:8] = 10  # line
-    img[20, :] = 5  # spike
-    img[60:120, 2:7] = 11  # precip field
-    r = np.arange(0, 100000, 10000)
-    az = np.arange(0, 360)
-    el = np.arange(0, 90)
-    th = np.zeros_like(az)
-    az1 = np.ones_like(el) * 225
-    img = img
-    proj = georef.create_osr("dwd-radolan")
-
-    da_ppi = georef.create_xarray_dataarray(img, r, az, th)
-    da_ppi = georef.georeference_dataset(da_ppi, proj=None)
-    da_rhi = georef.create_xarray_dataarray(img[0:90], r, az1, el)
-    da_rhi = georef.georeference_dataset(da_rhi, proj=None)
-
-    def test_plot_ppi(self):
-        ax, pm = vis.plot_ppi(self.img, re=6371000.0, ke=(4.0 / 3.0))
-        ax, pm = vis.plot_ppi(self.img, self.r, self.az, re=6371000.0, ke=(4.0 / 3.0))
+    def test_plot_ppi(self, pol_data):
+        ax, pm = vis.plot_ppi(pol_data.img, re=6371000.0, ke=(4.0 / 3.0))
         ax, pm = vis.plot_ppi(
-            self.img, self.r, self.az, re=6371000.0, ke=(4.0 / 3.0), ax=ax
+            pol_data.img, pol_data.r, pol_data.az, re=6371000.0, ke=(4.0 / 3.0)
         )
         ax, pm = vis.plot_ppi(
-            self.img, self.r, self.az, re=6371000.0, ke=(4.0 / 3.0), ax=212
+            pol_data.img, pol_data.r, pol_data.az, re=6371000.0, ke=(4.0 / 3.0), ax=ax
         )
-        ax, pm = vis.plot_ppi(self.img)
+        ax, pm = vis.plot_ppi(
+            pol_data.img, pol_data.r, pol_data.az, re=6371000.0, ke=(4.0 / 3.0), ax=212
+        )
+        ax, pm = vis.plot_ppi(pol_data.img)
         vis.plot_ppi_crosshair(site=(0, 0, 0), ranges=[2, 4, 8])
         vis.plot_ppi_crosshair(
             site=(0, 0, 0),
@@ -56,130 +93,150 @@ class TestPolarPlot:
             angles=[0, 45, 90, 180, 270],
             line=dict(color="white", linestyle="solid"),
         )
-        ax, pm = vis.plot_ppi(self.img, self.r, site=(10.0, 45.0, 0.0), proj=self.proj)
+        ax, pm = vis.plot_ppi(pol_data.img, func="contour")
+        ax, pm = vis.plot_ppi(pol_data.img, func="contourf")
+        with pytest.warns(UserWarning):
+            ax, pm = vis.plot_ppi(pol_data.img, proj=None, site=(0, 0, 0))
+        with pytest.raises(ValueError):
+            vis.plot_ppi_crosshair(site=(0, 0), ranges=[2, 4, 8])
+
+    @requires_gdal
+    def test_plot_ppi_proj(self, prj_data):
+        ax, pm = vis.plot_ppi(
+            prj_data.img, prj_data.r, site=(10.0, 45.0, 0.0), proj=prj_data.proj
+        )
         vis.plot_ppi_crosshair(
             site=(10.0, 45.0, 0.0),
             ranges=[2, 4, 8],
             angles=[0, 45, 90, 180, 270],
-            proj=self.proj,
+            proj=prj_data.proj,
             line=dict(color="white", linestyle="solid"),
         )
-        ax, pm = vis.plot_ppi(self.img, func="contour")
-        ax, pm = vis.plot_ppi(self.img, func="contourf")
-        ax, pm = vis.plot_ppi(self.img, self.r, self.az, proj=self.proj, site=(0, 0, 0))
+
+        ax, pm = vis.plot_ppi(
+            prj_data.img, prj_data.r, prj_data.az, proj=prj_data.proj, site=(0, 0, 0)
+        )
         with pytest.warns(UserWarning):
-            ax, pm = vis.plot_ppi(self.img, site=(10.0, 45.0, 0.0), proj=self.proj)
-        with pytest.warns(UserWarning):
-            ax, pm = vis.plot_ppi(self.img, proj=None, site=(0, 0, 0))
+            ax, pm = vis.plot_ppi(
+                prj_data.img, site=(10.0, 45.0, 0.0), proj=prj_data.proj
+            )
+
         with pytest.raises(TypeError):
-            ax, pm = vis.plot_ppi(self.img, proj=self.proj)
+            ax, pm = vis.plot_ppi(prj_data.img, proj=prj_data.proj)
         with pytest.raises(ValueError):
-            ax, pm = vis.plot_ppi(self.img, site=(0, 0), proj=self.proj)
+            ax, pm = vis.plot_ppi(prj_data.img, site=(0, 0), proj=prj_data.proj)
         with pytest.raises(ValueError):
             vis.plot_ppi_crosshair(site=(0, 0), ranges=[2, 4, 8])
 
-    def test_plot_ppi_xarray(self):
-        self.da_ppi.wradlib.rays
-        self.da_ppi.wradlib.plot()
-        self.da_ppi.wradlib.plot_ppi()
-        self.da_ppi.wradlib.contour()
-        self.da_ppi.wradlib.contourf()
-        self.da_ppi.wradlib.pcolormesh()
-        self.da_ppi.wradlib.plot(proj="cg")
-        self.da_ppi.wradlib.plot_ppi(proj="cg")
-        self.da_ppi.wradlib.contour(proj="cg")
-        self.da_ppi.wradlib.contourf(proj="cg")
-        self.da_ppi.wradlib.pcolormesh(proj="cg")
-        with pytest.raises(TypeError):
-            self.da_ppi.wradlib.pcolormesh(proj=self.proj)
+    @requires_gdal
+    def test_plot_ppi_xarray(self, prj_data):
+        prj_data.da_ppi.wradlib.rays
+        prj_data.da_ppi.wradlib.plot()
+        prj_data.da_ppi.wradlib.plot_ppi()
+        prj_data.da_ppi.wradlib.contour()
+        prj_data.da_ppi.wradlib.contourf()
+        prj_data.da_ppi.wradlib.pcolormesh()
+        prj_data.da_ppi.wradlib.plot(proj="cg")
+        prj_data.da_ppi.wradlib.plot_ppi(proj="cg")
+        prj_data.da_ppi.wradlib.contour(proj="cg")
+        prj_data.da_ppi.wradlib.contourf(proj="cg")
+        prj_data.da_ppi.wradlib.pcolormesh(proj="cg")
         fig = pl.figure()
         ax = fig.add_subplot(111)
         with pytest.raises(TypeError):
-            self.da_ppi.wradlib.pcolormesh(proj={"rot": 0, "scale": 1}, ax=ax)
+            prj_data.da_ppi.wradlib.pcolormesh(proj={"rot": 0, "scale": 1}, ax=ax)
 
-    @pytest.mark.skipif("cartopy" not in sys.modules, reason="without Cartopy")
-    def test_plot_ppi_cartopy(self):
-        if cartopy:
-            if (LooseVersion(cartopy.__version__) < LooseVersion("0.18.0")) and (
-                LooseVersion(mpl.__version__) >= LooseVersion("3.3.0")
-            ):
-                pytest.skip("fails for cartopy < 0.18.0 and matplotlib >= 3.3.0")
-            site = (7, 45, 0.0)
-            map_proj = cartopy.crs.Mercator(central_longitude=site[1])
-            ax, pm = vis.plot_ppi(self.img, self.r, self.az, proj=map_proj)
-            assert isinstance(ax, cartopy.mpl.geoaxes.GeoAxes)
-            fig = pl.figure(figsize=(10, 10))
-            ax = fig.add_subplot(111, projection=map_proj)
-            self.da_ppi.wradlib.plot_ppi(ax=ax)
-            ax.gridlines(draw_labels=True)
+    @requires_gdal
+    def test_plot_ppi_xarray_proj(self, prj_data):
+        with pytest.raises(TypeError):
+            prj_data.da_ppi.wradlib.pcolormesh(proj=prj_data.proj)
 
-    def test_plot_rhi(self):
-        ax, pm = vis.plot_rhi(self.img[0:90, :])
-        ax, pm = vis.plot_rhi(self.img[0:90, :], th_res=0.5)
-        ax, pm = vis.plot_rhi(self.img[0:90, :], th_res=0.5, ax=212)
-        ax, pm = vis.plot_rhi(self.img[0:90, :], r=np.arange(10), th=np.arange(90))
-        ax, pm = vis.plot_rhi(self.img[0:90, :], func="contour")
-        ax, pm = vis.plot_rhi(self.img[0:90, :], func="contourf")
+    @requires_cartopy
+    @requires_gdal
+    def test_plot_ppi_cartopy(self, prj_data):
+        if (LooseVersion(cartopy.__version__) < LooseVersion("0.18.0")) and (
+            LooseVersion(mpl.__version__) >= LooseVersion("3.3.0")
+        ):
+            pytest.skip("fails for cartopy < 0.18.0 and matplotlib >= 3.3.0")
+        site = (7, 45, 0.0)
+        map_proj = cartopy.crs.Mercator(central_longitude=site[1])
+        ax, pm = vis.plot_ppi(prj_data.img, prj_data.r, prj_data.az, proj=map_proj)
+        assert isinstance(ax, cartopy.mpl.geoaxes.GeoAxes)
+        fig = pl.figure(figsize=(10, 10))
+        ax = fig.add_subplot(111, projection=map_proj)
+        prj_data.da_ppi.wradlib.plot_ppi(ax=ax)
+        ax.gridlines(draw_labels=True)
+
+    def test_plot_rhi(self, pol_data):
+        ax, pm = vis.plot_rhi(pol_data.img[0:90, :])
+        ax, pm = vis.plot_rhi(pol_data.img[0:90, :], th_res=0.5)
+        ax, pm = vis.plot_rhi(pol_data.img[0:90, :], th_res=0.5, ax=212)
+        ax, pm = vis.plot_rhi(pol_data.img[0:90, :], r=np.arange(10), th=np.arange(90))
+        ax, pm = vis.plot_rhi(pol_data.img[0:90, :], func="contour")
+        ax, pm = vis.plot_rhi(pol_data.img[0:90, :], func="contourf")
         ax, pm = vis.plot_rhi(
-            self.img[0:90, :],
+            pol_data.img[0:90, :],
             r=np.arange(10),
             th=np.arange(90),
-            proj=self.proj,
+            proj=None,
             site=(0, 0, 0),
         )
 
-    def test_plot_rhi_xarray(self):
+    @requires_gdal
+    def test_plot_rhi_xarray(self, prj_data):
         assert (
-            repr(self.da_rhi.wradlib).split("\n", 1)[1]
-            == repr(self.da_rhi).split("\n", 1)[1]
+            repr(prj_data.da_rhi.wradlib).split("\n", 1)[1]
+            == repr(prj_data.da_rhi).split("\n", 1)[1]
         )
-        self.da_rhi.wradlib.rays
-        self.da_rhi.wradlib.plot()
-        self.da_rhi.wradlib.plot_rhi()
-        self.da_rhi.wradlib.contour()
-        self.da_rhi.wradlib.contourf()
-        self.da_rhi.wradlib.pcolormesh()
-        self.da_rhi.wradlib.plot(proj="cg")
-        self.da_rhi.wradlib.plot_rhi(proj="cg")
-        self.da_rhi.wradlib.contour(proj="cg")
-        self.da_rhi.wradlib.contourf(proj="cg")
-        self.da_rhi.wradlib.pcolormesh(proj="cg")
+        prj_data.da_rhi.wradlib.rays
+        prj_data.da_rhi.wradlib.plot()
+        prj_data.da_rhi.wradlib.plot_rhi()
+        prj_data.da_rhi.wradlib.contour()
+        prj_data.da_rhi.wradlib.contourf()
+        prj_data.da_rhi.wradlib.pcolormesh()
+        prj_data.da_rhi.wradlib.plot(proj="cg")
+        prj_data.da_rhi.wradlib.plot_rhi(proj="cg")
+        prj_data.da_rhi.wradlib.contour(proj="cg")
+        prj_data.da_rhi.wradlib.contourf(proj="cg")
+        prj_data.da_rhi.wradlib.pcolormesh(proj="cg")
 
-    def test_plot_cg_ppi(self):
-        cgax, pm = vis.plot_ppi(self.img, elev=2.0, proj="cg")
-        cgax, pm = vis.plot_ppi(self.img, elev=2.0, proj="cg", site=(0, 0, 0))
-        cgax, pm = vis.plot_ppi(self.img, elev=2.0, proj="cg", ax=cgax)
+    def test_plot_cg_ppi(self, pol_data):
+        cgax, pm = vis.plot_ppi(pol_data.img, elev=2.0, proj="cg")
+        cgax, pm = vis.plot_ppi(pol_data.img, elev=2.0, proj="cg", site=(0, 0, 0))
+        cgax, pm = vis.plot_ppi(pol_data.img, elev=2.0, proj="cg", ax=cgax)
         fig, ax = pl.subplots(2, 2)
         with pytest.raises(TypeError):
-            vis.plot_ppi(self.img, elev=2.0, proj="cg", ax=ax[0, 0])
-        cgax, pm = vis.plot_ppi(self.img, elev=2.0, proj="cg", ax=111)
-        cgax, pm = vis.plot_ppi(self.img, elev=2.0, proj="cg", ax=121)
-        cgax, pm = vis.plot_ppi(self.img, proj="cg")
-        cgax, pm = vis.plot_ppi(self.img, func="contour", proj="cg")
-        cgax, pm = vis.plot_ppi(self.img, func="contourf", proj="cg")
-        cgax, pm = vis.plot_ppi(self.img, func="contourf", proj="cg")
+            vis.plot_ppi(pol_data.img, elev=2.0, proj="cg", ax=ax[0, 0])
+        cgax, pm = vis.plot_ppi(pol_data.img, elev=2.0, proj="cg", ax=111)
+        cgax, pm = vis.plot_ppi(pol_data.img, elev=2.0, proj="cg", ax=121)
+        cgax, pm = vis.plot_ppi(pol_data.img, proj="cg")
+        cgax, pm = vis.plot_ppi(pol_data.img, func="contour", proj="cg")
+        cgax, pm = vis.plot_ppi(pol_data.img, func="contourf", proj="cg")
+        cgax, pm = vis.plot_ppi(pol_data.img, func="contourf", proj="cg")
 
-    def test_plot_cg_rhi(self):
-        cgax, pm = vis.plot_rhi(self.img[0:90, :], proj="cg")
-        cgax, pm = vis.plot_rhi(self.img[0:90, :], proj="cg", ax=cgax)
+    def test_plot_cg_rhi(self, pol_data):
+        cgax, pm = vis.plot_rhi(pol_data.img[0:90, :], proj="cg")
+        cgax, pm = vis.plot_rhi(pol_data.img[0:90, :], proj="cg", ax=cgax)
         fig, ax = pl.subplots(2, 2)
         with pytest.raises(TypeError):
-            vis.plot_rhi(self.img[0:90, :], proj="cg", ax=ax[0, 0])
-        cgax, pm = vis.plot_rhi(self.img[0:90, :], th_res=0.5, proj="cg")
-        cgax, pm = vis.plot_rhi(self.img[0:90, :], proj="cg")
+            vis.plot_rhi(pol_data.img[0:90, :], proj="cg", ax=ax[0, 0])
+        cgax, pm = vis.plot_rhi(pol_data.img[0:90, :], th_res=0.5, proj="cg")
+        cgax, pm = vis.plot_rhi(pol_data.img[0:90, :], proj="cg")
         cgax, pm = vis.plot_rhi(
-            self.img[0:90, :], r=np.arange(10), th=np.arange(90), proj="cg"
+            pol_data.img[0:90, :], r=np.arange(10), th=np.arange(90), proj="cg"
         )
-        cgax, pm = vis.plot_rhi(self.img[0:90, :], func="contour", proj="cg")
-        cgax, pm = vis.plot_rhi(self.img[0:90, :], func="contourf", proj="cg")
+        cgax, pm = vis.plot_rhi(pol_data.img[0:90, :], func="contour", proj="cg")
+        cgax, pm = vis.plot_rhi(pol_data.img[0:90, :], func="contourf", proj="cg")
 
     def test_create_cg(self):
         cgax, caax, paax = vis.create_cg()
         cgax, caax, paax = vis.create_cg(subplot=121)
 
 
+@requires_matplotlib
 class TestMiscPlot:
     @requires_data
+    @requires_gdal
     def test_plot_scan_strategy(self):
         ranges = np.arange(0, 10000, 100)
         elevs = np.arange(1, 30, 3)
@@ -191,6 +248,7 @@ class TestMiscPlot:
 
     @requires_data
     @requires_secrets
+    @requires_gdal
     def test_plot_scan_strategy_terrain(self):
         ranges = np.arange(0, 10000, 100)
         elevs = np.arange(1, 30, 3)

--- a/wradlib/tests/test_zonalstats.py
+++ b/wradlib/tests/test_zonalstats.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
-# Copyright (c) 2011-2020, wradlib developers.
+# Copyright (c) 2011-2021, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import tempfile
+from dataclasses import dataclass
 
 import numpy as np
 import pytest
-from osgeo import osr
 
 from wradlib import georef, util, zonalstats
 
-from . import requires_data
+from . import osr, requires_data, requires_gdal, requires_geos
 
 np.set_printoptions(
     edgeitems=3,
@@ -24,62 +24,83 @@ np.set_printoptions(
 )
 
 
+@pytest.fixture
+def data_source():
+    @dataclass(init=False, repr=False, eq=False)
+    class Data:
+        # create synthetic box
+        box0 = np.array(
+            [
+                [2600000.0, 5630000.0],
+                [2600000.0, 5640000.0],
+                [2610000.0, 5640000.0],
+                [2610000.0, 5630000.0],
+                [2600000.0, 5630000.0],
+            ]
+        )
+
+        box1 = np.array(
+            [
+                [2700000.0, 5630000.0],
+                [2700000.0, 5640000.0],
+                [2710000.0, 5640000.0],
+                [2710000.0, 5630000.0],
+                [2700000.0, 5630000.0],
+            ]
+        )
+
+        data = np.array([box0, box1], dtype=object)
+
+        ds = zonalstats.DataSource(data)
+
+        values1 = np.array([47.11, 47.11])
+        values2 = np.array([47.11, 15.08])
+
+    yield Data
+
+
+@requires_geos
 class TestDataSource:
-    # create synthetic box
-    box0 = np.array(
-        [
-            [2600000.0, 5630000.0],
-            [2600000.0, 5640000.0],
-            [2610000.0, 5640000.0],
-            [2610000.0, 5630000.0],
-            [2600000.0, 5630000.0],
-        ]
-    )
-
-    box1 = np.array(
-        [
-            [2700000.0, 5630000.0],
-            [2700000.0, 5640000.0],
-            [2710000.0, 5640000.0],
-            [2710000.0, 5630000.0],
-            [2700000.0, 5630000.0],
-        ]
-    )
-
-    data = np.array([box0, box1], dtype=object)
-
-    ds = zonalstats.DataSource(data)
-
-    values1 = np.array([47.11, 47.11])
-    values2 = np.array([47.11, 15.08])
-
     @requires_data
+    @requires_gdal
     def test__check_src(self):
         filename = util.get_wradlib_data_file("shapefiles/agger/" "agger_merge.shp")
         assert len(zonalstats.DataSource(filename).data) == 13
+
+    @requires_gdal
+    def test_error(self):
         with pytest.raises(RuntimeError):
             zonalstats.DataSource("test_zonalstats.py")
 
-    def test_data(self):
-        np.testing.assert_almost_equal(self.ds.data, self.data)
+    @requires_gdal
+    def test_data(self, data_source):
+        np.testing.assert_almost_equal(data_source.ds.data, data_source.data)
 
-    def test__get_data(self):
-        ds = zonalstats.DataSource(self.data)
-        np.testing.assert_almost_equal(ds._get_data(), self.data)
+    @requires_gdal
+    def test__get_data(self, data_source):
+        ds = zonalstats.DataSource(data_source.data)
+        np.testing.assert_almost_equal(ds._get_data(), data_source.data)
 
-    def test_get_data_by_idx(self):
-        ds = zonalstats.DataSource(self.data)
-        np.testing.assert_almost_equal(ds.get_data_by_idx([0]), self.data[0:1])
-        np.testing.assert_almost_equal(ds.get_data_by_idx([1]), self.data[1:2])
-        np.testing.assert_almost_equal(ds.get_data_by_idx([0, 1]), self.data)
+    @requires_gdal
+    def test_get_data_by_idx(self, data_source):
+        ds = zonalstats.DataSource(data_source.data)
+        np.testing.assert_almost_equal(ds.get_data_by_idx([0]), data_source.data[0:1])
+        np.testing.assert_almost_equal(ds.get_data_by_idx([1]), data_source.data[1:2])
+        np.testing.assert_almost_equal(ds.get_data_by_idx([0, 1]), data_source.data)
 
-    def test_get_data_by_att(self):
-        ds = zonalstats.DataSource(self.data)
-        np.testing.assert_almost_equal(ds.get_data_by_att("index", 0), self.data[0:1])
-        np.testing.assert_almost_equal(ds.get_data_by_att("index", 1), self.data[1:2])
+    @requires_gdal
+    def test_get_data_by_att(self, data_source):
+        ds = zonalstats.DataSource(data_source.data)
+        np.testing.assert_almost_equal(
+            ds.get_data_by_att("index", 0), data_source.data[0:1]
+        )
+        np.testing.assert_almost_equal(
+            ds.get_data_by_att("index", 1), data_source.data[1:2]
+        )
 
-    def test_get_data_by_geom(self):
-        ds = zonalstats.DataSource(self.data)
+    @requires_gdal
+    def test_get_data_by_geom(self, data_source):
+        ds = zonalstats.DataSource(data_source.data)
         lyr = ds.ds.GetLayer()
         lyr.ResetReading()
         lyr.SetSpatialFilter(None)
@@ -87,23 +108,26 @@ class TestDataSource:
         for i, feature in enumerate(lyr):
             geom = feature.GetGeometryRef()
             np.testing.assert_almost_equal(
-                ds.get_data_by_geom(geom), self.data[i : i + 1]
+                ds.get_data_by_geom(geom), data_source.data[i : i + 1]
             )
 
-    def test_set_attribute(self):
-        ds = zonalstats.DataSource(self.data)
-        ds.set_attribute("test", self.values1)
-        assert np.allclose(ds.get_attributes(["test"]), self.values1)
-        ds.set_attribute("test", self.values2)
-        assert np.allclose(ds.get_attributes(["test"]), self.values2)
+    @requires_gdal
+    def test_set_attribute(self, data_source):
+        ds = zonalstats.DataSource(data_source.data)
+        ds.set_attribute("test", data_source.values1)
+        assert np.allclose(ds.get_attributes(["test"]), data_source.values1)
+        ds.set_attribute("test", data_source.values2)
+        assert np.allclose(ds.get_attributes(["test"]), data_source.values2)
 
-    def test_get_attributes(self):
-        ds = zonalstats.DataSource(self.data)
-        ds.set_attribute("test", self.values2)
-        assert ds.get_attributes(["test"], filt=("index", 0)) == self.values2[0]
-        assert ds.get_attributes(["test"], filt=("index", 1)) == self.values2[1]
+    @requires_gdal
+    def test_get_attributes(self, data_source):
+        ds = zonalstats.DataSource(data_source.data)
+        ds.set_attribute("test", data_source.values2)
+        assert ds.get_attributes(["test"], filt=("index", 0)) == data_source.values2[0]
+        assert ds.get_attributes(["test"], filt=("index", 1)) == data_source.values2[1]
 
     @requires_data
+    @requires_gdal
     def test_get_geom_properties(self):
         proj = osr.SpatialReference()
         proj.ImportFromEPSG(31466)
@@ -113,11 +137,13 @@ class TestDataSource:
             [[76722499.98474795]], test.get_geom_properties(["Area"], filt=("FID", 1))
         )
 
-    def test_dump_vector(self):
-        ds = zonalstats.DataSource(self.data)
+    @requires_gdal
+    def test_dump_vector(self, data_source):
+        ds = zonalstats.DataSource(data_source.data)
         ds.dump_vector(tempfile.NamedTemporaryFile(mode="w+b").name)
 
     @requires_data
+    @requires_gdal
     def test_dump_raster(self):
         proj = osr.SpatialReference()
         proj.ImportFromEPSG(31466)
@@ -136,412 +162,458 @@ class TestDataSource:
         )
 
 
-@pytest.mark.skipif(not util.has_geos(), reason="GDAL without GEOS")
-class TestZonalDataBase:
-    # GK3-Projection
-    proj = osr.SpatialReference()
-    proj.ImportFromEPSG(31466)
+@pytest.fixture
+def data_base():
+    @dataclass(init=False, repr=False, eq=False)
+    class Data:
+        # GK3-Projection
+        proj = osr.SpatialReference()
+        proj.ImportFromEPSG(31466)
 
-    # create synthetic box
-    box0 = np.array(
-        [
-            [2600000.0, 5630000.0],
-            [2600000.0, 5640000.0],
-            [2610000.0, 5640000.0],
-            [2610000.0, 5630000.0],
-            [2600000.0, 5630000.0],
-        ]
-    )
+        # create synthetic box
+        box0 = np.array(
+            [
+                [2600000.0, 5630000.0],
+                [2600000.0, 5640000.0],
+                [2610000.0, 5640000.0],
+                [2610000.0, 5630000.0],
+                [2600000.0, 5630000.0],
+            ]
+        )
 
-    box1 = np.array(
-        [
-            [2610000.0, 5630000.0],
-            [2610000.0, 5640000.0],
-            [2620000.0, 5640000.0],
-            [2620000.0, 5630000.0],
-            [2610000.0, 5630000.0],
-        ]
-    )
+        box1 = np.array(
+            [
+                [2610000.0, 5630000.0],
+                [2610000.0, 5640000.0],
+                [2620000.0, 5640000.0],
+                [2620000.0, 5630000.0],
+                [2610000.0, 5630000.0],
+            ]
+        )
 
-    box3 = np.array(
-        [
-            [2595000.0, 5625000.0],
-            [2595000.0, 5635000.0],
-            [2605000.0, 5635000.0],
-            [2605000.0, 5625000.0],
-            [2595000.0, 5625000.0],
-        ]
-    )
+        box3 = np.array(
+            [
+                [2595000.0, 5625000.0],
+                [2595000.0, 5635000.0],
+                [2605000.0, 5635000.0],
+                [2605000.0, 5625000.0],
+                [2595000.0, 5625000.0],
+            ]
+        )
 
-    box4 = np.array(
-        [
-            [2615000.0, 5635000.0],
-            [2615000.0, 5645000.0],
-            [2625000.0, 5645000.0],
-            [2625000.0, 5635000.0],
-            [2615000.0, 5635000.0],
-        ]
-    )
+        box4 = np.array(
+            [
+                [2615000.0, 5635000.0],
+                [2615000.0, 5645000.0],
+                [2625000.0, 5645000.0],
+                [2625000.0, 5635000.0],
+                [2615000.0, 5635000.0],
+            ]
+        )
 
-    box5 = np.array(
-        [
-            # [2600000.0, 5635000.0],
-            [2605000.0, 5635000.0],
-            [2605000.0, 5630000.0],
-            [2600000.0, 5630000.0],
-            [2600000.0, 5635000.0],
-            [2605000.0, 5635000.0],
-        ]
-    )
+        box5 = np.array(
+            [
+                # [2600000.0, 5635000.0],
+                [2605000.0, 5635000.0],
+                [2605000.0, 5630000.0],
+                [2600000.0, 5630000.0],
+                [2600000.0, 5635000.0],
+                [2605000.0, 5635000.0],
+            ]
+        )
 
-    box6 = np.array(
-        [
-            # [2615000.0, 5635000.0],
-            [2615000.0, 5640000.0],
-            [2620000.0, 5640000.0],
-            [2620000.0, 5635000.0],
-            [2615000.0, 5635000.0],
-            [2615000.0, 5640000.0],
-        ]
-    )
+        box6 = np.array(
+            [
+                # [2615000.0, 5635000.0],
+                [2615000.0, 5640000.0],
+                [2620000.0, 5640000.0],
+                [2620000.0, 5635000.0],
+                [2615000.0, 5635000.0],
+                [2615000.0, 5640000.0],
+            ]
+        )
 
-    box7 = np.array(
-        [
-            [2715000.0, 5635000.0],
-            [2715000.0, 5640000.0],
-            [2720000.0, 5640000.0],
-            [2720000.0, 5635000.0],
-            [2715000.0, 5635000.0],
-        ]
-    )
+        box7 = np.array(
+            [
+                [2715000.0, 5635000.0],
+                [2715000.0, 5640000.0],
+                [2720000.0, 5640000.0],
+                [2720000.0, 5635000.0],
+                [2715000.0, 5635000.0],
+            ]
+        )
 
-    src = np.array([box0, box1])
-    trg = np.array([box3, box4])
-    dst = np.array([[box5], [box6]])
-    zdb = zonalstats.ZonalDataBase(src, trg, srs=proj)
-    f = tempfile.NamedTemporaryFile(mode="w+b").name
-    zdb.dump_vector(f)
-
-    def test___init__(self):
-        zdb = zonalstats.ZonalDataBase(self.src, self.trg, srs=self.proj)
-        assert isinstance(zdb.src, zonalstats.DataSource)
-        assert isinstance(zdb.trg, zonalstats.DataSource)
-        assert isinstance(zdb.dst, zonalstats.DataSource)
-        assert zdb._count_intersections == 2
-        zd = zonalstats.DataSource(self.src, name="src", srs=self.proj)
-        zdb = zonalstats.ZonalDataBase(zd, self.trg, srs=self.proj)
-        assert isinstance(zdb.src, zonalstats.DataSource)
-        assert isinstance(zdb.trg, zonalstats.DataSource)
-        assert isinstance(zdb.dst, zonalstats.DataSource)
-        assert zdb._count_intersections == 2
-        zd1 = zonalstats.DataSource(self.src, name="src", srs=self.proj)
-        zd2 = zonalstats.DataSource(self.trg, name="trg", srs=self.proj)
-        zdb = zonalstats.ZonalDataBase(zd1, zd2, srs=self.proj)
-        assert isinstance(zdb.src, zonalstats.DataSource)
-        assert isinstance(zdb.trg, zonalstats.DataSource)
-        assert isinstance(zdb.dst, zonalstats.DataSource)
-        assert zdb._count_intersections == 2
-
-    def test_count_intersections(self):
-        zdb = zonalstats.ZonalDataBase(self.src, self.trg, srs=self.proj)
-        assert zdb.count_intersections == 2
-
-    def test_srs(self):
-        zdb = zonalstats.ZonalDataBase(self.src, self.trg, srs=self.proj)
-        assert zdb.srs == self.proj
-
-    def test_isecs(self):
-        # todo: Normalize Polygons before comparison.
-        zdb = zonalstats.ZonalDataBase(self.src, self.trg, srs=self.proj)
-        np.testing.assert_equal(zdb.isecs, self.dst)
-
-    def test_get_isec(self):
-        zdb = zonalstats.ZonalDataBase(self.src, self.trg, srs=self.proj)
-        np.testing.assert_equal(zdb.get_isec(0), [self.box5])
-        np.testing.assert_equal(zdb.get_isec(1), [self.box6])
-
-    def test_get_source_index(self):
-        zdb = zonalstats.ZonalDataBase(self.src, self.trg, srs=self.proj)
-        assert zdb.get_source_index(0) == 0
-        assert zdb.get_source_index(1) == 1
-
-    def test_dump_vector(self):
-        zdb = zonalstats.ZonalDataBase(self.src, self.trg, srs=self.proj)
+        src = np.array([box0, box1])
+        trg = np.array([box3, box4])
+        dst = np.array([[box5], [box6]])
+        zdb = zonalstats.ZonalDataBase(src, trg, srs=proj)
         f = tempfile.NamedTemporaryFile(mode="w+b").name
         zdb.dump_vector(f)
 
-    def test_load_vector(self):
-        zonalstats.ZonalDataBase(self.f)
+    yield Data
 
-    def test__get_intersection(self):
-        zdb = zonalstats.ZonalDataBase(self.src, self.trg, srs=self.proj)
+
+@requires_geos
+class TestZonalDataBase:
+    @requires_gdal
+    def test___init__(self, data_base):
+        zdb = zonalstats.ZonalDataBase(data_base.src, data_base.trg, srs=data_base.proj)
+        assert isinstance(zdb.src, zonalstats.DataSource)
+        assert isinstance(zdb.trg, zonalstats.DataSource)
+        assert isinstance(zdb.dst, zonalstats.DataSource)
+        assert zdb._count_intersections == 2
+        zd = zonalstats.DataSource(data_base.src, name="src", srs=data_base.proj)
+        zdb = zonalstats.ZonalDataBase(zd, data_base.trg, srs=data_base.proj)
+        assert isinstance(zdb.src, zonalstats.DataSource)
+        assert isinstance(zdb.trg, zonalstats.DataSource)
+        assert isinstance(zdb.dst, zonalstats.DataSource)
+        assert zdb._count_intersections == 2
+        zd1 = zonalstats.DataSource(data_base.src, name="src", srs=data_base.proj)
+        zd2 = zonalstats.DataSource(data_base.trg, name="trg", srs=data_base.proj)
+        zdb = zonalstats.ZonalDataBase(zd1, zd2, srs=data_base.proj)
+        assert isinstance(zdb.src, zonalstats.DataSource)
+        assert isinstance(zdb.trg, zonalstats.DataSource)
+        assert isinstance(zdb.dst, zonalstats.DataSource)
+        assert zdb._count_intersections == 2
+
+    @requires_gdal
+    def test_count_intersections(self, data_base):
+        zdb = zonalstats.ZonalDataBase(data_base.src, data_base.trg, srs=data_base.proj)
+        assert zdb.count_intersections == 2
+
+    @requires_gdal
+    def test_srs(self, data_base):
+        zdb = zonalstats.ZonalDataBase(data_base.src, data_base.trg, srs=data_base.proj)
+        assert zdb.srs == data_base.proj
+
+    @requires_gdal
+    def test_isecs(self, data_base):
+        # todo: Normalize Polygons before comparison.
+        zdb = zonalstats.ZonalDataBase(data_base.src, data_base.trg, srs=data_base.proj)
+        np.testing.assert_equal(zdb.isecs, data_base.dst)
+
+    @requires_gdal
+    def test_get_isec(self, data_base):
+        zdb = zonalstats.ZonalDataBase(data_base.src, data_base.trg, srs=data_base.proj)
+        np.testing.assert_equal(zdb.get_isec(0), [data_base.box5])
+        np.testing.assert_equal(zdb.get_isec(1), [data_base.box6])
+
+    @requires_gdal
+    def test_get_source_index(self, data_base):
+        zdb = zonalstats.ZonalDataBase(data_base.src, data_base.trg, srs=data_base.proj)
+        assert zdb.get_source_index(0) == 0
+        assert zdb.get_source_index(1) == 1
+
+    @requires_gdal
+    def test_dump_vector(self, data_base):
+        zdb = zonalstats.ZonalDataBase(data_base.src, data_base.trg, srs=data_base.proj)
+        f = tempfile.NamedTemporaryFile(mode="w+b").name
+        zdb.dump_vector(f)
+
+    @requires_gdal
+    def test_load_vector(self, data_base):
+        zonalstats.ZonalDataBase(data_base.f)
+
+    @requires_gdal
+    def test__get_intersection(self, data_base):
+        zdb = zonalstats.ZonalDataBase(data_base.src, data_base.trg, srs=data_base.proj)
         with pytest.raises(TypeError):
             zdb._get_intersection()
-        np.testing.assert_equal(zdb._get_intersection(trg=self.box3), [self.box5])
-        np.testing.assert_equal(zdb._get_intersection(idx=0), [self.box5])
+        np.testing.assert_equal(
+            zdb._get_intersection(trg=data_base.box3), [data_base.box5]
+        )
+        np.testing.assert_equal(zdb._get_intersection(idx=0), [data_base.box5])
         with pytest.raises(TypeError):
             zdb._get_intersection(idx=2)
-        zdb = zonalstats.ZonalDataBase(self.src, [self.box7], srs=self.proj)
+        zdb = zonalstats.ZonalDataBase(
+            data_base.src, [data_base.box7], srs=data_base.proj
+        )
         zdb.trg = None
         with pytest.raises(TypeError):
             zdb._get_intersection(idx=0)
 
 
-@pytest.mark.skipif(not util.has_geos(), reason="GDAL without GEOS")
+@pytest.fixture
+def data_poly():
+    @dataclass(init=False, repr=False, eq=False)
+    class Data:
+        # GK3-Projection
+        proj = osr.SpatialReference()
+        proj.ImportFromEPSG(31466)
+
+        # create synthetic box
+        box0 = np.array(
+            [
+                [2600000.0, 5630000.0],
+                [2600000.0, 5640000.0],
+                [2610000.0, 5640000.0],
+                [2610000.0, 5630000.0],
+                [2600000.0, 5630000.0],
+            ]
+        )
+
+        box1 = np.array(
+            [
+                [2610000.0, 5630000.0],
+                [2610000.0, 5640000.0],
+                [2620000.0, 5640000.0],
+                [2620000.0, 5630000.0],
+                [2610000.0, 5630000.0],
+            ]
+        )
+
+        box3 = np.array(
+            [
+                [2595000.0, 5625000.0],
+                [2595000.0, 5635000.0],
+                [2605000.0, 5635000.0],
+                [2605000.0, 5625000.0],
+                [2595000.0, 5625000.0],
+            ]
+        )
+
+        box4 = np.array(
+            [
+                [2615000.0, 5635000.0],
+                [2615000.0, 5645000.0],
+                [2625000.0, 5645000.0],
+                [2625000.0, 5635000.0],
+                [2615000.0, 5635000.0],
+            ]
+        )
+
+        box5 = np.array(
+            [
+                [2600000.0, 5635000.0],
+                [2605000.0, 5635000.0],
+                [2605000.0, 5630000.0],
+                [2600000.0, 5630000.0],
+                [2600000.0, 5635000.0],
+            ]
+        )
+
+        box6 = np.array(
+            [
+                [2615000.0, 5635000.0],
+                [2615000.0, 5640000.0],
+                [2620000.0, 5640000.0],
+                [2620000.0, 5635000.0],
+                [2615000.0, 5635000.0],
+            ]
+        )
+
+        box7 = np.array(
+            [
+                [2715000.0, 5635000.0],
+                [2715000.0, 5640000.0],
+                [2720000.0, 5640000.0],
+                [2720000.0, 5635000.0],
+                [2715000.0, 5635000.0],
+            ]
+        )
+
+        src = np.array([box0, box1])
+        trg = np.array([box3, box4])
+        dst = np.array([[box5], [box6]])
+        zdb = zonalstats.ZonalDataBase(src, trg, srs=proj)
+        f = tempfile.NamedTemporaryFile(mode="w+b").name
+        zdb.dump_vector(f)
+
+    yield Data
+
+
+@requires_geos
 class TestZonalDataPoly:
-    # GK3-Projection
-    proj = osr.SpatialReference()
-    proj.ImportFromEPSG(31466)
-
-    # create synthetic box
-    box0 = np.array(
-        [
-            [2600000.0, 5630000.0],
-            [2600000.0, 5640000.0],
-            [2610000.0, 5640000.0],
-            [2610000.0, 5630000.0],
-            [2600000.0, 5630000.0],
-        ]
-    )
-
-    box1 = np.array(
-        [
-            [2610000.0, 5630000.0],
-            [2610000.0, 5640000.0],
-            [2620000.0, 5640000.0],
-            [2620000.0, 5630000.0],
-            [2610000.0, 5630000.0],
-        ]
-    )
-
-    box3 = np.array(
-        [
-            [2595000.0, 5625000.0],
-            [2595000.0, 5635000.0],
-            [2605000.0, 5635000.0],
-            [2605000.0, 5625000.0],
-            [2595000.0, 5625000.0],
-        ]
-    )
-
-    box4 = np.array(
-        [
-            [2615000.0, 5635000.0],
-            [2615000.0, 5645000.0],
-            [2625000.0, 5645000.0],
-            [2625000.0, 5635000.0],
-            [2615000.0, 5635000.0],
-        ]
-    )
-
-    box5 = np.array(
-        [
-            [2600000.0, 5635000.0],
-            [2605000.0, 5635000.0],
-            [2605000.0, 5630000.0],
-            [2600000.0, 5630000.0],
-            [2600000.0, 5635000.0],
-        ]
-    )
-
-    box6 = np.array(
-        [
-            [2615000.0, 5635000.0],
-            [2615000.0, 5640000.0],
-            [2620000.0, 5640000.0],
-            [2620000.0, 5635000.0],
-            [2615000.0, 5635000.0],
-        ]
-    )
-
-    box7 = np.array(
-        [
-            [2715000.0, 5635000.0],
-            [2715000.0, 5640000.0],
-            [2720000.0, 5640000.0],
-            [2720000.0, 5635000.0],
-            [2715000.0, 5635000.0],
-        ]
-    )
-
-    src = np.array([box0, box1])
-    trg = np.array([box3, box4])
-    dst = np.array([[box5], [box6]])
-    zdb = zonalstats.ZonalDataBase(src, trg, srs=proj)
-    f = tempfile.NamedTemporaryFile(mode="w+b").name
-    zdb.dump_vector(f)
-
-    def test__get_idx_weights(self):
-        zdp = zonalstats.ZonalDataPoly(self.src, self.trg, srs=self.proj)
+    @requires_gdal
+    def test__get_idx_weights(self, data_poly):
+        zdp = zonalstats.ZonalDataPoly(data_poly.src, data_poly.trg, srs=data_poly.proj)
         assert zdp._get_idx_weights() == (
             [np.array([0]), np.array([1])],
             [np.array([25000000.0]), np.array([25000000.0])],
         )
 
 
-@pytest.mark.skipif(not util.has_geos(), reason="GDAL without GEOS")
+@pytest.fixture
+def data_point():
+    @dataclass(init=False, repr=False, eq=False)
+    class Data:
+        # GK3-Projection
+        proj = osr.SpatialReference()
+        proj.ImportFromEPSG(31466)
+
+        # create synthetic box
+        point0 = np.array([2600000.0, 5630000.0])
+
+        point1 = np.array([2620000.0, 5640000.0])
+
+        box3 = np.array(
+            [
+                [2595000.0, 5625000.0],
+                [2595000.0, 5635000.0],
+                [2605000.0, 5635000.0],
+                [2605000.0, 5625000.0],
+                [2595000.0, 5625000.0],
+            ]
+        )
+
+        box4 = np.array(
+            [
+                [2615000.0, 5635000.0],
+                [2615000.0, 5645000.0],
+                [2625000.0, 5645000.0],
+                [2625000.0, 5635000.0],
+                [2615000.0, 5635000.0],
+            ]
+        )
+
+        box5 = np.array(
+            [
+                [2600000.0, 5635000.0],
+                [2605000.0, 5635000.0],
+                [2605000.0, 5630000.0],
+                [2600000.0, 5630000.0],
+                [2600000.0, 5635000.0],
+            ]
+        )
+
+        box6 = np.array(
+            [
+                [2615000.0, 5635000.0],
+                [2615000.0, 5640000.0],
+                [2620000.0, 5640000.0],
+                [2620000.0, 5635000.0],
+                [2615000.0, 5635000.0],
+            ]
+        )
+
+        box7 = np.array(
+            [
+                [2715000.0, 5635000.0],
+                [2715000.0, 5640000.0],
+                [2720000.0, 5640000.0],
+                [2720000.0, 5635000.0],
+                [2715000.0, 5635000.0],
+            ]
+        )
+
+        src = np.array([point0, point1])
+        trg = np.array([box3, box4])
+        dst = np.array([[point0], [point1]])
+        zdb = zonalstats.ZonalDataBase(src, trg, srs=proj)
+        f = tempfile.NamedTemporaryFile(mode="w+b").name
+        zdb.dump_vector(f)
+
+    yield Data
+
+
+@requires_geos
 class TestZonalDataPoint:
-    # GK3-Projection
-    proj = osr.SpatialReference()
-    proj.ImportFromEPSG(31466)
-
-    # create synthetic box
-    point0 = np.array([2600000.0, 5630000.0])
-
-    point1 = np.array([2620000.0, 5640000.0])
-
-    box3 = np.array(
-        [
-            [2595000.0, 5625000.0],
-            [2595000.0, 5635000.0],
-            [2605000.0, 5635000.0],
-            [2605000.0, 5625000.0],
-            [2595000.0, 5625000.0],
-        ]
-    )
-
-    box4 = np.array(
-        [
-            [2615000.0, 5635000.0],
-            [2615000.0, 5645000.0],
-            [2625000.0, 5645000.0],
-            [2625000.0, 5635000.0],
-            [2615000.0, 5635000.0],
-        ]
-    )
-
-    box5 = np.array(
-        [
-            [2600000.0, 5635000.0],
-            [2605000.0, 5635000.0],
-            [2605000.0, 5630000.0],
-            [2600000.0, 5630000.0],
-            [2600000.0, 5635000.0],
-        ]
-    )
-
-    box6 = np.array(
-        [
-            [2615000.0, 5635000.0],
-            [2615000.0, 5640000.0],
-            [2620000.0, 5640000.0],
-            [2620000.0, 5635000.0],
-            [2615000.0, 5635000.0],
-        ]
-    )
-
-    box7 = np.array(
-        [
-            [2715000.0, 5635000.0],
-            [2715000.0, 5640000.0],
-            [2720000.0, 5640000.0],
-            [2720000.0, 5635000.0],
-            [2715000.0, 5635000.0],
-        ]
-    )
-
-    src = np.array([point0, point1])
-    trg = np.array([box3, box4])
-    dst = np.array([[point0], [point1]])
-    zdb = zonalstats.ZonalDataBase(src, trg, srs=proj)
-    f = tempfile.NamedTemporaryFile(mode="w+b").name
-    zdb.dump_vector(f)
-
-    def test__get_idx_weights(self):
-        zdp = zonalstats.ZonalDataPoint(self.src, self.trg, srs=self.proj)
+    @requires_gdal
+    def test__get_idx_weights(self, data_point):
+        zdp = zonalstats.ZonalDataPoint(
+            data_point.src, data_point.trg, srs=data_point.proj
+        )
         assert zdp._get_idx_weights() == (
             [np.array([0]), np.array([1])],
             [np.array([1.0]), np.array([1.0])],
         )
 
 
-@pytest.mark.skipif(not util.has_geos(), reason="GDAL without GEOS")
+@pytest.fixture
+def stats_base():
+    @dataclass(init=False, repr=False, eq=False)
+    class Data:
+        # GK3-Projection
+        proj = osr.SpatialReference()
+        proj.ImportFromEPSG(31466)
+
+        # create synthetic box
+        box0 = np.array(
+            [
+                [2600000.0, 5630000.0],
+                [2600000.0, 5640000.0],
+                [2610000.0, 5640000.0],
+                [2610000.0, 5630000.0],
+                [2600000.0, 5630000.0],
+            ]
+        )
+
+        box1 = np.array(
+            [
+                [2610000.0, 5630000.0],
+                [2610000.0, 5640000.0],
+                [2620000.0, 5640000.0],
+                [2620000.0, 5630000.0],
+                [2610000.0, 5630000.0],
+            ]
+        )
+
+        box3 = np.array(
+            [
+                [2595000.0, 5625000.0],
+                [2595000.0, 5635000.0],
+                [2605000.0, 5635000.0],
+                [2605000.0, 5625000.0],
+                [2595000.0, 5625000.0],
+            ]
+        )
+
+        box4 = np.array(
+            [
+                [2615000.0, 5635000.0],
+                [2615000.0, 5645000.0],
+                [2625000.0, 5645000.0],
+                [2625000.0, 5635000.0],
+                [2615000.0, 5635000.0],
+            ]
+        )
+
+        box5 = np.array(
+            [
+                [2600000.0, 5635000.0],
+                [2605000.0, 5635000.0],
+                [2605000.0, 5630000.0],
+                [2600000.0, 5630000.0],
+                [2600000.0, 5635000.0],
+            ]
+        )
+
+        box6 = np.array(
+            [
+                [2615000.0, 5635000.0],
+                [2615000.0, 5640000.0],
+                [2620000.0, 5640000.0],
+                [2620000.0, 5635000.0],
+                [2615000.0, 5635000.0],
+            ]
+        )
+
+        box7 = np.array(
+            [
+                [2715000.0, 5635000.0],
+                [2715000.0, 5640000.0],
+                [2720000.0, 5640000.0],
+                [2720000.0, 5635000.0],
+                [2715000.0, 5635000.0],
+            ]
+        )
+
+        src = np.array([box0, box1])
+        trg = np.array([box3, box4])
+        dst = np.array([[box5], [box6]])
+        zdb = zonalstats.ZonalDataBase(src, trg, srs=proj)
+        zdp = zonalstats.ZonalDataPoly(src, trg, srs=proj)
+
+    yield Data
+
+
+@requires_geos
 class TestZonalStatsBase:
-    # GK3-Projection
-    proj = osr.SpatialReference()
-    proj.ImportFromEPSG(31466)
-
-    # create synthetic box
-    box0 = np.array(
-        [
-            [2600000.0, 5630000.0],
-            [2600000.0, 5640000.0],
-            [2610000.0, 5640000.0],
-            [2610000.0, 5630000.0],
-            [2600000.0, 5630000.0],
-        ]
-    )
-
-    box1 = np.array(
-        [
-            [2610000.0, 5630000.0],
-            [2610000.0, 5640000.0],
-            [2620000.0, 5640000.0],
-            [2620000.0, 5630000.0],
-            [2610000.0, 5630000.0],
-        ]
-    )
-
-    box3 = np.array(
-        [
-            [2595000.0, 5625000.0],
-            [2595000.0, 5635000.0],
-            [2605000.0, 5635000.0],
-            [2605000.0, 5625000.0],
-            [2595000.0, 5625000.0],
-        ]
-    )
-
-    box4 = np.array(
-        [
-            [2615000.0, 5635000.0],
-            [2615000.0, 5645000.0],
-            [2625000.0, 5645000.0],
-            [2625000.0, 5635000.0],
-            [2615000.0, 5635000.0],
-        ]
-    )
-
-    box5 = np.array(
-        [
-            [2600000.0, 5635000.0],
-            [2605000.0, 5635000.0],
-            [2605000.0, 5630000.0],
-            [2600000.0, 5630000.0],
-            [2600000.0, 5635000.0],
-        ]
-    )
-
-    box6 = np.array(
-        [
-            [2615000.0, 5635000.0],
-            [2615000.0, 5640000.0],
-            [2620000.0, 5640000.0],
-            [2620000.0, 5635000.0],
-            [2615000.0, 5635000.0],
-        ]
-    )
-
-    box7 = np.array(
-        [
-            [2715000.0, 5635000.0],
-            [2715000.0, 5640000.0],
-            [2720000.0, 5640000.0],
-            [2720000.0, 5635000.0],
-            [2715000.0, 5635000.0],
-        ]
-    )
-
-    src = np.array([box0, box1])
-    trg = np.array([box3, box4])
-    dst = np.array([[box5], [box6]])
-    zdb = zonalstats.ZonalDataBase(src, trg, srs=proj)
-    zdp = zonalstats.ZonalDataPoly(src, trg, srs=proj)
-
-    def test__init__(self):
+    @requires_gdal
+    def test__init__(self, stats_base):
         with pytest.raises(NotImplementedError):
-            zonalstats.ZonalStatsBase(self.zdb)
-        zonalstats.ZonalStatsBase(self.zdp)
+            zonalstats.ZonalStatsBase(stats_base.zdb)
+        zonalstats.ZonalStatsBase(stats_base.zdp)
         with pytest.raises(TypeError):
             zonalstats.ZonalStatsBase("test")
         with pytest.raises(TypeError):
@@ -549,224 +621,241 @@ class TestZonalStatsBase:
         with pytest.raises(TypeError):
             zonalstats.ZonalStatsBase(ix=np.arange(10), w=np.arange(11))
 
-    def test_w(self):
-        zdp = zonalstats.ZonalStatsBase(self.zdp)
+    @requires_gdal
+    def test_w(self, stats_base):
+        zdp = zonalstats.ZonalStatsBase(stats_base.zdp)
         np.testing.assert_equal(zdp.w, np.array([[25000000.0], [25000000.0]]))
         np.testing.assert_equal(zdp.ix, np.array([[0], [1]]))
 
-    def test__check_vals(self):
-        zdp = zonalstats.ZonalStatsBase(self.zdp)
+    @requires_gdal
+    def test__check_vals(self, stats_base):
+        zdp = zonalstats.ZonalStatsBase(stats_base.zdp)
         with pytest.raises(AssertionError):
             zdp._check_vals(np.arange(3))
 
-    def test_mean(self):
-        zdp = zonalstats.ZonalStatsBase(self.zdp)
+    @requires_gdal
+    def test_mean(self, stats_base):
+        zdp = zonalstats.ZonalStatsBase(stats_base.zdp)
         np.testing.assert_equal(zdp.mean(np.arange(10, 21, 10)), np.array([10, 20]))
 
-    def test_var(self):
-        zdp = zonalstats.ZonalStatsBase(self.zdp)
+    @requires_gdal
+    def test_var(self, stats_base):
+        zdp = zonalstats.ZonalStatsBase(stats_base.zdp)
         np.testing.assert_equal(zdp.var(np.arange(10, 21, 10)), np.array([0, 0]))
 
 
-@pytest.mark.skipif(not util.has_geos(), reason="GDAL without GEOS")
+@pytest.fixture
+def zonal_data():
+    @dataclass(init=False, repr=False, eq=False)
+    class Data:
+        # setup test grid and catchment
+        lon = 7.071664
+        lat = 50.730521
+        r = np.array(range(50, 100 * 1000 + 50, 100))
+        a = np.array(range(0, 360, 1))
+        rays = a.shape[0]
+        bins = r.shape[0]
+
+        # setup OSR objects
+        proj_gk = osr.SpatialReference()
+        proj_gk.ImportFromEPSG(31466)
+        proj_ll = osr.SpatialReference()
+        proj_ll.ImportFromEPSG(4326)
+
+        # create polar grid polygon vertices in lat,lon
+        coords = georef.spherical_to_polyvert(r, a, 0, (lon, lat), proj=proj_ll)
+        radar_ll = coords[..., 0:2]
+
+        # create polar grid centroids in lat,lon
+        coords = georef.spherical_to_centroids(r, a, 0, (lon, lat), proj=proj_ll)
+        radar_llc = coords[..., 0:2]
+
+        # project ll grids to GK2
+        radar_gk = georef.reproject(
+            radar_ll, projection_source=proj_ll, projection_target=proj_gk
+        )
+        radar_gkc = georef.reproject(
+            radar_llc, projection_source=proj_ll, projection_target=proj_gk
+        )
+
+        # reshape
+        radar_gk.shape = (rays, bins, 5, 2)
+        radar_gkc.shape = (rays, bins, 2)
+
+        box0 = np.array(
+            [
+                [2600000.0, 5630000.0],
+                [2600000.0, 5630100.0],
+                [2600100.0, 5630100.0],
+                [2600100.0, 5630000.0],
+                [2600000.0, 5630000.0],
+            ]
+        )
+
+        box1 = np.array(
+            [
+                [2600100.0, 5630000.0],
+                [2600100.0, 5630100.0],
+                [2600200.0, 5630100.0],
+                [2600200.0, 5630000.0],
+                [2600100.0, 5630000.0],
+            ]
+        )
+
+        data = np.array([box0, box1])
+
+        # create catchment bounding box
+        buffer = 5000.0
+        bbox = zonalstats.get_bbox(data[..., 0], data[..., 1])
+        bbox = dict(
+            left=bbox["left"] - buffer,
+            right=bbox["right"] + buffer,
+            bottom=bbox["bottom"] - buffer,
+            top=bbox["top"] + buffer,
+        )
+
+        mask, shape = zonalstats.mask_from_bbox(
+            radar_gkc[..., 0], radar_gkc[..., 1], bbox, polar=True
+        )
+
+        radar_gkc = radar_gkc[mask, :]
+        radar_gk = radar_gk[mask]
+
+        zdpoly = zonalstats.ZonalDataPoly(radar_gk, data, srs=proj_gk)
+        # zdpoly.dump_vector('test_zdpoly')
+        zdpoint = zonalstats.ZonalDataPoint(radar_gkc, data, srs=proj_gk)
+        # zdpoint.dump_vector('test_zdpoint')
+
+        isec_poly0 = np.array(
+            [
+                np.array(
+                    [
+                        # [2600000.0, 5630000.0],
+                        [2600000.0, 5630100.0],
+                        [2600009.61157242, 5630100.0],
+                        [2600041.77844048, 5630000.0],
+                        [2600000.0, 5630000.0],
+                        [2600000.0, 5630100.0],
+                    ]
+                ),
+                np.array(
+                    [
+                        # [2600009.61157242, 5630100.0],
+                        [2600100.0, 5630100.0],
+                        [2600100.0, 5630000.0],
+                        [2600041.77844048, 5630000.0],
+                        [2600009.61157242, 5630100.0],
+                        [2600100.0, 5630100.0],
+                    ]
+                ),
+                np.array(
+                    [
+                        # [2600091.80406488, 5630100.0],
+                        [2600100.0, 5630100.0],
+                        [2600100.0, 5630074.58501104],
+                        [2600091.80406488, 5630100.0],
+                        [2600100.0, 5630100.0],
+                    ]
+                ),
+            ],
+            dtype=object,
+        )
+        isec_poly1 = np.array(
+            [
+                np.array(
+                    [
+                        # [2600100.0, 5630000.0],
+                        [2600100.0, 5630100.0],
+                        [2600114.66582085, 5630100.0],
+                        [2600146.83254704, 5630000.0],
+                        [2600100.0, 5630000.0],
+                        [2600100.0, 5630100.0],
+                    ]
+                ),
+                np.array(
+                    [
+                        # [2600114.66582085, 5630100.0],
+                        [2600200.0, 5630100.0],
+                        [2600200.0, 5630000.0],
+                        [2600146.83254704, 5630000.0],
+                        [2600114.66582085, 5630100.0],
+                        [2600200.0, 5630100.0],
+                    ]
+                ),
+                np.array(
+                    [
+                        # [2600197.20644071, 5630100.0],
+                        [2600200.0, 5630100.0],
+                        [2600200.0, 5630091.33737992],
+                        [2600197.20644071, 5630100.0],
+                        [2600200.0, 5630100.0],
+                    ]
+                ),
+            ],
+            dtype=object,
+        )
+
+        isec_point0 = np.array([[2600077.2899581, 5630056.0874306]])
+        isec_point1 = np.array([[2600172.498418, 5630086.7127034]])
+
+        isec_poly = np.array([isec_poly0, isec_poly1])
+        isec_point = np.array([isec_point0, isec_point1])
+
+    yield Data
+
+
+@requires_geos
 class TestZonalData:
-    global skip
-    # setup test grid and catchment
-    lon = 7.071664
-    lat = 50.730521
-    r = np.array(range(50, 100 * 1000 + 50, 100))
-    a = np.array(range(0, 360, 1))
-    rays = a.shape[0]
-    bins = r.shape[0]
+    @requires_gdal
+    def test_srs(self, zonal_data):
+        assert zonal_data.zdpoly.srs == zonal_data.proj_gk
+        assert zonal_data.zdpoint.srs == zonal_data.proj_gk
 
-    # setup OSR objects
-    proj_gk = osr.SpatialReference()
-    proj_gk.ImportFromEPSG(31466)
-    proj_ll = osr.SpatialReference()
-    proj_ll.ImportFromEPSG(4326)
-
-    # create polar grid polygon vertices in lat,lon
-    radar_ll = georef.spherical_to_polyvert(r, a, 0, (lon, lat), proj=proj_ll)[..., 0:2]
-
-    # create polar grid centroids in lat,lon
-    coords = georef.spherical_to_centroids(r, a, 0, (lon, lat), proj=proj_ll)
-
-    radar_llc = coords[..., 0:2]
-
-    # project ll grids to GK2
-    radar_gk = georef.reproject(
-        radar_ll, projection_source=proj_ll, projection_target=proj_gk
-    )
-    radar_gkc = georef.reproject(
-        radar_llc, projection_source=proj_ll, projection_target=proj_gk
-    )
-
-    # reshape
-    radar_gk.shape = (rays, bins, 5, 2)
-    radar_gkc.shape = (rays, bins, 2)
-
-    box0 = np.array(
-        [
-            [2600000.0, 5630000.0],
-            [2600000.0, 5630100.0],
-            [2600100.0, 5630100.0],
-            [2600100.0, 5630000.0],
-            [2600000.0, 5630000.0],
-        ]
-    )
-
-    box1 = np.array(
-        [
-            [2600100.0, 5630000.0],
-            [2600100.0, 5630100.0],
-            [2600200.0, 5630100.0],
-            [2600200.0, 5630000.0],
-            [2600100.0, 5630000.0],
-        ]
-    )
-
-    data = np.array([box0, box1])
-
-    # create catchment bounding box
-    buffer = 5000.0
-    bbox = zonalstats.get_bbox(data[..., 0], data[..., 1])
-    bbox = dict(
-        left=bbox["left"] - buffer,
-        right=bbox["right"] + buffer,
-        bottom=bbox["bottom"] - buffer,
-        top=bbox["top"] + buffer,
-    )
-
-    mask, shape = zonalstats.mask_from_bbox(
-        radar_gkc[..., 0], radar_gkc[..., 1], bbox, polar=True
-    )
-
-    radar_gkc = radar_gkc[mask, :]
-    radar_gk = radar_gk[mask]
-
-    zdpoly = zonalstats.ZonalDataPoly(radar_gk, data, srs=proj_gk)
-    # zdpoly.dump_vector('test_zdpoly')
-    zdpoint = zonalstats.ZonalDataPoint(radar_gkc, data, srs=proj_gk)
-    # zdpoint.dump_vector('test_zdpoint')
-
-    isec_poly0 = np.array(
-        [
-            np.array(
-                [
-                    # [2600000.0, 5630000.0],
-                    [2600000.0, 5630100.0],
-                    [2600009.61157242, 5630100.0],
-                    [2600041.77844048, 5630000.0],
-                    [2600000.0, 5630000.0],
-                    [2600000.0, 5630100.0],
-                ]
-            ),
-            np.array(
-                [
-                    # [2600009.61157242, 5630100.0],
-                    [2600100.0, 5630100.0],
-                    [2600100.0, 5630000.0],
-                    [2600041.77844048, 5630000.0],
-                    [2600009.61157242, 5630100.0],
-                    [2600100.0, 5630100.0],
-                ]
-            ),
-            np.array(
-                [
-                    # [2600091.80406488, 5630100.0],
-                    [2600100.0, 5630100.0],
-                    [2600100.0, 5630074.58501104],
-                    [2600091.80406488, 5630100.0],
-                    [2600100.0, 5630100.0],
-                ]
-            ),
-        ],
-        dtype=object,
-    )
-    isec_poly1 = np.array(
-        [
-            np.array(
-                [
-                    # [2600100.0, 5630000.0],
-                    [2600100.0, 5630100.0],
-                    [2600114.66582085, 5630100.0],
-                    [2600146.83254704, 5630000.0],
-                    [2600100.0, 5630000.0],
-                    [2600100.0, 5630100.0],
-                ]
-            ),
-            np.array(
-                [
-                    # [2600114.66582085, 5630100.0],
-                    [2600200.0, 5630100.0],
-                    [2600200.0, 5630000.0],
-                    [2600146.83254704, 5630000.0],
-                    [2600114.66582085, 5630100.0],
-                    [2600200.0, 5630100.0],
-                ]
-            ),
-            np.array(
-                [
-                    # [2600197.20644071, 5630100.0],
-                    [2600200.0, 5630100.0],
-                    [2600200.0, 5630091.33737992],
-                    [2600197.20644071, 5630100.0],
-                    [2600200.0, 5630100.0],
-                ]
-            ),
-        ],
-        dtype=object,
-    )
-
-    isec_point0 = np.array([[2600077.2899581, 5630056.0874306]])
-    isec_point1 = np.array([[2600172.498418, 5630086.7127034]])
-
-    isec_poly = np.array([isec_poly0, isec_poly1])
-    isec_point = np.array([isec_point0, isec_point1])
-
-    def test_srs(self):
-        assert self.zdpoly.srs == self.proj_gk
-        assert self.zdpoint.srs == self.proj_gk
-
-    def test_isecs(self):
+    @requires_gdal
+    def test_isecs(self, zonal_data):
         # need to iterate over nested array for correct testing
-        for i, ival in enumerate(self.zdpoly.isecs):
+        for i, ival in enumerate(zonal_data.zdpoly.isecs):
             for k, kval in enumerate(ival):
                 np.testing.assert_allclose(
-                    kval.astype(float), self.isec_poly[i, k], rtol=1e-6
+                    kval.astype(float), zonal_data.isec_poly[i, k], rtol=1e-6
                 )
 
         np.testing.assert_allclose(
-            self.zdpoint.isecs.astype(float), self.isec_point, rtol=1e-6
+            zonal_data.zdpoint.isecs.astype(float), zonal_data.isec_point, rtol=1e-6
         )
 
-    def test_get_isec(self):
+    @requires_gdal
+    def test_get_isec(self, zonal_data):
         for i in [0, 1]:
-            for k, arr in enumerate(self.zdpoly.get_isec(i)):
+            for k, arr in enumerate(zonal_data.zdpoly.get_isec(i)):
                 np.testing.assert_allclose(
-                    arr.astype(float), self.isec_poly[i, k], rtol=1e-6
+                    arr.astype(float), zonal_data.isec_poly[i, k], rtol=1e-6
                 )
             np.testing.assert_allclose(
-                self.zdpoint.get_isec(i).astype(float), self.isec_point[i], rtol=1e-6
+                zonal_data.zdpoint.get_isec(i).astype(float),
+                zonal_data.isec_point[i],
+                rtol=1e-6,
             )
 
-    def test_get_source_index(self):
+    @requires_gdal
+    def test_get_source_index(self, zonal_data):
         np.testing.assert_array_equal(
-            self.zdpoly.get_source_index(0), np.array([2254, 2255])
+            zonal_data.zdpoly.get_source_index(0), np.array([2254, 2255])
         )
         np.testing.assert_array_equal(
-            self.zdpoly.get_source_index(1), np.array([2255, 2256])
+            zonal_data.zdpoly.get_source_index(1), np.array([2255, 2256])
         )
         np.testing.assert_array_equal(
-            self.zdpoint.get_source_index(0), np.array([2255])
+            zonal_data.zdpoint.get_source_index(0), np.array([2255])
         )
         np.testing.assert_array_equal(
-            self.zdpoint.get_source_index(1), np.array([2256])
+            zonal_data.zdpoint.get_source_index(1), np.array([2256])
         )
 
 
-class TestZonalStatsUtil:
-    npobj = np.array(
+@pytest.fixture
+def npobj():
+    yield np.array(
         [
             [2600000.0, 5630000.0],
             [2600000.0, 5630100.0],
@@ -776,13 +865,19 @@ class TestZonalStatsUtil:
         ]
     )
 
-    ogrobj = georef.numpy_to_ogr(npobj, "Polygon")
 
+@pytest.fixture
+def ogrobj(npobj):
+    yield georef.numpy_to_ogr(npobj, "Polygon")
+
+
+class TestZonalStatsUtil:
     def test_angle_between(self):
         assert zonalstats.angle_between(355.0, 5.0) == pytest.approx(10.0)
         assert zonalstats.angle_between(5.0, 355.0) == pytest.approx(-10.0)
 
-    def test_get_clip_mask(self):
+    @requires_gdal
+    def test_get_clip_mask(self, npobj):
         proj_gk = osr.SpatialReference()
         proj_gk.ImportFromEPSG(31466)
         coords = np.array(
@@ -794,6 +889,6 @@ class TestZonalStatsUtil:
                 [2600040.0, 5640000.0],
             ]
         )
-        mask = zonalstats.get_clip_mask(coords, self.npobj, proj_gk)
+        mask = zonalstats.get_clip_mask(coords, npobj, proj_gk)
         out = np.array([True, True, True, False, False])
         np.testing.assert_array_equal(mask, out)

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -25,6 +25,7 @@ __all__ = [
     "calculate_polynomial",
     "derivate",
     "despeckle",
+    "import_optional",
 ]
 __doc__ = __doc__.format("\n   ".join(__all__))
 
@@ -35,7 +36,6 @@ import os
 
 import deprecation
 import numpy as np
-from osgeo import gdal, ogr
 from scipy import ndimage, signal
 
 from wradlib import version
@@ -573,6 +573,8 @@ def find_bbox_indices(coords, bbox):
 
 
 def has_geos():
+    gdal = import_optional("osgeo.gdal")
+    ogr = import_optional("osgeo.ogr")
     pnt1 = ogr.CreateGeometryFromWkt("POINT(10 20)")
     pnt2 = ogr.CreateGeometryFromWkt("POINT(30 20)")
     ogrex = ogr.GetUseExceptions()
@@ -983,6 +985,10 @@ def _open_file(name):
     else:
         # otherwise assume file-like object and pass
         yield name
+
+
+def has_import(module):
+    return not isinstance(module, OptionalModuleStub)
 
 
 if __name__ == "__main__":

--- a/wradlib/vpr.py
+++ b/wradlib/vpr.py
@@ -31,49 +31,6 @@ as *voxels*. In wradlib, you can create
 CAPPIS (:class:`~wradlib.vpr.CAPPI`) and Pseudo CAPPIs
 (:class:`~wradlib.vpr.PseudoCAPPI`) for different altitudes at once.
 
-Here's an example how a set of CAPPIs can be created from synthetic polar
-volume data:
-
-    >>> import wradlib
-    >>> import numpy as np
-    >>> from osgeo import osr
-    >>> import matplotlib.pyplot as pl
-    >>> pl.interactive(True)
-    >>> # define elevation and azimuth angles, ranges, radar site coordinates,
-    >>> # projection
-    >>> elevs  = np.array([0.5,1.5,2.4,3.4,4.3,5.3,6.2,7.5,8.7,10,12,14,16.7,19.5])
-    >>> azims  = np.arange(0., 360., 1.)
-    >>> ranges = np.arange(0., 120000., 1000.)
-    >>> sitecoords = (120.255547,14.924218,500.)
-    >>> proj = osr.SpatialReference()
-    >>> _ = proj.ImportFromEPSG(32651)
-    >>> # create Cartesian coordinates corresponding the location of the
-    >>> # polar volume bins
-    >>> polxyz  = wradlib.vpr.volcoords_from_polar(sitecoords, elevs,
-    ...                                            azims, ranges, proj)  # noqa
-    >>> poldata = wradlib.vpr.synthetic_polar_volume(polxyz)
-    >>> # this is the shape of our polar volume
-    >>> polshape = (len(elevs),len(azims),len(ranges))
-    >>> # now we define the coordinates for the 3-D grid (the CAPPI layers)
-    >>> x = np.linspace(polxyz[:,0].min(), polxyz[:,0].max(), 120)
-    >>> y = np.linspace(polxyz[:,1].min(), polxyz[:,1].max(), 120)
-    >>> z = np.arange(500.,10500.,500.)
-    >>> xyz = wradlib.util.gridaspoints(z, y, x)
-    >>> gridshape = (len(z), len(y), len(x))
-    >>> # create an instance of the CAPPI class and
-    >>> # use it to create a series of CAPPIs
-    >>> gridder = wradlib.vpr.CAPPI(polxyz, xyz, maxrange=ranges.max(),  # noqa
-    ...                             minelev=elevs.min(), maxelev=elevs.max(),
-    ...                             ipclass=wradlib.ipol.Idw)
-    >>> gridded = np.ma.masked_invalid( gridder(poldata) ).reshape(gridshape)
-    >>>
-    >>> # plot results
-    >>> levels = np.linspace(0,100,25)
-    >>> wradlib.vis.plot_max_plan_and_vert(x, y, z, gridded, levels=levels,
-    ...                                    cmap=pl.cm.viridis)
-    >>> pl.show()
-
-
 .. autosummary::
    :nosignatures:
    :toctree: generated/
@@ -91,6 +48,7 @@ __all__ = [
     "blindspots",
 ]
 __doc__ = __doc__.format("\n   ".join(__all__))
+__doctest_requires__ = {"CAPPI": ["osgeo"]}
 
 import warnings
 
@@ -261,6 +219,48 @@ class CAPPI(CartesianVolume):
     Examples
     --------
     See :ref:`/notebooks/workflow/recipe2.ipynb`.
+
+    Here's an example how a set of CAPPIs can be created from synthetic polar volume data:
+
+
+        >>> import wradlib
+        >>> import numpy as np
+        >>> from osgeo import osr
+        >>> import matplotlib.pyplot as pl
+        >>> pl.interactive(True)
+        >>> # define elevation and azimuth angles, ranges, radar site coordinates,
+        >>> # projection
+        >>> elevs  = np.array([0.5,1.5,2.4,3.4,4.3,5.3,6.2,7.5,8.7,10,12,14,16.7,19.5])
+        >>> azims  = np.arange(0., 360., 1.)
+        >>> ranges = np.arange(0., 120000., 1000.)
+        >>> sitecoords = (120.255547,14.924218,500.)
+        >>> proj = osr.SpatialReference()
+        >>> _ = proj.ImportFromEPSG(32651)
+        >>> # create Cartesian coordinates corresponding the location of the
+        >>> # polar volume bins
+        >>> polxyz  = wradlib.vpr.volcoords_from_polar(sitecoords, elevs,
+        ...                                            azims, ranges, proj)  # noqa
+        >>> poldata = wradlib.vpr.synthetic_polar_volume(polxyz)
+        >>> # this is the shape of our polar volume
+        >>> polshape = (len(elevs),len(azims),len(ranges))
+        >>> # now we define the coordinates for the 3-D grid (the CAPPI layers)
+        >>> x = np.linspace(polxyz[:,0].min(), polxyz[:,0].max(), 120)
+        >>> y = np.linspace(polxyz[:,1].min(), polxyz[:,1].max(), 120)
+        >>> z = np.arange(500.,10500.,500.)
+        >>> xyz = wradlib.util.gridaspoints(z, y, x)
+        >>> gridshape = (len(z), len(y), len(x))
+        >>> # create an instance of the CAPPI class and
+        >>> # use it to create a series of CAPPIs
+        >>> gridder = wradlib.vpr.CAPPI(polxyz, xyz, maxrange=ranges.max(),  # noqa
+        ...                             minelev=elevs.min(), maxelev=elevs.max(),
+        ...                             ipclass=wradlib.ipol.Idw)
+        >>> gridded = np.ma.masked_invalid( gridder(poldata) ).reshape(gridshape)
+        >>>
+        >>> # plot results
+        >>> levels = np.linspace(0,100,25)
+        >>> wradlib.vis.plot_max_plan_and_vert(x, y, z, gridded, levels=levels,
+        ...                                    cmap=pl.cm.viridis)
+        >>> pl.show()
     """
 
     def _get_mask(self, gridcoords, polcoords, maxrange, minelev, maxelev):

--- a/wradlib/zonalstats.py
+++ b/wradlib/zonalstats.py
@@ -61,15 +61,19 @@ import tempfile
 import warnings
 
 import numpy as np
-from matplotlib import patches
-from matplotlib.path import Path
-from osgeo import gdal, ogr
 from scipy import spatial
 
 from wradlib import georef, io
+from wradlib.util import has_import, import_optional
 
-ogr.UseExceptions()
-gdal.UseExceptions()
+ogr = import_optional("osgeo.ogr")
+gdal = import_optional("osgeo.gdal")
+mpl_patches = import_optional("matplotlib.patches")
+mpl_path = import_optional("matplotlib.path")
+
+if has_import(gdal):
+    ogr.UseExceptions()
+    gdal.UseExceptions()
 
 # check windows
 isWindows = os.name == "nt"
@@ -1074,11 +1078,11 @@ def numpy_to_pathpatch(arr):
             code = np.full(vert.shape[0], 2, dtype=np.int)
             ind = np.cumsum([0] + [len(x) for x in item[:-1]])
             code[ind] = 1
-            path = Path(vert, code)
-            paths.append(patches.PathPatch(path))
+            path = mpl_path.Path(vert, code)
+            paths.append(mpl_patches.PathPatch(path))
         else:
-            path = Path(item, [1] + (len(item) - 1) * [2])
-            paths.append(patches.PathPatch(path))
+            path = mpl_path.Path(item, [1] + (len(item) - 1) * [2])
+            paths.append(mpl_patches.PathPatch(path))
 
     return np.array(paths)
 


### PR DESCRIPTION
Resolves #506 

This makes the following dependencies optional, at least when using them in the code:

`dask gdal h5netcdf h5py netCDF4 requests xmltodict cartopy`

If you use pip to install wradlib all dependencies (requirements.txt + requirements_optional.txt) will be installed for the time being. This will change with version 2.0 sometime next year.

If you want to take advantage of this now, you would need to use `--no-deps` when invoking `pip` and install the necessary dependencies beforehand.