### PR TITLE
util.py: Update crs default value in cross_section_ppi

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -30,6 +30,7 @@ You can install the latest {{wradlib}} release from PyPI via ``$ python -m pip i
 * FIX: disentangle cg/normal plotting for better maintainability and apply explicit colorbar handling for cg plotting ({pull}`652`) by {at}`kmuehlbauer`
 * FIX: properly implement bearer token authentication adn function calling convention for plot_scan_strategy with terrain=True ({issue}`651`) by {at}`JulianGiles`, ({pull}`652`) by {at}`kmuehlbauer`
 * FIX: align earth radius in plot_scan_strategy for CG plots ({pull}`655`) by {at}`kmuehlbauer`
+* FIX: new default value for crs in cross_section_ppi is "None": crs = kwargs.get("crs", "None"). This fixes an issue with the altitude value of the georeferenced object. By {at}`JulianGiles`
 
 
 ## Version 2.0.0

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -1158,7 +1158,7 @@ def cross_section_ppi(
     """
     bw = kwargs.get("bw", None)
     npl = kwargs.get("npl", 1000)
-    crs = kwargs.get("crs")
+    crs = kwargs.get("crs", "None")
     method = kwargs.get("method", None)
     tolerance = kwargs.get("tolerance", None)
 


### PR DESCRIPTION
The new default value for crs in cross_section_ppi is "None": crs = kwargs.get("crs", "None")

This fixes an issue with the altitude value of the georeferenced object.