### PR TITLE
MNT: move to pooch base wradlib-data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           python -m pip install . --no-deps
       - name: Install wradlib-data
         run: |
-          python -m pip install git+https://github.com/wradlib/wradlib-data@pooch
+          python -m pip install wradlib-data
           mkdir ./wradlib-data
       - name: Version Info
         run: |
@@ -136,7 +136,7 @@ jobs:
           python -m pip install . --no-deps
       - name: Install wradlib-data
         run: |
-          python -m pip install git+https://github.com/wradlib/wradlib-data@pooch
+          python -m pip install wradlib-data
           mkdir ./wradlib-data
       - name: Version Info
         run: |
@@ -192,7 +192,7 @@ jobs:
           python -m pip install . --no-deps
       - name: Install wradlib-data
         run: |
-          python -m pip install git+https://github.com/wradlib/wradlib-data@pooch
+          python -m pip install wradlib-data
           mkdir ./wradlib-data
       - name: Version Info
         run: |
@@ -248,7 +248,7 @@ jobs:
           python -m pip install . --no-deps
       - name: Install wradlib-data
         run: |
-          python -m pip install git+https://github.com/wradlib/wradlib-data@pooch
+          python -m pip install wradlib-data
           mkdir ./wradlib-data
       - name: Version Info
         run: |
@@ -303,7 +303,7 @@ jobs:
           python -m pip install . --no-deps
       - name: Install wradlib-data
         run: |
-          python -m pip install git+https://github.com/wradlib/wradlib-data@pooch
+          python -m pip install wradlib-data
           mkdir ./wradlib-data
       - name: Clone wradlib-notebooks
         run: |


### PR DESCRIPTION
This moves the installation from github-based wradlib-data to pypi-based wradlib data.
