### PR TITLE
MNT: use Python 3.10 conda-forge everywhere, use cartopy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,6 @@ jobs:
         mv .bashrcBAK "$HOME/.bashrc"
     - name: Install deps
       run: |
-        if [ ${{ matrix.python-version }} != "3.10" ]
-        then
-          echo "cartopy" >> ci/requirements/unittests.txt
-        fi
         micromamba create -y -n wradlib-tests python=${{ matrix.python-version }} -f ci/requirements/unittests.txt --channel conda-forge
         echo "set -eo pipefail" >> "$HOME/.bash_profile"
         echo "micromamba activate wradlib-tests" >> "$HOME/.bash_profile"
@@ -113,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -176,7 +172,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -243,7 +239,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -324,7 +320,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -352,7 +348,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/ci/requirements/unittests.txt
+++ b/ci/requirements/unittests.txt
@@ -1,4 +1,5 @@
 bottleneck
+cartopy
 codecov
 coverage
 dask

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,3 +1,4 @@
+cartopy
 dask
 gdal
 h5netcdf


### PR DESCRIPTION
conda-forge migration for Python 3.10 for the wradlib package-stack is finished. Trying to move CI to Python 3.10 for all OS.