### PR TITLE
MNT: use pypa's setuptools_scm and build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 env:
-  micromamba_version: 0.17.0
+  micromamba_version: 0.22.0
 
 on:
   push:
@@ -63,14 +63,13 @@ jobs:
           python=${{ matrix.python-version }}
     - name: Install wradlib
       run: |
-        python setup.py sdist
         python -m pip install . --no-deps
     - name: Clone wradlib-data
       run: |
         git clone https://github.com/wradlib/wradlib-data.git
     - name: Version Info
       run: |
-        python -c "import wradlib; print(wradlib.version.full_version)"
+        python -c "import wradlib; print(wradlib.version.version)"
         python -c "import wradlib; print(wradlib.show_versions())"
     - name: Test with pytest
       env:
@@ -116,14 +115,13 @@ jobs:
     - name: Install wradlib
       run: |
         cat "$HOME/.bash_profile"
-        python setup.py sdist
         python -m pip install . --no-deps
     - name: Clone wradlib-data
       run: |
         git clone https://github.com/wradlib/wradlib-data.git
     - name: Version Info
       run: |
-        python -c "import wradlib; print(wradlib.version.full_version)"
+        python -c "import wradlib; print(wradlib.version.version)"
         python -c "import wradlib; print(wradlib.show_versions())"
     - name: Test with pytest
       env:
@@ -168,14 +166,13 @@ jobs:
             python=${{ matrix.python-version }}
       - name: Install wradlib
         run: |
-          python setup.py sdist
           python -m pip install . --no-deps
       - name: Clone wradlib-data
         run: |
           git clone https://github.com/wradlib/wradlib-data.git
       - name: Version Info
         run: |
-          python -c "import wradlib; print(wradlib.version.full_version)"
+          python -c "import wradlib; print(wradlib.version.version)"
           python -c "import wradlib; print(wradlib.show_versions())"
       - name: Test with pytest
         env:
@@ -219,7 +216,6 @@ jobs:
             python=${{ matrix.python-version }}
       - name: Install wradlib
         run: |
-          python setup.py sdist
           python -m pip install . --no-deps
       - name: Clone wradlib-data
         run: |
@@ -229,7 +225,7 @@ jobs:
           git clone --depth 1 https://github.com/wradlib/wradlib-notebooks.git notebooks
       - name: Version Info
         run: |
-          python -c "import wradlib; print(wradlib.version.full_version)"
+          python -c "import wradlib; print(wradlib.version.version)"
           python -c "import wradlib; print(wradlib.show_versions())"
       - name: Test with pytest
         env:
@@ -283,13 +279,13 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install semver setuptools wheel twine
+          pip install build setuptools wheel twine
       - name: Package and Upload
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
         run: |
-          python setup.py sdist
+          python -m build
           twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
   upload_pypi:
