### PR TITLE
Fix zero padding of bits in rainbow format flags (issue 549)

### DIFF
--- a/wradlib/clutter.py
+++ b/wradlib/clutter.py
@@ -78,11 +78,11 @@ def filter_gabella_a(img, wsize, tr1, cartesian=False, radial=False):
         for sr in range_shift:
             refr = np.roll(refa, sr, axis=1)
             count += img - refr < tr1
-    count[:, 0:nn] = wsize ** 2
-    count[:, -nn:] = wsize ** 2
+    count[:, 0:nn] = wsize**2
+    count[:, -nn:] = wsize**2
     if cartesian:
-        count[0:nn, :] = wsize ** 2
-        count[-nn:, :] = wsize ** 2
+        count[0:nn, :] = wsize**2
+        count[-nn:, :] = wsize**2
     return count
 
 

--- a/wradlib/comp.py
+++ b/wradlib/comp.py
@@ -37,7 +37,7 @@ def extract_circle(center, radius, coords):
         1-darray of integers, index array referring to the ``coords`` array
 
     """
-    return np.where(((coords - center) ** 2).sum(axis=-1) < radius ** 2)[0]
+    return np.where(((coords - center) ** 2).sum(axis=-1) < radius**2)[0]
 
 
 def togrid(src, trg, radius, center, data, interpol, *args, **kwargs):

--- a/wradlib/dp.py
+++ b/wradlib/dp.py
@@ -587,7 +587,7 @@ def depolarization(zdr, rho):
         numpy broadcasting rules apply
     """
     zdr = trafo.idecibel(np.asanyarray(zdr))
-    m = 2 * np.asanyarray(rho) * zdr ** 0.5
+    m = 2 * np.asanyarray(rho) * zdr**0.5
 
     return trafo.decibel((1 + zdr - m) / (1 + zdr + m))
 

--- a/wradlib/georef/misc.py
+++ b/wradlib/georef/misc.py
@@ -55,7 +55,7 @@ def bin_altitude(r, theta, sitealt, re, ke=4.0 / 3.0):
     """
     reff = ke * re
     sr = reff + sitealt
-    return np.sqrt(r ** 2 + sr ** 2 + 2 * r * sr * np.sin(np.radians(theta))) - reff
+    return np.sqrt(r**2 + sr**2 + 2 * r * sr * np.sin(np.radians(theta))) - reff
 
 
 def bin_distance(r, theta, sitealt, re, ke=4.0 / 3.0):

--- a/wradlib/georef/rect.py
+++ b/wradlib/georef/rect.py
@@ -289,10 +289,10 @@ Polar-Stereographic-Projection`.
 
             sinlat0 = np.sin(np.radians(lat0))
 
-            fac = (6370.040 ** 2.0) * ((1.0 + sinlat0) ** 2.0)
+            fac = (6370.040**2.0) * ((1.0 + sinlat0) ** 2.0)
             lon = np.degrees(np.arctan((-x / y))) + lon0
             lat = np.degrees(
-                np.arcsin((fac - (x ** 2.0 + y ** 2.0)) / (fac + (x ** 2.0 + y ** 2.0)))
+                np.arcsin((fac - (x**2.0 + y**2.0)) / (fac + (x**2.0 + y**2.0)))
             )
             radolan_grid = np.dstack((lon, lat))
         else:

--- a/wradlib/io/backends.py
+++ b/wradlib/io/backends.py
@@ -1191,7 +1191,7 @@ class RainbowStore(AbstractDataStore):
         vmin = float(raw.get("@min"))
         vmax = float(raw.get("@max"))
         depth = int(raw.get("@depth"))
-        scale_factor = (vmax - vmin) / (2 ** depth - 2)
+        scale_factor = (vmax - vmin) / (2**depth - 2)
         mname = rainbow_mapping.get(name, name)
         mapping = moments_mapping.get(mname, {})
         attrs = {key: mapping[key] for key in moment_attrs if key in mapping}

--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -251,8 +251,8 @@ def read_dx(filename):
 
     azimuthbitmask = 2 ** (14 - 1)
     databitmask = 2 ** (13 - 1) - 1
-    clutterflag = 2 ** 15
-    dataflag = 2 ** 13 - 1
+    clutterflag = 2**15
+    dataflag = 2**13 - 1
 
     with get_radolan_filehandle(filename) as f:
 

--- a/wradlib/io/rainbow.py
+++ b/wradlib/io/rainbow.py
@@ -220,7 +220,7 @@ def get_rb_blob_data(datastring, blobid):
     return data
 
 
-def map_rb_data(data, datadepth):
+def map_rb_data(data, datadepth, datashape=0):
     """Map BLOB data to correct DataWidth and Type and convert it
     to numpy array
 
