### PR TITLE
numpy 2.0 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           black --check .
       - name: Lint with ruff
         run: |
-          ruff .
+          ruff check .
 
   build_0:
     name: wradlib unit tests - linux

--- a/ci/requirements/notebooktests.yml
+++ b/ci/requirements/notebooktests.yml
@@ -10,7 +10,7 @@ dependencies:
   - coverage
   - dask
   - deprecation
-  - gdal
+  - gdal=3.8
   - geopandas
   - h5py
   - h5netcdf

--- a/ci/requirements/unittests.yml
+++ b/ci/requirements/unittests.yml
@@ -13,6 +13,7 @@ dependencies:
   - h5py
   - h5netcdf
   - lat_lon_parser
+  - libgdal-hdf5
   - netCDF4
   - numpy
   - matplotlib-base

--- a/ci/requirements/unittests.yml
+++ b/ci/requirements/unittests.yml
@@ -9,11 +9,10 @@ dependencies:
   - coverage
   - dask
   - deprecation
-  - gdal
+  - gdal=3.8
   - h5py
   - h5netcdf
   - lat_lon_parser
-  - libgdal-hdf5
   - netCDF4
   - numpy
   - matplotlib-base

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ exclude = [
     "docs",
 ]
 
+[tool.ruff.lint]
 # E402: module level import not at top of file
 # E501: line too long - let black worry about that
 # E731: do not assign a lambda expression, use a def
