### PR TITLE
Rel 1.13.0

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2011-2020 wradlib developers
+Copyright (c) 2011-2021 wradlib developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,6 @@ include MANIFEST.in
 include pyproject.toml
 include requirements.txt
 include requirements_devel.txt
+include requirements_optional.txt
 recursive-include wradlib/tests *.py
 recursive-exclude wradlib/tests *.pyc

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ LICENSE = "MIT"
 CLASSIFIERS = list(filter(None, CLASSIFIERS.split("\n")))
 PLATFORMS = ["Linux", "Mac OS-X", "Unix", "Windows"]
 MAJOR = 1
-MINOR = 12
+MINOR = 13
 PATCH = 0
 VERSION = "%d.%d.%d" % (MAJOR, MINOR, PATCH)
 


### PR DESCRIPTION
Due to the missing `requirements_optional.txt` in version `1.12.0` and the resulting problems with documentation wradlib 1.13.0 is released in short succession. It's contains essentially the same changes as 1.12.0.