### PR TITLE
FIX: update DWD grids

### DIFF
--- a/ci/requirements/notebooktests.yml
+++ b/ci/requirements/notebooktests.yml
@@ -15,6 +15,7 @@ dependencies:
   - h5netcdf
   - lat_lon_parser
   - nbconvert
+  - nc-time-axis
   - netCDF4
   - notebook
   - numpy

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,6 +1,6 @@
 cartopy
 dask
-gdal
+gdal>=3
 geopandas
 h5netcdf
 h5py

--- a/wradlib/georef/projection.py
+++ b/wradlib/georef/projection.py
@@ -28,7 +28,6 @@ __all__ = [
 __doc__ = __doc__.format("\n   ".join(__all__))
 
 import numpy as np
-from packaging.version import Version
 
 from wradlib.util import import_optional
 
@@ -39,19 +38,19 @@ osr = import_optional("osgeo.osr")
 # Taken from document "Radarkomposits - Projektionen und Gitter", Version 1.01
 # 5th of April 2022
 _radolan_ref = dict(
-        sphere=dict(
-            default=dict(x_0=0.0, y_0=0.0),
-            rx=dict(x_0=522962.16692185635, y_0=3759144.724265574),
-            de1200=dict(x_0=542962.166921856585, y_0=3609144.7242655745),
-            de4800=dict(x_0=543337.16692185646, y_0=3608769.7242655735),
-        ),
-        wgs84=dict(
-            default=dict(x_0=0.0, y_0=0.0),
-            rx=dict(x_0=523196.83521777776, y_0=3772588.861931134),
-            de1200=dict(x_0=543196.83521776402, y_0=3622588.8619310018),
-            de4800=dict(x_0=543571.83521776402, y_0=3622213.8619310018),
-        ),
-    )
+    sphere=dict(
+        default=dict(x_0=0.0, y_0=0.0),
+        rx=dict(x_0=522962.16692185635, y_0=3759144.724265574),
+        de1200=dict(x_0=542962.166921856585, y_0=3609144.7242655745),
+        de4800=dict(x_0=543337.16692185646, y_0=3608769.7242655735),
+    ),
+    wgs84=dict(
+        default=dict(x_0=0.0, y_0=0.0),
+        rx=dict(x_0=523196.83521777776, y_0=3772588.861931134),
+        de1200=dict(x_0=543196.83521776402, y_0=3622588.8619310018),
+        de4800=dict(x_0=543571.83521776402, y_0=3622213.8619310018),
+    ),
+)
 
 
 def create_osr(projname, **kwargs):

--- a/wradlib/georef/projection.py
+++ b/wradlib/georef/projection.py
@@ -36,6 +36,23 @@ gdal = import_optional("osgeo.gdal")
 ogr = import_optional("osgeo.ogr")
 osr = import_optional("osgeo.osr")
 
+# Taken from document "Radarkomposits - Projektionen und Gitter", Version 1.01
+# 5th of April 2022
+_radolan_ref = dict(
+        sphere=dict(
+            default=dict(x_0=0.0, y_0=0.0),
+            rx=dict(x_0=522962.16692185635, y_0=3759144.724265574),
+            de1200=dict(x_0=542962.166921856585, y_0=3609144.7242655745),
+            de4800=dict(x_0=543337.16692185646, y_0=3608769.7242655735),
+        ),
+        wgs84=dict(
+            default=dict(x_0=0.0, y_0=0.0),
+            rx=dict(x_0=523196.83521777776, y_0=3772588.861931134),
+            de1200=dict(x_0=543196.83521776402, y_0=3622588.8619310018),
+            de4800=dict(x_0=543571.83521776402, y_0=3622213.8619310018),
+        ),
+    )
+
 
 def create_osr(projname, **kwargs):
     """Conveniently supports the construction of osr spatial reference objects
@@ -77,21 +94,7 @@ def create_osr(projname, **kwargs):
     See :ref:`/notebooks/basics/wradlib_workflow.ipynb#\
 Georeferencing-and-Projection`.
     """