@@ -114,9 +115,10 @@ select = [
     "I",
     # Pyupgrade
     "UP",
+    "NPY201",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["wradlib"]
 
 [tool.pytest.ini_options]

--- a/requirements_devel.txt
+++ b/requirements_devel.txt
@@ -8,3 +8,4 @@ pytest-cov
 pytest-doctestplus
 pytest-sugar
 pytest-xdist
+ruff

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,3 +1,4 @@
+bottleneck
 cartopy
 cmweather
 dask

--- a/wradlib/adjust.py
+++ b/wradlib/adjust.py
@@ -663,7 +663,7 @@ class AdjustMFB(AdjustBase):
                 except Exception:
                     # no correction if linear regression fails
                     pass
-        if type(corrfact) == np.ma.core.MaskedConstant:
+        if isinstance(corrfact, np.ma.core.MaskedConstant):
             corrfact = 1.0
         return corrfact * raw
 
@@ -874,14 +874,14 @@ def best(x, y, /):
         1-d array of float with length len(y)
 
     """
-    if type(x) == np.ndarray:
+    if isinstance(x, np.ndarray):
         if x.ndim != 1:
             raise ValueError("`x` must be a 1-d array of floats or a float.")
         if len(x) != len(y):
             raise ValueError(
                 f"Length of `x` ({len(x)}) and `y` ({len(y)}) must be equal."
             )
-    if type(y) == np.ndarray:
+    if isinstance(y, np.ndarray):
         if y.ndim > 2:
             raise ValueError("'y' must be 1-d or 2-d array of floats.")
     else:

--- a/wradlib/classify.py
+++ b/wradlib/classify.py
@@ -340,7 +340,7 @@ def filter_gabella(
     bad = np.isnan(obj)
     if rm_nans:
         obj = obj.copy()
-        obj[bad] = np.Inf
+        obj[bad] = np.inf
     ntr1 = filter_gabella_a(
         obj, wsize=wsize, tr1=tr1, cartesian=cartesian, radial=radial
     )
@@ -709,15 +709,15 @@ def classify_echo_fuzzy(dat, *, weights=None, trpz=None):
         trpz = dict(list(trpz_default.items()) + list(trpz.items()))
 
     # check data conformity
-    if not np.all(np.in1d(dkeys, list(dat.keys()))):
+    if not np.all(np.isin(dkeys, list(dat.keys()))):
         raise ValueError(
             "Argument `dat` must be a dictionary " f"with mandatory keywords {*dkeys,}."
         )
-    if not np.all(np.in1d(wkeys, list(weights.keys()))):
+    if not np.all(np.isin(wkeys, list(weights.keys()))):
         raise ValueError(
             "Argument `weights` must be a dictionary " f"with keywords {*wkeys,}."
         )
-    if not np.all(np.in1d(tkeys, list(trpz.keys()))):
+    if not np.all(np.isin(tkeys, list(trpz.keys()))):
         raise ValueError(
             "Argument `trpz` must be a dictionary " f"with keywords {*tkeys,}."
         )

--- a/wradlib/dp.py
+++ b/wradlib/dp.py
@@ -175,7 +175,7 @@ def phidp_kdp_vulpiani(
     # start the actual phidp/kdp iteration
     for _i in range(niter):
         # phidp from kdp through integration
-        phidp = 2 * integrate.cumtrapz(kdp, dx=dr, initial=0.0, axis=-1)
+        phidp = 2 * integrate.cumulative_trapezoid(kdp, dx=dr, initial=0.0, axis=-1)
         # kdp from phidp by convolution
         kdp = kdp_from_phidp(phidp, dr=dr, winlen=winlen, **kwargs)
 

--- a/wradlib/georef/polar.py
+++ b/wradlib/georef/polar.py
@@ -890,9 +890,9 @@ def maximum_intensity_projection(
     """
     # providing 'reasonable defaults', based on the data's shape
     if r is None:
-        r = np.arange(data.shape[1], dtype=np.float_)
+        r = np.arange(data.shape[1], dtype=np.float64)
     if az is None:
-        az = np.arange(data.shape[0], dtype=np.float_)
+        az = np.arange(data.shape[0], dtype=np.float64)
 
     if angle is None:
         angle = 0.0

--- a/wradlib/georef/vector.py
+++ b/wradlib/georef/vector.py
@@ -479,6 +479,6 @@ def get_centroid(polyg):
         x and y coordinate of the centroid
 
     """
-    if type(polyg) is not ogr.Geometry:
+    if not isinstance(polyg, ogr.Geometry):
         polyg = numpy_to_ogr(polyg, "Polygon")
     return polyg.Centroid().GetPoint()[0:2]

--- a/wradlib/georef/vector.py
+++ b/wradlib/georef/vector.py
@@ -479,6 +479,6 @@ def get_centroid(polyg):
         x and y coordinate of the centroid
 
     """
-    if not type(polyg) == ogr.Geometry:
+    if not isinstance(polyg, ogr.Geometry):
         polyg = numpy_to_ogr(polyg, "Polygon")
     return polyg.Centroid().GetPoint()[0:2]

--- a/wradlib/georef/vector.py
+++ b/wradlib/georef/vector.py
@@ -479,6 +479,6 @@ def get_centroid(polyg):
         x and y coordinate of the centroid
 
     """
-    if not isinstance(polyg, ogr.Geometry):
+    if type(polyg) is not ogr.Geometry:
         polyg = numpy_to_ogr(polyg, "Polygon")
     return polyg.Centroid().GetPoint()[0:2]

--- a/wradlib/georef/xarray.py
+++ b/wradlib/georef/xarray.py
@@ -109,18 +109,18 @@ def create_xarray_dataarray(
 
     if phi is None:
         if sweep_mode == "azimuth_surveillance":
-            phi = np.arange(data.shape[0], dtype=np.float_)
+            phi = np.arange(data.shape[0], dtype=np.float64)
             phi += (phi[1] - phi[0]) / 2.0
         else:
             phi = 0.0
 
     if r is None:
-        r = np.arange(data.shape[1], dtype=np.float_)
+        r = np.arange(data.shape[1], dtype=np.float64)
         r += (r[1] - r[0]) / 2.0
 
     if theta is None:
         if sweep_mode == "rhi":
-            theta = np.arange(data.shape[0], dtype=np.float_)
+            theta = np.arange(data.shape[0], dtype=np.float64)
             theta += (theta[1] - theta[0]) / 2.0
         else:
             theta = 0.0

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -139,7 +139,7 @@ class IpolBase:
         if type(x) in [list, tuple]:
             x = [item.ravel() for item in x]
             x = np.array(x).transpose()
-        elif type(x) == np.ndarray:
+        elif isinstance(x, np.ndarray):
             if x.ndim == 1:
                 x = x.reshape(-1, 1)
             elif x.ndim == 2:
@@ -1569,7 +1569,7 @@ def interpolate_polar(data, *, mask=None, ipclass=Nearest):
     """
     if mask is None:
         # no mask assigned: try to get it from masked array
-        if type(data) != np.ma.core.MaskedArray:
+        if not isinstance(data, np.ma.core.MaskedArray):
             util.warn(
                 "Neither an explicit mask is assigned nor the data-array is masked."
             )

--- a/wradlib/tests/test_dp.py
+++ b/wradlib/tests/test_dp.py
@@ -75,7 +75,7 @@ def test_phidp_kdp_vulpiani(derivation_method, window, copy):
 
     kdp_true0 = np.sin(0.3 * r)
     kdp_true0[kdp_true0 < 0] = 0.0
-    phidp_true0 = 2 * integrate.cumtrapz(kdp_true0, axis=-1, initial=0, dx=dr)
+    phidp_true0 = 2 * integrate.cumulative_trapezoid(kdp_true0, axis=-1, initial=0, dx=dr)
     fillval = phidp_true0[200]
     phidp_true0 = np.concatenate(
         (phidp_true0[:200], np.ones(20) * fillval, phidp_true0[200:])

--- a/wradlib/tests/test_dp.py
+++ b/wradlib/tests/test_dp.py
@@ -54,7 +54,7 @@ def dp_data():
         az = 360
         rng = 1000
         pad = window // 2
-        kdp_true = np.arange(az * rng, dtype=np.float_).reshape(az, rng)
+        kdp_true = np.arange(az * rng, dtype=np.float64).reshape(az, rng)
         phidp_true = np.power(kdp_true, 2)
         dr = 0.1
         kdp_true /= dr

--- a/wradlib/tests/test_dp.py
+++ b/wradlib/tests/test_dp.py
@@ -75,7 +75,9 @@ def test_phidp_kdp_vulpiani(derivation_method, window, copy):
 
     kdp_true0 = np.sin(0.3 * r)
     kdp_true0[kdp_true0 < 0] = 0.0
-    phidp_true0 = 2 * integrate.cumulative_trapezoid(kdp_true0, axis=-1, initial=0, dx=dr)
+    phidp_true0 = 2 * integrate.cumulative_trapezoid(
+        kdp_true0, axis=-1, initial=0, dx=dr
+    )
     fillval = phidp_true0[200]
     phidp_true0 = np.concatenate(
         (phidp_true0[:200], np.ones(20) * fillval, phidp_true0[200:])

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -266,8 +266,8 @@ def test_maximum_intensity_projection():
     filename = util.get_wradlib_data_file("misc/polar_dBZ_tur.gz")
     data = np.loadtxt(filename)
     # we need to have meter here for the georef function inside mip
-    d1 = np.arange(data.shape[1], dtype=np.float_) * 1000
-    d2 = np.arange(data.shape[0], dtype=np.float_)
+    d1 = np.arange(data.shape[1], dtype=np.float64) * 1000
+    d2 = np.arange(data.shape[0], dtype=np.float64)
     data = np.roll(data, (d2 >= angle).nonzero()[0][0], axis=0)
 
     # calculate max intensity projection

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -892,7 +892,7 @@ def test_parse_dwd_composite_header():
 
     def _check_product(data, test):
         for key, value in data.items():
-            if type(value) == np.ndarray:
+            if isinstance(value, np.ndarray):
                 np.testing.assert_allclose(value, test[key])
             else:
                 assert value == test[key]
@@ -945,7 +945,7 @@ def test_read_radolan_composite():
     assert data.shape == (900, 900)
 
     for key, value in attrs.items():
-        if type(value) == np.ndarray:
+        if isinstance(value, np.ndarray):
             assert value.dtype in [np.int32, np.int64]
         else:
             assert value == test_attrs[key]
@@ -957,7 +957,7 @@ def test_read_radolan_composite():
         assert data.shape == (900, 900)
 
     for key, value in attrs.items():
-        if type(value) == np.ndarray:
+        if isinstance(value, np.ndarray):
             assert value.dtype in [np.int32, np.int64]
         else:
             assert value == test_attrs[key]
@@ -966,7 +966,7 @@ def test_read_radolan_composite():
     data, attrs = io.radolan.read_radolan_composite(rw_file, loaddata=False)
     assert data is None
     for key, value in attrs.items():
-        if type(value) == np.ndarray:
+        if isinstance(value, np.ndarray):
             assert value.dtype == np.int64
         else:
             assert value == test_attrs[key]

--- a/wradlib/tests/test_qual.py
+++ b/wradlib/tests/test_qual.py
@@ -13,10 +13,10 @@ from wradlib import qual
 
 def test_get_bb_ratio():
     heights = np.array(
-        [[1100, 1100], [1100, 1100], [1100, 1100], [1100, 1100]], dtype=np.float_
+        [[1100, 1100], [1100, 1100], [1100, 1100], [1100, 1100]], dtype=np.float64
     )
-    widths = np.array([[50, 50], [50, 50], [50, 50], [50, 50]], dtype=np.float_)
-    quality = np.array([[1, 1], [1, 1], [1, 0], [0, 1]], dtype=np.float_)
+    widths = np.array([[50, 50], [50, 50], [50, 50], [50, 50]], dtype=np.float64)
+    quality = np.array([[1, 1], [1, 1], [1, 0], [0, 1]], dtype=np.float64)
     z = np.array(
         [
             [[1075, 1100, 1125, 900], [1000, 1090, 1110, 1300]],
@@ -24,7 +24,7 @@ def test_get_bb_ratio():
             [[1075, 1100, 1125, 900], [1000, 1090, 1110, 1300]],
             [[1075, 1100, 1125, 900], [1000, 1090, 1110, 1300]],
         ],
-        dtype=np.float_,
+        dtype=np.float64,
     )
     ratio_out = np.array(
         [

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -158,9 +158,9 @@ def from_to(tstart, tend, tdelta):
         list of datetime.datetime objects
 
     """
-    if not type(tstart) == dt.datetime:
+    if not isinstance(tstart, dt.datetime):
         tstart = dt.datetime.strptime(tstart, "%Y-%m-%d %H:%M:%S")
-    if not type(tend) == dt.datetime:
+    if not isinstance(tend, dt.datetime):
         tend = dt.datetime.strptime(tend, "%Y-%m-%d %H:%M:%S")
     tdelta = dt.timedelta(seconds=tdelta)
     tsteps = [

--- a/wradlib/zonalstats.py
+++ b/wradlib/zonalstats.py
@@ -340,7 +340,7 @@ class ZonalDataBase:
             raise TypeError("Either `trg` or `idx` kwargs must be given!")
 
         # check for geometry
-        if type(trg) is not ogr.Geometry:
+        if not isinstance(trg, ogr.Geometry):
             trg = georef.vector.numpy_to_ogr(trg, "Polygon")
 
         # apply Buffer value

--- a/wradlib/zonalstats.py
+++ b/wradlib/zonalstats.py
@@ -340,7 +340,7 @@ class ZonalDataBase:
             raise TypeError("Either `trg` or `idx` kwargs must be given!")
 
         # check for geometry
-        if not type(trg) == ogr.Geometry:
+        if not isinstance(trg, ogr.Geometry):
             trg = georef.vector.numpy_to_ogr(trg, "Polygon")
 
         # apply Buffer value

--- a/wradlib/zonalstats.py
+++ b/wradlib/zonalstats.py
@@ -340,7 +340,7 @@ class ZonalDataBase:
             raise TypeError("Either `trg` or `idx` kwargs must be given!")
 
         # check for geometry
-        if not isinstance(trg, ogr.Geometry):
+        if type(trg) is not ogr.Geometry:
             trg = georef.vector.numpy_to_ogr(trg, "Polygon")
 
         # apply Buffer value


### PR DESCRIPTION
I noticed that some parts of wradlib currently do not work with numpy 2.0. I fixed these issues in the code and tried to make the unit tests github actions succeed after that. This unearthed some other issues related to the newest gdal version, so I had to pin the gdal version for the test environments to 3.8.

Now all tests seem to succeed, except for 2 tests in the georeferencing module. The outcome differs more than 3 decimals from the expected output. This probably also has something to do with the new gdal version or maybe the new numpy version, since I changed nothing functionally in the code.