### PR TITLE
ENH use only one data variable for testing

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -9,6 +9,7 @@ You can install the latest {{wradlib}} release from PyPI via ``$ python -m pip i
 
 ## Development version
 
+* ENH: use only one data variable for testing ({pull}`685`) by {at}`egouden`
 * FIX: manual garbage collector is needed before each test ({pull}`684`) by {at}`egouden`
 
 ## Version 2.3

--- a/wradlib/tests/test_util.py
+++ b/wradlib/tests/test_util.py
@@ -333,14 +333,16 @@ def test_find_bbox_indices(bb_data):
 @requires_data
 def test_cross_section_ppi():
     file = util.get_wradlib_data_file("hdf5/71_20181220_061228.pvol.h5")
+    # only load DBZH for testing
+    keep_vars = ["DBZH", "sweep_mode", "sweep_number", "prt_mode", "follow_mode"]
     # load all sweeps manually and merge them
     sweeps = []
     for sn in np.arange(14):
-        sweeps.append(
-            xr.open_dataset(file, engine="odim", group="sweep_" + str(sn)).set_coords(
-                "sweep_fixed_angle"
-            )
-        )
+        sweep = xr.open_dataset(
+            file, engine="odim", group="sweep_" + str(sn)
+        ).set_coords("sweep_fixed_angle")
+        sweep = sweep[keep_vars]
+        sweeps.append(sweep)
         sweeps[-1].coords["azimuth"] = (
             sweeps[-1].coords["azimuth"].round(1)
         )  # round the azimuths to avoid slight differences


### PR DESCRIPTION
A dataset containing many variables is used in test_cross_session_ppi. This needs more than 1GB of memory.

Using only DBZH significantly reduces the memory footprint of the test.