### PR TITLE
FIX: radians should be used when computing geographic size

### DIFF
--- a/wradlib/georef/projection.py
+++ b/wradlib/georef/projection.py
@@ -671,6 +671,7 @@ def geographic_size(bounds, size):
     ysize = ysize / one_degree_latitude_meters
     lon_min, lon_max, lat_min, lat_max = bounds
     lat_mid = lat_min / 2 + lat_max / 2
+    lat_mid = np.radians(lat_mid)
     one_degree_longitude_meters = one_degree_latitude_meters * np.cos(lat_mid)
     xsize = xsize / one_degree_longitude_meters
     xsize = np.abs(xsize)


### PR DESCRIPTION
For example at any longitude and 68.5 latitude the geographic size should be (0.04, 0.02) and not (0.40, 0.02). 