-
     aeqd_wkt = (
-        'PROJCS["unnamed",'
-        'GEOGCS["WGS 84",'
-        'DATUM["unknown",'
-        'SPHEROID["WGS84",6378137,298.257223563]],'
-        'PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]],'
-        'PROJECTION["Azimuthal_Equidistant"],'
-        'PARAMETER["latitude_of_center", {0:-f}],'
-        'PARAMETER["longitude_of_center", {1:-f}],'
-        'PARAMETER["false_easting", {2:-f}],'
-        'PARAMETER["false_northing", {3:-f}],'
-        'UNIT["Meter",1]]'
-    )
-    aeqd_wkt3 = (
         'PROJCS["unnamed",'
         'GEOGCS["WGS 84",'
         'DATUM["unknown",'
@@ -106,7 +109,18 @@ Georeferencing-and-Projection`.
         'UNIT["Meter",1]]'
     )
 
-    radolan_wkt3 = (
+    wgs84_wkt = (
+        'PROJCS["Radolan Projection",'
+        'GEOGCS["Radolan Coordinate System",'
+        'DATUM["unknown based on WGS 84",'
+        'SPHEROID["WGS 84", 6378137, 298.25722356301]],'
+        'PRIMEM["Greenwich", 0,'
+        'AUTHORITY["EPSG", "8901"]],'
+        'UNIT["degree", 0.0174532925199433,'
+        'AUTHORITY["EPSG", "9122"]]],'
+    )
+
+    sphere_wkt = (
         'PROJCS["Radolan Projection",'
         'GEOGCS["Radolan Coordinate System",'
         'DATUM["Radolan_Kugel",'
@@ -115,64 +129,54 @@ Georeferencing-and-Projection`.
         'AUTHORITY["EPSG","8901"]],'
         'UNIT["degree", 0.017453292519943295,'
         'AUTHORITY["EPSG","9122"]]],'
-        'PROJECTION["Polar_Stereographic"],'
-        'PARAMETER["latitude_of_origin", 90],'
-        'PARAMETER["central_meridian", 10],'
-        'PARAMETER["scale_factor", {0:8.12f}],'
-        'PARAMETER["false_easting", 0],'
-        'PARAMETER["false_northing", 0],'
-        'UNIT["kilometre", 1000,'
-        'AUTHORITY["EPSG","9036"]],'
-        'AXIS["Easting",SOUTH],'
-        'AXIS["Northing",SOUTH]]'
     )
 
