### PR TITLE
ENH: add PZ-product (DWD station product) to RADOLAN reader

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -11,6 +11,8 @@ You can install the latest {{wradlib}} release from PyPI via ``$ python -m pip i
 
 **New features**
 
+* ENH: add PZ-product (DWD station product) to RADOLAN reader ({pull}`656`) by {at}`kmuehlbauer
+
 **Maintenance - Code**
 
 **Maintenance - CI**
@@ -27,7 +29,6 @@ You can install the latest {{wradlib}} release from PyPI via ``$ python -m pip i
 * FIX: disentangle cg/normal plotting for better maintainability and apply explicit colorbar handling for cg plotting ({pull}`652`) by {at}`kmuehlbauer`
 * FIX: properly implement bearer token authentication adn function calling convention for plot_scan_strategy with terrain=True ({issue}`651`) by {at}`JulianGiles`, ({pull}`652`) by {at}`kmuehlbauer`
 * FIX: align earth radius in plot_scan_strategy for CG plots ({pull}`655`) by {at}`kmuehlbauer`
-
 
 
 ## Version 2.0.0

--- a/wradlib/georef/rect.py
+++ b/wradlib/georef/rect.py
@@ -118,6 +118,7 @@ def get_radolan_coordinates(nrows=None, ncols=None, **kwargs):
         shape is (nrows+1, ) and (ncols+1, ) if `mode='edge'`
     """
     # setup default parameters in dicts
+    station = {"j_0": 200, "i_0": 200, "res": 2}
     tiny = {"j_0": 450, "i_0": 450, "res": 2}
     small = {"j_0": 460, "i_0": 460, "res": 2}
     rx = {"j_0": 450, "i_0": 450, "res": 1}
@@ -126,6 +127,7 @@ def get_radolan_coordinates(nrows=None, ncols=None, **kwargs):
     extended = {"j_0": 600, "i_0": 800, "res": 1}
     de4800 = {"j_0": 470, "i_0": 600, "res": 0.25}
     griddefs = {
+        (200, 200): station,
         (450, 450): tiny,
         (460, 460): small,
         (900, 900): rx,
@@ -156,7 +158,9 @@ def get_radolan_coordinates(nrows=None, ncols=None, **kwargs):
     i_0 = griddefs[(nrows, ncols)]["i_0"]
     res = griddefs[(nrows, ncols)]["res"]
 
-    x_0, y_0 = get_radolan_coords(9.0, 51.0, crs=crs)
+    lon = kwargs.get("lon", 9.0)
+    lat = kwargs.get("lat", 51.0)
+    x_0, y_0 = get_radolan_coords(lon, lat, crs=crs)
 
     if mode == "edge":
         ncols += 1

--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -1162,7 +1162,7 @@ class _radolan_file:
             self.attrs["nodatamask"] = np.where(data == self.attrs["nodataflag"])[0]
         elif self.product in ["PG", "PC", "PZ"]:
             self.attrs["nodataflag"] = 255
-            self.attrs["nodatamask"] = np.where(data == 255)[0]
+            self.attrs["nodatamask"] = data == 255
         elif self.product in ["RX", "EX", "WX"]:
             self.attrs["nodatamask"] = np.where(data == 250)[0]
             self.attrs["cluttermask"] = np.where(data == 249)[0]

--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -905,7 +905,7 @@ def read_radolan_composite(f, *, missing=-9999, loaddata=True, fillmissing=False
         arr = arr * attrs["precision"]
     # set nodata value
     if "nodatamask" in attrs:
-        arr.flat[attrs["nodatamask"]] = NODATA
+        arr.flat[attrs["nodatamask"].flatten()] = NODATA
     return arr, attrs
 
 

--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -507,6 +507,9 @@ def parse_dwd_composite_header(header):
     # get dict of header token with positions
     if out["producttype"] == "PZ":
         kwargs = dict(mode="site")
+        # assume site product with 200 rows/cols
+        out["nrow"] = 200
+        out["ncol"] = 200
     else:
         kwargs = dict(mode="composite")
     head = get_radolan_header_token_pos(header, **kwargs)
@@ -564,11 +567,14 @@ def parse_dwd_composite_header(header):
                 locationstring = header[v[0] :].strip().split("<")[1].split(">")[0]
                 out["radardays"] = locationstring.split(",")
             if k == "CS":
-                out["indicator"] = {
-                    0: "near ground level",
-                    1: "maximum",
-                    2: "tops",
-                }.get(int(header[v[0] : v[1]]))
+                if out["producttype"] == "PZ":
+                    out["statisticfilter"] = header[v[0] : v[1]].strip()
+                else:
+                    out["indicator"] = {
+                        0: "near ground level",
+                        1: "maximum",
+                        2: "tops",
+                    }.get(int(header[v[0] : v[1]]))
             if k == "MX":
                 out["imagecount"] = int(header[v[0] : v[1]])
             if k == "VV":
@@ -583,13 +589,8 @@ def parse_dwd_composite_header(header):
                 out["cluttermap"] = header[v[0] : v[1]].strip()
             if k == "CD":
                 out["dopplerfilter"] = header[v[0] : v[1]].strip()
-            if k == "CS":
-                out["statisticfilter"] = header[v[0] : v[1]].strip()
             if k == "MH":
                 out["maxheight"] = int(header[v[0] : v[1]])
-                # assume site product with 200 rows/cols
-                out["nrow"] = 200
-                out["ncol"] = 200
             if k == "HI":
                 out["hailwarning"] = header[v[0] : v[1]].strip()
             if k == "CI":
@@ -601,7 +602,6 @@ def parse_dwd_composite_header(header):
                 out["severeconvectionheights"] = [int(cl[0:2]), int(cl[2:4])]
             if k == "FL":
                 out["freezing_level"] = header[v[0] : v[1]].strip()
-
     return out
 
 

--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -719,7 +719,8 @@ def decode_radolan_runlength_array(binarr, attrs):
         line = read_radolan_runlength_line(buf)
 
     # reshape early for PZ station product
-    arr = arr.reshape(attrs.get("maxheight"), attrs["nrow"], attrs["ncol"])
+    if mh := attrs.get("maxheight", False):
+        arr = arr.reshape(mh, attrs["nrow"], attrs["ncol"])
     # return upside down because first line read is top line
     return np.flip(arr, axis=-2)
 

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -853,11 +853,39 @@ def test_parse_dwd_composite_header():
         ],
     }
 
+    pz_header = (
+        "PZ220704104101123BY 4923VS 1LV 6  1.0 19.0 28.0 37.0 46.0 55.0"
+        "CO0CD0CS0MH12HI-32.0CI-32.0-32.0CL 0 0FL9999MS  0"
+    )
+
+    test_pz = {
+        "producttype": "PZ",
+        "datetime": datetime.datetime(2023, 11, 22, 7, 4),
+        "radarid": "10410",
+        "nrow": 200,
+        "ncol": 200,
+        "datasize": 4811,
+        "formatversion": 1,
+        "maxrange": "100 km",
+        "message": "",
+        "nlevel": 6,
+        "level": np.array([1.0, 19.0, 28.0, 37.0, 46.0, 55.0]),
+        "statisticfilter": "0",
+        "cluttermap": "0",
+        "dopplerfilter": "0",
+        "maxheight": 12,
+        "hailwarning": "-32.0",
+        "severeconvection": [-32.0, -32.0],
+        "severeconvectionheights": [0, 0],
+        "freezing_level": "9999",
+    }
+
     rx = io.radolan.parse_dwd_composite_header(rx_header)
     pg = io.radolan.parse_dwd_composite_header(pg_header)
     rq = io.radolan.parse_dwd_composite_header(rq_header)
     sq = io.radolan.parse_dwd_composite_header(sq_header)
     yw = io.radolan.parse_dwd_composite_header(yw_header)
+    pz = io.radolan.parse_dwd_composite_header(pz_header)
 
     for key, value in rx.items():
         assert value == test_rx[key]
@@ -874,6 +902,7 @@ def test_parse_dwd_composite_header():
     _check_product(rq, test_rq)
     _check_product(sq, test_sq)
     _check_product(yw, test_yw)
+    _check_product(pz, test_pz)
 
 
 @requires_data


### PR DESCRIPTION
See https://www.dwd.de/EN/ourservices/radar_products/radar_products.html

PZ is available as binary data file which can be decoded using these enhancements. Beware, that BUFR files which are also available can't be decoded.

Also note, that according DWD -> PZ product might be discontinued in the future.