### PR TITLE
FIX manual garbage collector is needed in test with object creation

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -7,6 +7,10 @@ Please note that {{wradlib}} releases follow [semantic versioning](https://semve
 
 You can install the latest {{wradlib}} release from PyPI via ``$ python -m pip install wradlib`` or specific version via ``$ pip install wradlib==x.y.z``. The recommended installation process is described in {doc}`installation`.
 
+## Development version
+
+* FIX: manual garbage collector is needed before each test
+
 ## Version 2.3
 
 This is a pure maintenance release, following the merge of datatree into xarray codebase. This release will pin xradar >= 0.8.0 and xarray >= 2024.10.0 and

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -9,7 +9,7 @@ You can install the latest {{wradlib}} release from PyPI via ``$ python -m pip i
 
 ## Development version
 
-* FIX: manual garbage collector is needed before each test
+* FIX: manual garbage collector is needed before each test ({pull}`684`) by {at}`egouden`
 
 ## Version 2.3
 

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2011-2023, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
+import gc
 import sys
 from dataclasses import dataclass
 
@@ -33,6 +34,12 @@ np.set_printoptions(
     threshold=1000,
     formatter=None,
 )
+
+
+# this ensures objects from previous tests are cleaned
+@pytest.fixture(autouse=True)
+def ensure_gc():
+    gc.collect()
 
 
 @pytest.fixture


### PR DESCRIPTION
Running the tests was not possible on a modest machine with 4GB of RAM running debian 12. It appeared quickly that the memory was growing after each separate test.

After several hours of investigation it seems that it is related to the [caching of fixtures](https://github.com/pytest-dev/pytest/discussions/10387).

This quick fix allows reducing the memory footprint by cleaning manually the most demanding part of the tests.