-    radolan_wkt = (
-        'PROJCS["Radolan projection",'
-        'GEOGCS["Radolan Coordinate System",'
-        'DATUM["Radolan Kugel",'
-        'SPHEROID["Erdkugel", 6370040.0, 0.0]],'
-        'PRIMEM["Greenwich", 0.0, AUTHORITY["EPSG","8901"]],'
-        'UNIT["degree", 0.017453292519943295],'
-        'AXIS["Longitude", EAST],'
-        'AXIS["Latitude", NORTH]],'
-        'PROJECTION["polar_stereographic"],'
-        'PARAMETER["central_meridian", 10.0],'
-        'PARAMETER["latitude_of_origin", 90.0],'
-        'PARAMETER["scale_factor", {0:8.10f}],'
-        'PARAMETER["false_easting", 0.0],'
-        'PARAMETER["false_northing", 0.0],'
-        'UNIT["m*1000.0", 1000.0],'
-        'AXIS["X", EAST],'
-        'AXIS["Y", NORTH]]'
+    radolan_ellps = dict(sphere=sphere_wkt, wgs84=wgs84_wkt)
+    meter = 'UNIT["metre", 1,' 'AUTHORITY["EPSG", "9001"]],'
+    kmeter = 'UNIT["kilometre", 1000,' 'AUTHORITY["EPSG","9036"]],'
+
+    polar_stereo_wkt = (
+        'PROJECTION["Polar_Stereographic"],'
+        'PARAMETER["latitude_of_origin", 60],'
+        'PARAMETER["central_meridian", 10],'
+        'PARAMETER["false_easting", {0:-.16f}],'
+        'PARAMETER["false_northing", {1:-.16f}],'
+        "{2}"
+        'AXIS["Easting", SOUTH],'
+        'AXIS["Northing", SOUTH]]'
     )
 
     proj = osr.SpatialReference()
 
     if projname == "aeqd":
         # Azimuthal Equidistant
-        if Version(gdal.VersionInfo("RELEASE_NAME")) >= Version("3"):
-            aeqd_wkt = aeqd_wkt3
-
+        x_0 = kwargs.get("x_0", 0.0)
+        y_0 = kwargs.get("y_0", 0.0)
         if "x_0" in kwargs:
             proj.ImportFromWkt(
-                aeqd_wkt.format(
-                    kwargs["lat_0"], kwargs["lon_0"], kwargs["x_0"], kwargs["y_0"]
-                )
+                aeqd_wkt.format(kwargs["lat_0"], kwargs["lon_0"], x_0, y_0)
             )
         else:
             proj.ImportFromWkt(
                 aeqd_wkt.format(kwargs["lat_0"], kwargs["lon_0"], 0.0, 0.0)
             )
-
-    elif projname == "dwd-radolan":
-        # DWD-RADOLAN polar stereographic projection
-        scale = (1.0 + np.sin(np.radians(60.0))) / (1.0 + np.sin(np.radians(90.0)))
-        if Version(gdal.VersionInfo("RELEASE_NAME")) >= Version("3"):
-            radolan_wkt = radolan_wkt3.format(scale)
+    elif "dwd-radolan" in projname:
+        projname = projname.split("-")
+        if len(projname) > 2:
+            ellps = projname[2]
+            unit = meter
         else:
-            radolan_wkt = radolan_wkt.format(scale)
-
+            ellps = "sphere"
+            unit = kmeter
+        if len(projname) > 3:
+            grid = projname[3]
+        else:
+            grid = "default"
+        ref = _radolan_ref[ellps][grid]
+        # override false easting/northing
+        x_0 = kwargs.get("x_0", ref["x_0"])
+        y_0 = kwargs.get("y_0", ref["y_0"])
+        radolan_wkt = radolan_ellps[ellps] + polar_stereo_wkt.format(x_0, y_0, unit)
         proj.ImportFromWkt(radolan_wkt)
     else:
         raise ValueError(
@@ -202,9 +206,6 @@ def proj4_to_osr(proj4str):
     proj.ImportFromProj4(proj4str)
     proj.AutoIdentifyEPSG()
 
-    if Version(gdal.VersionInfo("RELEASE_NAME")) < Version("3"):
-        proj.Fixup()
-        proj.FixupOrdering()
     if proj.Validate() == ogr.OGRERR_CORRUPT_DATA:
         raise ValueError(
             "proj4str validates to 'ogr.OGRERR_CORRUPT_DATA'"
@@ -300,18 +301,15 @@ def reproject(*args, **kwargs):
     projection_target = kwargs.get("projection_target", get_default_projection())
     area_of_interest = kwargs.get("area_of_interest", None)
 
-    if Version(gdal.VersionInfo("RELEASE_NAME")) >= Version("3"):
-        axis_order = osr.OAMS_TRADITIONAL_GIS_ORDER
-        projection_source.SetAxisMappingStrategy(axis_order)
-        projection_target.SetAxisMappingStrategy(axis_order)
-        options = osr.CoordinateTransformationOptions()
-        if area_of_interest is not None:
-            options.SetAreaOfInterest(*area_of_interest)
-        ct = osr.CreateCoordinateTransformation(
-            projection_source, projection_target, options
-        )
-    else:
-        ct = osr.CoordinateTransformation(projection_source, projection_target)
+    axis_order = osr.OAMS_TRADITIONAL_GIS_ORDER
+    projection_source.SetAxisMappingStrategy(axis_order)
+    projection_target.SetAxisMappingStrategy(axis_order)
+    options = osr.CoordinateTransformationOptions()
+    if area_of_interest is not None:
+        options.SetAreaOfInterest(*area_of_interest)
+    ct = osr.CreateCoordinateTransformation(
+        projection_source, projection_target, options
+    )
     trans = np.array(ct.TransformPoints(C))
 
     if len(args) == 1:

--- a/wradlib/georef/rect.py
+++ b/wradlib/georef/rect.py
@@ -184,7 +184,7 @@ def get_radolan_coordinates(nrows=None, ncols=None, **kwargs):
         nrows += 1
 
     # get from km to meter for meter-base projections
-    if proj is not None and proj is not "trig":
+    if proj is not None and proj != "trig":
         lin = proj.GetLinearUnits()
         if lin == 1.0:
             res *= 1000

--- a/wradlib/georef/vector.py
+++ b/wradlib/georef/vector.py
@@ -114,9 +114,8 @@ def transform_geometry(geom, dest_srs, **kwargs):
         if gsrs is None:
             geom.AssignSpatialReference(srs)
             gsrs = geom.GetSpatialReference()
-        if gdal.VersionInfo()[0] >= "3":
-            dest_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
-            gsrs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        dest_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        gsrs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
         geom.TransformTo(dest_srs)
 
     return geom

--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -37,7 +37,7 @@ import numpy as np
 import xarray as xr
 
 from wradlib import util, version
-from wradlib.georef import rect, projection
+from wradlib.georef import projection, rect
 from wradlib.io.xarray import WradlibVariable, raise_on_missing_xarray_backend
 
 # current DWD file naming pattern (2008) for example:
@@ -443,7 +443,7 @@ def parse_dwd_composite_header(header):
             if k == "BY":
                 out["datasize"] = int(header[v[0] : v[1]]) - len(header) - 1
             if k == "VS":
-                vs = int(header[v[0]: v[1]])
+                vs = int(header[v[0] : v[1]])
                 out["formatversion"] = vs
                 out["maxrange"] = {
                     0: "100 km and 128 km (mixed)",

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -613,28 +613,36 @@ class TestProjections:
         proj_wgs84 = osr.SpatialReference()
         proj_wgs84.ImportFromEPSG(4326)
         pcoords0 = georef.reproject(
-            coords, projection_source=proj_wgs84, projection_target=proj_utm,
+            coords,
+            projection_source=proj_wgs84,
+            projection_target=proj_utm,
         )
         pcoords1 = georef.reproject(
-            pcoords0, projection_source=proj_utm, projection_target=proj_gk,
+            pcoords0,
+            projection_source=proj_utm,
+            projection_target=proj_gk,
             area_of_interest=(2600000, 5900000, 2650000, 6000000),
         )
         pcoords2 = georef.reproject(
-            pcoords1, projection_source=proj_gk, projection_target=proj_wgs84,
-            area_of_interest=(6.0, 50.0, 10.0, 60.0)
+            pcoords1,
+            projection_source=proj_gk,
+            projection_target=proj_wgs84,
+            area_of_interest=(6.0, 50.0, 10.0, 60.0),
         )
 
         pcoords3 = georef.reproject(
-            pcoords1, projection_source=proj_gk, projection_target=proj_wgs84,
-            area_of_interest=(86.0, -50.0, 90.0, -40.0)
+            pcoords1,
+            projection_source=proj_gk,
+            projection_target=proj_wgs84,
+            area_of_interest=(86.0, -50.0, 90.0, -40.0),
         )
 
         assert pytest.approx(pcoords0[0, 0]) == 365786.7509261378
         assert pytest.approx(pcoords0[0, 1]) == 5874141.630656594
         assert pytest.approx(pcoords1[0, 0]) == 2567176.32987622
         assert pytest.approx(pcoords1[0, 1]) == 5874649.661898718
-        assert pytest.approx(pcoords2[0, 0]) == 7.
-        assert pytest.approx(pcoords2[0, 1]) == 53.
+        assert pytest.approx(pcoords2[0, 0]) == 7.0
+        assert pytest.approx(pcoords2[0, 1]) == 53.0
         assert pytest.approx(pcoords3[0, 0]) == 7.000755561448517
         assert pytest.approx(pcoords3[0, 1]) == 53.0014816583828
 

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -698,6 +698,7 @@ class TestRadolan:
         )
         test_rx = {
             "maxrange": "150 km",
+            "formatversion": 3,
             "radarlocations": [
                 "boo",
                 "ros",
@@ -773,6 +774,7 @@ class TestRadolan:
             "radarid": "10000",
             "datasize": 1620008,
             "maxrange": "128 km",
+            "formatversion": 2,
             "radolanversion": "1.7.2",
             "precision": 0.1,
             "intervalseconds": 3600,
@@ -815,6 +817,7 @@ class TestRadolan:
             "radarid": "10000",
             "datasize": 1620001,
             "maxrange": "150 km",
+            "formatversion": 3,
             "radolanversion": "2.13.1",
             "precision": 0.1,
             "intervalseconds": 21600,
@@ -869,6 +872,7 @@ class TestRadolan:
             "radarid": "10000",
             "datasize": 1980000,
             "maxrange": "150 km",
+            "formatversion": 3,
             "radolanversion": "2.18.3",
             "precision": 0.01,
             "intervalseconds": 300,
@@ -931,6 +935,7 @@ class TestRadolan:
         rw_file = util.get_wradlib_data_file(filename)
         test_attrs = {
             "maxrange": "150 km",
+            "formatversion": 3,
             "radarlocations": [
                 "boo",
                 "ros",
@@ -1070,6 +1075,7 @@ class TestRadolan:
         filename = "radolan/misc/raa01-rw_10000-1408030950-dwd---bin.gz"
         test_attrs = {
             "maxrange": "150 km",
+            "formatversion": 3,
             "radarlocations": [
                 "boo",
                 "ros",

--- a/wradlib/tests/test_io_backends.py
+++ b/wradlib/tests/test_io_backends.py
@@ -458,6 +458,7 @@ def test_radolan_backend(file_or_filelike):
             "mem",
         ],
         "radolanversion": "2.13.1",
+        "formatversion": 3,
         "radarid": "10000",
     }
     with get_wradlib_data_file(filename, file_or_filelike) as rwfile:

--- a/wradlib/tests/test_vpr.py
+++ b/wradlib/tests/test_vpr.py
@@ -165,14 +165,7 @@ class TestCartesianVolume:
         )
         out = gridder(cart_data.data)
         assert out.shape == (6084,)
-        # Todo: find out where this discrepancy comes from
-        from osgeo import gdal
-
-        if gdal.VersionInfo()[0] >= "3":
-            size = 3528
-        else:
-            size = 3512
-        assert len(np.where(np.isnan(out))[0]) == size
+        assert len(np.where(np.isnan(out))[0]) == 3528
 
     @requires_gdal
     def test_PseudoCAPPI(self, cart_data):


### PR DESCRIPTION
DWD has recently updated some of their products to use wgs84 ellipsoid instead of sphere as earth model.

This PR:

- add these capabilities
- fixes RADOLAN xarray coordinates (which have been off by 0.5km)
- removes GDAL < 3 compatibility code
