### PR TITLE
Use numpy.linspace in ipol.interpolate_polar

### DIFF
--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -1579,7 +1579,7 @@ def interpolate_polar(data, mask=None, ipclass=Nearest):
     ranges = np.tile(np.arange(0.5, data.shape[1] + 0.5), data.shape[0])
     # construct the angles for every bin
     angles = np.repeat(
-        np.radians(np.linspace(0,360,endpoint=False, num = data.shape[0])), data.shape[1]
+        np.radians(np.linspace(0, 360, endpoint = False, num = data.shape[0])), data.shape[1]
         )
     # calculate cartesian coordinates for every bin
     binx = np.cos(angles) * ranges

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -1579,8 +1579,8 @@ def interpolate_polar(data, mask=None, ipclass=Nearest):
     ranges = np.tile(np.arange(0.5, data.shape[1] + 0.5), data.shape[0])
     # construct the angles for every bin
     angles = np.repeat(
-        np.radians(np.linspace(0, 360, endpoint = False, num = data.shape[0])), data.shape[1]
-        )
+        np.radians(np.linspace(0, 360, endpoint=False, num=data.shape[0])), data.shape[1]
+    )
     # calculate cartesian coordinates for every bin
     binx = np.cos(angles) * ranges
     biny = np.sin(angles) * ranges

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -1578,11 +1578,9 @@ def interpolate_polar(data, mask=None, ipclass=Nearest):
     # construct the ranges for every bin
     ranges = np.tile(np.arange(0.5, data.shape[1] + 0.5), data.shape[0])
     # construct the angles for every bin
-    # angles = np.repeat(
-       # np.radians(np.arange(0, 360, 360.0 / data.shape[0])), data.shape[1]
-    # )
     angles = np.repeat(
-        np.radians(np.linspace(0, 360, data.shape[0])), data.shape[1]
+        
+        np.radians(np.linspace(0,360,endpoint=False, num = data.shape[0])), data.shape[1]
     )
     # calculate cartesian coordinates for every bin
     binx = np.cos(angles) * ranges

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -1579,7 +1579,8 @@ def interpolate_polar(data, mask=None, ipclass=Nearest):
     ranges = np.tile(np.arange(0.5, data.shape[1] + 0.5), data.shape[0])
     # construct the angles for every bin
     angles = np.repeat(
-        np.radians(np.linspace(0, 360, endpoint=False, num=data.shape[0])), data.shape[1]
+        np.radians(np.linspace(0, 360, endpoint=False, num=data.shape[0])),
+        data.shape[1],
     )
     # calculate cartesian coordinates for every bin
     binx = np.cos(angles) * ranges

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -1578,8 +1578,11 @@ def interpolate_polar(data, mask=None, ipclass=Nearest):
     # construct the ranges for every bin
     ranges = np.tile(np.arange(0.5, data.shape[1] + 0.5), data.shape[0])
     # construct the angles for every bin
+    # angles = np.repeat(
+       # np.radians(np.arange(0, 360, 360.0 / data.shape[0])), data.shape[1]
+    # )
     angles = np.repeat(
-        np.radians(np.arange(0, 360, 360.0 / data.shape[0])), data.shape[1]
+        np.radians(np.linspace(0, 360, data.shape[0])), data.shape[1]
     )
     # calculate cartesian coordinates for every bin
     binx = np.cos(angles) * ranges

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -1578,7 +1578,9 @@ def interpolate_polar(data, mask=None, ipclass=Nearest):
     # construct the ranges for every bin
     ranges = np.tile(np.arange(0.5, data.shape[1] + 0.5), data.shape[0])
     # construct the angles for every bin
-    angles = np.repeat(np.radians(np.linspace(0,360,endpoint=False, num = data.shape[0])), data.shape[1])
+    angles = np.repeat(
+        np.radians(np.linspace(0,360,endpoint=False, num = data.shape[0])), data.shape[1]
+        )
     # calculate cartesian coordinates for every bin
     binx = np.cos(angles) * ranges
     biny = np.sin(angles) * ranges

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -1578,10 +1578,7 @@ def interpolate_polar(data, mask=None, ipclass=Nearest):
     # construct the ranges for every bin
     ranges = np.tile(np.arange(0.5, data.shape[1] + 0.5), data.shape[0])
     # construct the angles for every bin
-    angles = np.repeat(
-        
-        np.radians(np.linspace(0,360,endpoint=False, num = data.shape[0])), data.shape[1]
-    )
+    angles = np.repeat(np.radians(np.linspace(0,360,endpoint=False, num = data.shape[0])), data.shape[1])
     # calculate cartesian coordinates for every bin
     binx = np.cos(angles) * ranges
     biny = np.sin(angles) * ranges


### PR DESCRIPTION
changed np.arange(0,360, 360/data.shape[0]) to np.linspace(0,360,data.shape[0]). Because np.arange changes the shape of the array if the number is even. e.g., if the data is having a shape of 644, 2500 (azis, rngs), and doing np.arange(0, 360, 360.0 / 644).shape will give us the shape 645. This throws then error because it doesn't match with original array and therefore interpolation can't be done. 