### PR TITLE
FIX proj data package is needed for geoid heights

### DIFF
--- a/ci/requirements/unittests.yml
+++ b/ci/requirements/unittests.yml
@@ -20,6 +20,7 @@ dependencies:
   - numpy
   - matplotlib-base
   - pip
+  - proj-data
   - pytest
   - pytest-cov
   - pytest-doctestplus

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -3,7 +3,6 @@
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import gc
-import sys
 from dataclasses import dataclass
 
 import numpy as np
@@ -736,7 +735,6 @@ def test_get_earth_projection():
     georef.get_earth_projection("sphere")
 
 
-@pytest.mark.skipif(sys.platform.startswith("win"), reason="known break on windows")
 @requires_gdal
 def test_geoid_to_ellipsoid():
     coords = np.array([[5.0, 50.0, 300.0], [2, 54, 300], [50, 5, 300]])


### PR DESCRIPTION
Coordinate transformation from ellipsoid to geoid heights fails if the needed data are missing. This is the case on the current test configuration in windows.

This is fixed (quickly) by installing the proj-data package explicitly in conda.

Note that GDAL does not raise an error by default and simply returns the same coordinates. This is caught by a unit test which is now working for the windows configuration.