### PR TITLE
ENH: add "ancillary"-keyword to io.radolan._radolan_file 

### DIFF
--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -1107,7 +1107,7 @@ class TestRadolan:
             assert radfile.dtype == np.uint16
             assert radfile.product == "RW"
             assert radfile.attrs == test_attrs
-            assert radfile.data.shape == (900, 900)
+            assert radfile.data["RW"].shape == (900, 900)
 
     @requires_data
     def test_open_radolan_dataset(self):


### PR DESCRIPTION
This enables "secondary", "cluttermask" and "nodatamask" for xarray datasets in an fully backwards compatible way.