### PR TITLE
Changes in # read metadata under get_radiosonde()

### DIFF
--- a/wradlib/io/misc.py
+++ b/wradlib/io/misc.py
@@ -194,11 +194,11 @@ def get_radiosonde(wmoid, date, cols=None):
         k, v = row.split(":")
         k = k.strip()
         v = v.strip()
-        if i == 2:
+        if k == 'Station number':
             v = int(v)
-        elif i == 3:
+        elif k == 'Observation time':
             v = dt.datetime.strptime(v, "%y%m%d/%H%M")
-        elif i > 3:
+        elif i > 2:
             v = float(v)
         meta[k] = v
 

--- a/wradlib/io/misc.py
+++ b/wradlib/io/misc.py
@@ -194,9 +194,9 @@ def get_radiosonde(wmoid, date, cols=None):
         k, v = row.split(":")
         k = k.strip()
         v = v.strip()
-        if k == 'Station number':
+        if k == "Station number":
             v = int(v)
-        elif k == 'Observation time':
+        elif k == "Observation time":
             v = dt.datetime.strptime(v, "%y%m%d/%H%M")
         elif i > 2:
             v = float(v)


### PR DESCRIPTION
A bug in the original code in misc.py throws an error when the station being loaded with get_radiosonde() does not have the 'Station identifier' parameter. The problem arises because an iterator of parameters is created and then some transformations are made considering the indexing of the elements of the iterator, under the # read metadata section. When the 'Station identifier' parameter (which is the first element) is missing, the wrong parameter is selected and the error occurs. In this commit, changes in the # read metadata section allow for transforming the set of parameters of metadata referring to the keywords instead of the indexes, in order to avoid the problem of not having the 'Station identifier' parameter.