### PR TITLE
use tolerance for regular size when creating raster

### DIFF
--- a/wradlib/georef/raster.py
+++ b/wradlib/georef/raster.py
@@ -726,9 +726,9 @@ def create_raster_xarray(crs, bounds, size):
 
     xmin = xmin - xmin % xsize
     ymin = ymin - ymin % ysize
-    if xmax % xsize != 0:
+    if xmax % xsize >= 1e-6:
         xmax = xmax - xmax % xsize + xsize
-    if ymax % ysize != 0:
+    if ymax % ysize >= 1e-6:
         ymax = ymax - ymax % ysize + ysize
 
     geotransform = [xmin, xsize, 0, ymax, 0, -ysize]


### PR DESCRIPTION
Due to limited precision, providing a regular size can results in a raster array with an extra row and column.

This fix allows for a tolerance on the regular size precision.