@@ -311,11 +307,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install semver setuptools wheel twine
+          pip install build setuptools wheel twine
       - name: Package and Upload
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          python setup.py sdist
+          python -m build
           twine upload dist/*

--- a/ci/requirements/notebooktests.yml
+++ b/ci/requirements/notebooktests.yml
@@ -30,7 +30,6 @@ dependencies:
   - requests
   - rioxarray
   - scipy
-  - semver
   - setuptools
   - tqdm
   - wetterdienst

--- a/ci/requirements/unittests.yml
+++ b/ci/requirements/unittests.yml
@@ -23,7 +23,6 @@ dependencies:
   - pytest-xdist
   - requests
   - scipy
-  - semver
   - setuptools
   - xarray
   - xmltodict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,13 @@
 [build-system]
-requires = ["setuptools", "wheel", "semver"]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "setuptools_scm[toml]>=6.2",
+    "setuptools_scm_git_archive",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "wradlib/version.py"
+version_scheme = "release-branch-semver"
+fallback_version = "999"

--- a/requirements_devel.txt
+++ b/requirements_devel.txt
@@ -7,4 +7,3 @@ pytest-cov
 pytest-doctestplus
 pytest-sugar
 pytest-xdist
-semver

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,6 @@ intensity, identifying and correcting typical error sources (such as
 clutter or attenuation) and visualising the data.
 """
 
-import builtins
-import os
-import warnings
-from subprocess import CalledProcessError, check_output
-
-import semver
-
 DOCLINES = __doc__.split("\n")
 
 CLASSIFIERS = """\
@@ -45,129 +38,14 @@ MAINTAINER = "wradlib developers"
 MAINTAINER_EMAIL = "wradlib@wradlib.org"
 DESCRIPTION = DOCLINES[0]
 LONG_DESCRIPTION = "\n".join(DOCLINES[2:])
-URL = "http://wradlib.org"
+URL = "https://wradlib.org"
 DOWNLOAD_URL = "https://github.com/wradlib/wradlib"
 LICENSE = "MIT"
 CLASSIFIERS = list(filter(None, CLASSIFIERS.split("\n")))
 PLATFORMS = ["Linux", "Mac OS-X", "Unix", "Windows"]
-MAJOR = 1
-MINOR = 14
-PATCH = 0
-VERSION = f"{MAJOR}.{MINOR}.{PATCH}"
-
-
-# Return the git revision as a string
-def git_version():
-    try:
-        git_rev = check_output(["git", "describe", "--tags", "--long"])
-        git_hash = check_output(["git", "rev-parse", "HEAD"])
-        branch = check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
-
-        git_rev = git_rev.strip().decode("ascii").split("-")
-        branch = branch.strip().decode("ascii")
-
-        GIT_REVISION = "-".join([git_rev[0], "dev" + git_rev[1]])
-        GIT_REVISION = "+".join([GIT_REVISION, git_rev[2]])
-        GIT_HASH = git_hash.strip().decode("ascii")
-
-        ver = semver.VersionInfo.parse(GIT_REVISION)
-        minor = ver.minor
-        patch = ver.patch
-
-        if ver.prerelease != "dev0":
-            if "release" not in branch:
-                minor += 1
-            else:
-                patch += 1
-        GIT_REVISION = semver.format_version(
-            ver.major, minor, patch, ver.prerelease, ver.build
-        )
-
-    except (CalledProcessError, OSError):
-        print("WRADLIB: Unable to import git_revision from repository.")
-        raise
-    return GIT_REVISION, GIT_HASH
-
-
-# This is a bit hackish: we are setting a global variable so that the main
-# wradlib __init__ can detect if it is being loaded by the setup routine, to
-# avoid attempting to load components that aren't built yet.
-builtins.__WRADLIB_SETUP__ = True
-
-
-def write_version_py(filename="wradlib/version.py"):
-    cnt = """
-# THIS FILE IS GENERATED FROM WRADLIB SETUP.PY
-short_version = '%(short_version)s'
-version = '%(version)s'
-full_version = '%(full_version)s'
-git_revision = '%(git_revision)s'
-release = %(isrelease)s
-"""
-    # Adding the git rev number needs to be done inside write_version_py(),
-    # otherwise the import of wradlib.version messes up the build under
-    # Python 3.
-
-    SHORT_VERSION = VERSION
-    FULL_VERSION = VERSION
-    GIT_REVISION = VERSION + "-unknown"
-    GIT_HASH = "unknown"
-    ISRELEASED = "'unknown'"
-
-    if os.path.exists(".git"):
-        GIT_REVISION, GIT_HASH = git_version()
-    elif os.path.exists("wradlib/version.py"):
-        # must be a source distribution, use existing version file
-        try:
-            from wradlib.version import full_version as GIT_REVISION
-            from wradlib.version import git_revision as GIT_HASH
-        except ImportError:
-            raise ImportError(
-                "Unable to import git_revision. Try removing "
-                "wradlib/version.py and the build directory "
-                "before building."
-            )
-    else:
-        warnings.warn(
-            "wradlib source does not contain detailed version info "
-            "via git or version.py, exact version can't be "
-            "retrieved.",
-            UserWarning,
-        )
-
-    # parse version using semver
-    ver = semver.VersionInfo.parse(GIT_REVISION)
-
-    # get commit count, dev0 means tagged commit -> release
-    ISRELEASED = ver.prerelease == "dev0"
-    if not ISRELEASED:
-        SHORT_VERSION = semver.format_version(
-            ver.major, ver.minor, ver.patch, ver.prerelease
-        )
-        FULL_VERSION = GIT_REVISION
-
-    a = open(filename, "w")
-    try:
-        a.write(
-            cnt
-            % {
-                "short_version": SHORT_VERSION,
-                "version": FULL_VERSION,
-                "full_version": GIT_REVISION,
-                "git_revision": GIT_HASH,
-                "isrelease": str(ISRELEASED),
-            }
-        )
-    finally:
-        a.close()
-
-    return SHORT_VERSION
 
 
 def setup_package():
-
-    # rewrite version file
-    VERSION = write_version_py()
 
     from setuptools import find_packages, setup
 
@@ -189,11 +67,11 @@ def setup_package():
         description=DESCRIPTION,
         long_description=LONG_DESCRIPTION,
         url=URL,
-        version=VERSION,
         download_url=DOWNLOAD_URL,
         license=LICENSE,
         classifiers=CLASSIFIERS,
         platforms=PLATFORMS,
+        setup_requires=["setuptools_scm"],
         install_requires=INSTALL_REQUIRES,
         extras_require=dict(
             dev=DEVEL_REQUIRES,

--- a/wradlib/__init__.py
+++ b/wradlib/__init__.py
@@ -5,49 +5,39 @@
 """
 wradlib
 =======
-
-isort:skip_file
 """
 
-# Detect if we're being called as part of wradlib's setup procedure
+# Make sure that deprecation warnings get printed by default
+import warnings as _warnings
+
+_warnings.filterwarnings("always", category=DeprecationWarning, module="wradlib")
+
+# versioning
 try:
-    __WRADLIB_SETUP__
-except NameError:
-    __WRADLIB_SETUP__ = False
+    from .version import version as __version__
+except Exception:
+    # Local copy or not installed with setuptools.
+    # Disable minimum version checks on downstream libraries.
+    __version__ = "999"
 
-if __WRADLIB_SETUP__:
-    import sys as _sys
+# import subpackages
+from . import adjust  # noqa
+from . import atten  # noqa
+from . import classify  # noqa
+from . import clutter  # noqa
+from . import comp  # noqa
+from . import dp  # noqa
+from . import georef  # noqa
+from . import io  # noqa
+from . import ipol  # noqa
+from . import qual  # noqa
+from . import trafo  # noqa
+from . import util  # noqa
+from . import verify  # noqa
+from . import vis  # noqa
+from . import vpr  # noqa
+from . import zonalstats  # noqa
+from . import zr  # noqa
+from .util import show_versions  # noqa
 
-    _sys.stderr.write("Running from wradlib source directory.\n")
-    del _sys
-else:
-    # Make sure that deprecation warnings get printed by default
-    import warnings as _warnings
-
-    _warnings.filterwarnings("always", category=DeprecationWarning, module="wradlib")
-
-    # versioning
-    from .version import git_revision as __git_revision__  # noqa
-    from .version import version as __version__  # noqa
-
-    # import subpackages
-    from . import adjust  # noqa
-    from . import atten  # noqa
-    from . import classify  # noqa
-    from . import clutter  # noqa
-    from . import comp  # noqa
-    from . import dp  # noqa
-    from . import georef  # noqa
-    from . import io  # noqa
-    from . import ipol  # noqa
-    from . import qual  # noqa
-    from . import trafo  # noqa
-    from . import util  # noqa
-    from . import verify  # noqa
-    from . import vis  # noqa
-    from . import vpr  # noqa
-    from . import zonalstats  # noqa
-    from . import zr  # noqa
-    from .util import show_versions  # noqa
-
-    __all__ = [s for s in dir() if not s.startswith("_")]
+__all__ = [s for s in dir() if not s.startswith("_")]

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -967,7 +967,7 @@ def show_versions(file=None):
         file = sys.stdout
     xr.show_versions(file)
     print("", file=file)
-    print(f"wradlib: {version.full_version}")
+    print(f"wradlib: {version.version}")
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
This simplifies wradlib's install process in CI as well as the release process. It also removes the dependency to `semver`. In the future we should be able to only use `pyproject.toml` and remove `setup.py` and `setup.cfg`.