### PR TITLE
do not track autogenerated version.py or netcdf files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__/
 *.so
 *.log
 *.swp
+*.nc
+version.py
 
 # Root directories
 /.benchmarks/


### PR DESCRIPTION
* Netcdf files might end up in the project folder when running tests
* `version.py` is autogenerated

Add these in `.gitignore`.