@@ -230,6 +230,8 @@ def map_rb_data(data, datadepth):
         Blob Data
     datadepth : int
         bit depth of Blob data
+    datashape : tuple
+        expected data shape, only used for the flags to truncate
 
     Returns
     -------
@@ -247,7 +249,7 @@ def map_rb_data(data, datadepth):
     data = np.ndarray(shape=(int(len(data) / datawidth),), dtype=datatype, buffer=data)
 
     if flagdepth:
-        data = np.unpackbits(data)
+        data = np.unpackbits(data)[0 : np.prod(datashape)]
 
     return data
 
@@ -316,10 +318,11 @@ def get_rb_blob_from_string(datastring, blobdict):
     data = get_rb_blob_data(datastring, blobid)
     # map data to correct datatype and width
     datadepth = get_rb_data_attribute(blobdict, "depth")
-    data = map_rb_data(data, datadepth)
+    datashape = get_rb_data_shape(blobdict)
+    data = map_rb_data(data, datadepth, datashape)
 
     # reshape data
-    data.shape = get_rb_data_shape(blobdict)
+    data.shape = datashape
 
     return data
 

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -394,7 +394,7 @@ class Idw(IpolBase):
         """
         self._check_shape(vals)
 
-        weights = 1.0 / self.dists ** self.p
+        weights = 1.0 / self.dists**self.p
 
         # if maxdist isn't given, take the maximum distance
         if maxdist is not None:
@@ -892,14 +892,14 @@ def cov_sph(h, sill=1.0, rng=1.0):
     """spherical type covariance function"""
     h = np.asanyarray(h)
     return np.where(
-        h < rng, sill * (1.0 - 1.5 * h / rng + h ** 3 / (2 * rng ** 3)), 0.0
+        h < rng, sill * (1.0 - 1.5 * h / rng + h**3 / (2 * rng**3)), 0.0
     )
 
 
 def cov_gau(h, sill=1.0, rng=1.0):
     """gaussian type covariance function"""
     h = np.asanyarray(h)
-    return sill * np.exp(-(h ** 2) / rng ** 2)
+    return sill * np.exp(-(h**2) / rng**2)
 
 
 def cov_lin(h, sill=1.0, rng=1.0):
@@ -928,7 +928,7 @@ def cov_mat(h, sill=1.0, rng=1.0, shp=0.5):
         fac1 = h / rng * 2.0 * np.sqrt(shp)
         fac2 = tau(shp) * 2.0 ** (shp - 1.0)
 
-        c = np.where(h != 0, sill * 1.0 / fac2 * fac1 ** shp * kv(shp, fac1), sill)
+        c = np.where(h != 0, sill * 1.0 / fac2 * fac1**shp * kv(shp, fac1), sill)
 
     return c
 
@@ -936,7 +936,7 @@ def cov_mat(h, sill=1.0, rng=1.0, shp=0.5):
 def cov_pow(h, sill=1.0, rng=1.0):
     """power law covariance function"""
     h = np.asanyarray(h)
-    return sill - h ** rng
+    return sill - h**rng
 
 
 def cov_cau(h, sill=1.0, rng=1.0, alpha=1.0, beta=1.0):

--- a/wradlib/qual.py
+++ b/wradlib/qual.py
@@ -65,7 +65,7 @@ def pulse_volume(ranges, h, theta):
     See :ref:`/notebooks/workflow/recipe1.ipynb`.
 
     """
