### PR TITLE
Fix argument handling in fuzzy classification wrapper

### DIFF
--- a/wradlib/classify.py
+++ b/wradlib/classify.py
@@ -879,8 +879,7 @@ def _classify_echo_fuzzy_xarray(obj, dat, **kwargs):
 
     def _classify_echo_fuzzy_wrapper(*args, mom=None, **kwargs):
         dat = {name: value for name, value in zip(mom, args)}
-        prob, mask = classify_echo_fuzzy(dat, **kwargs)
-        return prob, mask
+        return classify_echo_fuzzy(dat, **kwargs)
 
     # all moments that are not derived automatically
     mom_all = ("zdr", "rho", "phi", "dop", "map", "dr", "cpa")

--- a/wradlib/classify.py
+++ b/wradlib/classify.py
@@ -877,14 +877,16 @@ def _classify_echo_fuzzy_xarray(obj, dat, **kwargs):
     :func:`~wradlib.dp.depolarization` - depolarization ratio
     """
 
-    def _classify_echo_fuzzy_wrapper(*args, **kwargs):
-        mom = ["rho", "phi", "ref", "dop", "zdr", "map"][: len(args)]
+    def _classify_echo_fuzzy_wrapper(*args, mom=None, **kwargs):
         dat = {name: value for name, value in zip(mom, args)}
         prob, mask = classify_echo_fuzzy(dat, **kwargs)
         return prob, mask
 
-    mom = ["rho", "phi", "ref", "dop", "zdr", "map", "rho2", "dpr", "cpa"]
-    args = [obj[dat[m]] for m in mom if m in dat]
+    # all moments that are not derived automatically
+    mom_all = ("zdr", "rho", "phi", "dop", "map", "dr", "cpa")
+    mom = [m for m in mom_all if m in dat] # available moments
+    args = [obj[dat[m]] for m in mom]
+    kwargs["mom"] = mom
     dim0 = args[0].wrl.util.dim0()
     input_core_dims = [[dim0, "range"]] * len(dat)
     prob, mask = xr.apply_ufunc(

--- a/wradlib/tests/test_classify.py
+++ b/wradlib/tests/test_classify.py
@@ -53,7 +53,6 @@ def test_histo_cut():
 def fuzzy_data():
     rhofile = get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-R.nc")
     phifile = get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-P.nc")
-    reffile = get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-Z.nc")
     dopfile = get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-V.nc")
     zdrfile = get_wradlib_data_file("netcdf/TAG-20120801" "-140046-02-D.nc")
     mapfile = get_wradlib_data_file("hdf5/TAG_cmap_sweeps" "_0204050607.hdf5")
@@ -61,7 +60,6 @@ def fuzzy_data():
     dat = {}
     dat["rho"], attrs_rho = io.read_edge_netcdf(rhofile)
     dat["phi"], attrs_phi = io.read_edge_netcdf(phifile)
-    dat["ref"], attrs_ref = io.read_edge_netcdf(reffile)
     dat["dop"], attrs_dop = io.read_edge_netcdf(dopfile)
     dat["zdr"], attrs_zdr = io.read_edge_netcdf(zdrfile)
     dat["map"] = io.from_hdf5(mapfile)[0][0]


### PR DESCRIPTION
Fix #719

The xarray wrapper for `classify_echo_fuzzy` should now handle correctly any allowed set of moments.

There are no automated tests covering the changes. I tested it with real radar data.

Minor cleanup in related tests.