-    return np.pi * h * (ranges ** 2) * (np.tan(np.radians(theta / 2.0))) ** 2
+    return np.pi * h * (ranges**2) * (np.tan(np.radians(theta / 2.0))) ** 2
 
 
 def beam_block_frac(th, bh, a):
@@ -124,7 +124,7 @@ def beam_block_frac(th, bh, a):
     clear = ya < -1.0
     block = ya > 1.0
 
-    numer = (ya * np.sqrt(a ** 2 - y ** 2)) + (a * np.arcsin(ya)) + (np.pi * a / 2.0)
+    numer = (ya * np.sqrt(a**2 - y**2)) + (a * np.arcsin(ya)) + (np.pi * a / 2.0)
 
     denom = np.pi * a
 

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -1026,7 +1026,7 @@ class TestGetGrids:
     @requires_gdal
     def test_grid_reference_points(self, grid, origin, wgs):
         arr = list(georef.get_radolan_grid(grid[0], grid[1], wgs84=wgs)[0, 0])
-        assert pytest.approx(arr, origin[0])
+        assert pytest.approx(arr) == origin
 
 
 @pytest.fixture

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -1279,7 +1279,11 @@ class TestRainbow:
         np.testing.assert_allclose(io.rainbow.map_rb_data(indata, 32), outdata32)
         flagdata = b"1"
         np.testing.assert_allclose(
-            io.rainbow.map_rb_data(flagdata, 1), [0, 0, 1, 1, 0, 0, 0, 1]
+            io.rainbow.map_rb_data(flagdata, 1, 8), [0, 0, 1, 1, 0, 0, 0, 1]
+        )
+        # added test for truncation
+        np.testing.assert_allclose(
+            io.rainbow.map_rb_data(flagdata, 1, 6), [0, 0, 1, 1, 0, 0]
         )
 
     def test_get_rb_blob_data(self):

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -373,7 +373,7 @@ def prob_round(x, prec=0):
     prec : int
         precision
     """
-    fixup = np.sign(x) * 10 ** prec
+    fixup = np.sign(x) * 10**prec
     x *= fixup
     intx = x.astype(int)
     round_func = intx + np.random.binomial(1, x - intx)
@@ -626,7 +626,7 @@ def calculate_polynomial(data, w):
     """
     poly = np.zeros_like(data)
     for i, c in enumerate(w):
-        poly += c * data ** i
+        poly += c * data**i
     return poly
 
 

--- a/wradlib/verify.py
+++ b/wradlib/verify.py
@@ -213,7 +213,7 @@ class ErrorMetrics:
 
     def sse(self):
         """Sum of Squared Errors"""
-        return np.round(np.sum(self.resids ** 2), 2)
+        return np.round(np.sum(self.resids**2), 2)
 
     def mse(self):
         """Mean Squared Error"""

--- a/wradlib/vpr.py
+++ b/wradlib/vpr.py
@@ -352,7 +352,7 @@ def out_of_range(center, gridcoords, maxrange):
         1-D Boolean array of length len(gridcoords)
 
     """
-    return ((gridcoords - center) ** 2).sum(axis=-1) > maxrange ** 2
+    return ((gridcoords - center) ** 2).sum(axis=-1) > maxrange**2
 
 
 def blindspots(center, gridcoords, minelev, maxelev, maxrange):

--- a/wradlib/zr.py
+++ b/wradlib/zr.py
@@ -83,7 +83,7 @@ def r_to_z(r, a=200.0, b=1.6):
         reflectivity in mm**6/m**3
 
     """
-    return a * r ** b
+    return a * r**b
 
 
 def z_to_r_enhanced(z, polar=True, shower=True):


### PR DESCRIPTION
This is a fix for #549 . I've added a test for the truncation as well. Put in default argument for datashape = 0, it is only used when looking at the flags (datadepth < 8) and therefore code in the original tests for the radar data itself should remain unaffected. 