### PR TITLE
use pyproj instead of osgeo.osr

### DIFF
--- a/ci/requirements/notebooktests.yml
+++ b/ci/requirements/notebooktests.yml
@@ -30,6 +30,7 @@ dependencies:
   - pip
   - pooch
   - psutil
+  - pyproj
   - pytest
   - pytest-cov
   - pytest-doctestplus

--- a/ci/requirements/readthedocs.yml
+++ b/ci/requirements/readthedocs.yml
@@ -34,6 +34,7 @@ dependencies:
   - pint-xarray
   - pooch
   - psutil
+  - pyproj
   - pytest
   - pytest-cov
   - pytest-doctestplus

--- a/ci/requirements/unittests.yml
+++ b/ci/requirements/unittests.yml
@@ -21,6 +21,7 @@ dependencies:
   - matplotlib-base
   - pip
   - pooch
+  - pyproj
   - pytest
   - pytest-cov
   - pytest-doctestplus

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ deprecation
 matplotlib
 numpy
 packaging
+pyproj
 scipy
 xarray>=2024.10.0
 xradar>=0.8.0

--- a/wradlib/comp.py
+++ b/wradlib/comp.py
@@ -28,9 +28,10 @@ __doc__ = __doc__.format("\n   ".join(__all__))
 from functools import singledispatch
 
 import numpy as np
+import pyproj
 from xarray import DataArray, Dataset, apply_ufunc, broadcast, concat, set_options
 
-from wradlib.georef import get_radar_projection, reproject, wkt_to_osr
+from wradlib.georef import get_radar_projection, reproject
 from wradlib.ipol import RectBin
 from wradlib.util import XarrayMethods, docstring
 
@@ -286,7 +287,7 @@ def transform_binned(sweep, raster):
 
     """
     wkt = raster.spatial_ref.attrs["crs_wkt"]
-    crs = wkt_to_osr(wkt)
+    crs = pyproj.CRS.from_wkt(wkt)
     sweep = sweep.wrl.georef.georeference(crs=crs)
     coord_sweep = np.dstack((sweep.x, sweep.y))
     x, y = np.meshgrid(raster.x, raster.y)
@@ -296,7 +297,7 @@ def transform_binned(sweep, raster):
 
     lon = float(sweep.longitude.values)
     lat = float(sweep.latitude.values)
-    if crs.IsGeographic():
+    if crs.is_geographic:
         alt = float(sweep.altitude.values)
         coord_raster2 = reproject(
             coord_raster, src_crs=crs, trg_crs=get_radar_projection((lon, lat, alt))

--- a/wradlib/io/gdal.py
+++ b/wradlib/io/gdal.py
@@ -229,8 +229,16 @@ class VectorSource:
     data : sequence or str
         sequence of source points (shape Nx2) or polygons (shape NxMx2) or
         Vector File (GDAL/OGR)  filename containing source points/polygons
-    trg_crs : :py:class:`gdal:osgeo.osr.SpatialReference`
-        GDAL OSR SRS describing target CRS the source data should be projected to
+    trg_crs
+        Coordinate Reference System (CRS) of the coordinates. Can be one of:
+
+        - A :py:class:`pyproj:pyproj.CRS` instance
+        - A :py:class:`cartopy:cartopy.crs.CRS` instance
+        - A :py:class:`gdal:osgeo.osr.SpatialReference` instance
+        - A type accepted by :py:meth:`pyproj.CRS.from_user_input` (e.g., EPSG code,
+          PROJ string, dictionary, WKT, or any object with a `to_wkt()` method)
+
+        CRS the source data should be projected to.
 
     Keyword Arguments
     -----------------
@@ -241,8 +249,16 @@ class VectorSource:
     mode : str
         Return type of class access functions/properties.
         Can be either of "numpy", "geo" and "ogr", defaults to "numpy".
-    src_crs : :py:class:`gdal:osgeo.osr.SpatialReference`
-        GDAL OGR SRS describing projection source in which data is provided in.
+    src_crs
+        Coordinate Reference System (CRS) of the coordinates. Can be one of:
+
+        - A :py:class:`pyproj:pyproj.CRS` instance
+        - A :py:class:`cartopy:cartopy.crs.CRS` instance
+        - A :py:class:`gdal:osgeo.osr.SpatialReference` instance
+        - A type accepted by :py:meth:`pyproj.CRS.from_user_input` (e.g., EPSG code,
+          PROJ string, dictionary, WKT, or any object with a `to_wkt()` method)
+
+        CRS in which source data is provided in.
 
     Warning
     -------
@@ -255,11 +271,11 @@ class VectorSource:
     """
 
     def __init__(self, data=None, trg_crs=None, name="layer", source=0, **kwargs):
-        self._trg_crs = trg_crs
+        self._trg_crs = georef.ensure_crs(trg_crs, trg="osr")
         self._name = name
         self._geo = None
         self._mode = kwargs.get("mode", "numpy")
-        self._src_crs = kwargs.get("src_crs", None)
+        self._src_crs = georef.ensure_crs(kwargs.get("src_crs", None), trg="osr")
         if data is not None:
             if isinstance(data, (np.ndarray, list)):
                 self._ds = self._check_src(data)

--- a/wradlib/io/radolan.py
+++ b/wradlib/io/radolan.py
@@ -1263,14 +1263,10 @@ class _radolan_file:
                 "prediction_time", data=pred_time, attrs=time_attrs
             )
 
-        # if GDAL is not installed, fall back to trigonometric calculation
-        if util.has_import(osr):
-            if attrs.get("formatversion", 3) >= 5:
-                crs = projection.create_osr("dwd-radolan-wgs84")
-            else:
-                crs = projection.create_osr("dwd-radolan-sphere")
+        if attrs.get("formatversion", 3) >= 5:
+            crs = projection.create_crs("dwd-radolan-wgs84")
         else:
-            crs = "trig"
+            crs = projection.create_crs("dwd-radolan-sphere")
 
         coords_kwargs = {}
         if self.attrs.get("maxheight", False):

--- a/wradlib/tests/__init__.py
+++ b/wradlib/tests/__init__.py
@@ -70,15 +70,16 @@ def get_wradlib_data_file(file):
     return wradlib_data.DATASETS.fetch(file)
 
 
+cartopy = util.import_optional("cartopy")
 dask = util.import_optional("dask")
-netCDF4 = util.import_optional("netCDF4")
+gdal = util.import_optional("osgeo.gdal")
 h5py = util.import_optional("h5py")
 h5netcdf = util.import_optional("h5netcdf")
-gdal = util.import_optional("osgeo.gdal")
+mpl = util.import_optional("matplotlib")
+netCDF4 = util.import_optional("netCDF4")
 ogr = util.import_optional("osgeo.ogr")
 osr = util.import_optional("osgeo.osr")
-mpl = util.import_optional("matplotlib")
-cartopy = util.import_optional("cartopy")
+pyproj = util.import_optional("pyproj")
 requests = util.import_optional("requests")
 xmltodict = util.import_optional("xmltodict")
 

--- a/wradlib/tests/test_comp.py
+++ b/wradlib/tests/test_comp.py
@@ -13,7 +13,6 @@ from wradlib import comp, georef, io, ipol
 
 from . import (
     get_wradlib_data_file,
-    requires_gdal,
 )
 
 
@@ -38,7 +37,6 @@ def comp_data():
     yield Data
 
 
-@requires_gdal
 def test_extract_circle(comp_data):
     x = comp_data.x
     y = comp_data.y
@@ -49,7 +47,6 @@ def test_extract_circle(comp_data):
     comp.extract_circle(np.array([x.mean(), y.mean()]), 128000.0, grid_xy)
 
 
-@requires_gdal
 def test_togrid(comp_data):
     x = comp_data.x
     y = comp_data.y
@@ -253,7 +250,6 @@ def test_compose():
     np.testing.assert_allclose(composite1, res1)
 
 
-@requires_gdal
 def test_sweep_to_raster():
 
     filename = "hdf5/IDR66_20141206_094829.vol.h5"
@@ -267,7 +263,7 @@ def test_sweep_to_raster():
     lat_min = round(lat) - 2
     lon_max = round(lon) + 2
     lat_max = round(lat) + 2
-    bounds = [lon_min, lon_max, lat_min, lat_max]
+    bounds = (lon_min, lon_max, lat_min, lat_max)
     size = 1000
     raster = georef.create_raster_geographic(bounds, size, size_in_meters=True)
     transform = comp.transform_binned(sweep, raster)

--- a/wradlib/tests/test_io.py
+++ b/wradlib/tests/test_io.py
@@ -13,6 +13,7 @@ import tempfile
 from dataclasses import dataclass
 
 import numpy as np
+import pyproj
 import pytest
 import xarray as xr
 
@@ -1279,10 +1280,7 @@ def test__check_src():
     get_wradlib_data_file("shapefiles/freiberger_mulde/freiberger_mulde.dbf")
     get_wradlib_data_file("shapefiles/freiberger_mulde/freiberger_mulde.shx")
     get_wradlib_data_file("shapefiles/freiberger_mulde/freiberger_mulde.prj")
-    from osgeo import osr
-
-    proj_gk2 = osr.SpatialReference()
-    proj_gk2.ImportFromEPSG(31466)
+    proj_gk2 = pyproj.CRS.from_epsg(31466)
     filename = get_wradlib_data_file("shapefiles/freiberger_mulde/freiberger_mulde.shp")
 
     assert len(io.VectorSource(filename, trg_crs=proj_gk2).data) == 430

--- a/wradlib/tests/test_verify.py
+++ b/wradlib/tests/test_verify.py
@@ -5,9 +5,10 @@
 from dataclasses import dataclass
 
 import numpy as np
+import pyproj
 import pytest
 
-from wradlib import georef, verify
+from wradlib import verify
 
 from . import requires_gdal
 
@@ -19,7 +20,7 @@ def pol_data():
         r = np.arange(1, 100, 10)
         az = np.arange(0, 360, 90)
         site = (9.7839, 48.5861, 0.0)
-        crs = georef.epsg_to_osr(31467)
+        crs = pyproj.CRS.from_epsg(31467)
         # Coordinates of the rain gages in Gauss-Krueger 3 coordinates
         x, y = (np.array([3557880, 3557890]), np.array([5383379, 5383375]))
 
@@ -31,7 +32,6 @@ def pol_data():
     del data
 
 
-@requires_gdal
 def test_PolarNeighbours__init__(pol_data):
     pn = verify.PolarNeighbours(
         pol_data.r,
@@ -45,7 +45,6 @@ def test_PolarNeighbours__init__(pol_data):
     assert isinstance(pn, verify.PolarNeighbours)
 
 
-@requires_gdal
 def test_extract(pol_data):
     pn = verify.PolarNeighbours(
         pol_data.r,
@@ -63,7 +62,6 @@ def test_extract(pol_data):
     np.testing.assert_allclose(neighbours[1], res1)
 
 
-@requires_gdal
 def test_get_bincoords(pol_data):
     pn = verify.PolarNeighbours(
         pol_data.r,

--- a/wradlib/tests/test_vis.py
+++ b/wradlib/tests/test_vis.py
@@ -63,7 +63,7 @@ def prj_data():
         el = np.arange(0, 90)
         th = np.zeros_like(az)
         az1 = np.ones_like(el) * 225
-        crs = georef.create_osr("dwd-radolan")
+        crs = georef.create_crs("dwd-radolan")
         da_ppi = georef.create_xarray_dataarray(img, r=r, phi=az, theta=th)
         da_ppi = georef.georeference(da_ppi, crs=None)
         print(da_ppi)
@@ -93,7 +93,6 @@ def test_plot_ppi(pol_data):
 
 
 @requires_matplotlib
-@requires_gdal
 def test_plot_ppi_proj(prj_data):
     da = prj_data.da_rhi
     vis.plot(da)
@@ -107,7 +106,6 @@ def test_plot_ppi_proj(prj_data):
 
 
 @requires_matplotlib
-@requires_gdal
 def test_plot_ppi_xarray(prj_data):
     assert hasattr(prj_data.da_ppi.wrl, "rays")
     vis.plot(prj_data.da_ppi)
@@ -125,7 +123,6 @@ def test_plot_ppi_xarray(prj_data):
 
 
 @requires_matplotlib
-@requires_gdal
 def test_plot_ppi_xarray_accessor(prj_data):
     assert hasattr(prj_data.da_ppi.wrl, "rays")
     prj_data.da_ppi.wrl.vis.plot()
@@ -143,7 +140,6 @@ def test_plot_ppi_xarray_accessor(prj_data):
 
 
 @requires_matplotlib
-@requires_gdal
 def test_plot_ppi_xarray_proj(prj_data):
     with pytest.raises(TypeError):
         prj_data.da_ppi.wrl.vis.pcolormesh(crs=prj_data.crs)
@@ -151,7 +147,6 @@ def test_plot_ppi_xarray_proj(prj_data):
 
 @requires_matplotlib
 @requires_cartopy
-@requires_gdal
 def test_plot_ppi_cartopy(prj_data):
     if (Version(cartopy.__version__) < Version("0.18.0")) and (
         Version(mpl.__version__) >= Version("3.3.0")
@@ -168,7 +163,6 @@ def test_plot_ppi_cartopy(prj_data):
 
 
 @requires_matplotlib
-@requires_gdal
 def test_plot_rhi_xarray(prj_data):
     assert (
         repr(prj_data.da_rhi.wrl).split("\n", 1)[1]

--- a/wradlib/tests/test_vpr.py
+++ b/wradlib/tests/test_vpr.py
@@ -5,9 +5,10 @@
 from dataclasses import dataclass
 
 import numpy as np
+import pyproj
 import pytest
 
-from wradlib import georef, vpr
+from wradlib import vpr
 
 from . import requires_gdal
 
@@ -17,7 +18,7 @@ def help_data():
     @dataclass(init=False, repr=False, eq=False)
     class Data:
         site = (7.0, 53.0, 100.0)
-        crs = georef.epsg_to_osr(31467)
+        crs = pyproj.CRS.from_epsg(31467)
         az = np.arange(0.0, 360.0, 2.0)
         r = np.arange(0, 50000, 1000)
         el = 2.5
@@ -25,7 +26,6 @@ def help_data():
     yield Data
 
 
-@requires_gdal
 def test_volcoords_from_polar(help_data):
     coords = vpr.volcoords_from_polar(
         help_data.site, help_data.el, help_data.az, help_data.r, crs=help_data.crs
@@ -115,7 +115,7 @@ def cart_data():
     @dataclass(init=False, repr=False, eq=False)
     class Data:
         site = (7.0, 53.0, 100.0)
-        crs = georef.epsg_to_osr(31467)
+        crs = pyproj.CRS.from_epsg(31467)
         az = np.arange(0.0, 360.0, 2.0) + 1.0
         r = np.arange(0.0, 50000.0, 1000.0)
         elev = np.array([1.0, 3.0, 5.0, 10.0])

--- a/wradlib/tests/test_zonalstats.py
+++ b/wradlib/tests/test_zonalstats.py
@@ -673,6 +673,7 @@ def zonal_data():
 @requires_geos
 @requires_gdal
 def test_ZonalData_srs(zonal_data):
+    print(type(zonal_data.zdpoly.crs), type(zonal_data.proj_gk))
     assert zonal_data.zdpoly.crs == zonal_data.proj_gk
     assert zonal_data.zdpoint.crs == zonal_data.proj_gk
 

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -1161,9 +1161,15 @@ def cross_section_ppi(
         If set to a certain beamwidth, it will return the same Dataset with additional
         "fake" empty beams (extra elevations) so that when plotting with matplotlib pcolormesh
         the beamwidths are correctly represented according to their width.
-    crs : :py:class:`gdal:osgeo.osr.SpatialReference`, :py:class:`cartopy.crs.CRS`, optional
-        Projection to use with :py:class:`wradlib.georef.xarray.georeference`.
-        If GDAL OSR SRS, output is in this projection, defaults to AEQD.
+    crs
+        Coordinate Reference System (CRS) of src and trg data. Can be one of:
+
+        - A :py:class:`pyproj:pyproj.CRS` instance
+        - A :py:class:`cartopy:cartopy.crs.CRS` instance
+        - A :py:class:`gdal:osgeo.osr.SpatialReference` instance
+        - A type accepted by :py:meth:`pyproj.CRS.from_user_input` (e.g., EPSG code,
+          PROJ string, dictionary, WKT, or any object with a `to_wkt()` method)
+        Projection to use with :py:class:`wradlib.georef.xarray.georeference`, defaults to AEQD.
     npl : int, optional
         Number of points to make up the line between p1 and p2, in case the user gives two arbitrary points
         instead of an azimuth value. npl should be high enough to accomodate more points along the line that
@@ -1178,7 +1184,7 @@ def cross_section_ppi(
     """
     bw = kwargs.get("bw", None)
     npl = kwargs.get("npl", 1000)
-    crs = kwargs.get("crs", "None")
+    crs = kwargs.get("crs", None)
     method = kwargs.get("method", None)
     tolerance = kwargs.get("tolerance", None)
 

--- a/wradlib/verify.py
+++ b/wradlib/verify.py
@@ -47,10 +47,10 @@ class PolarNeighbours:
     az : :class:`numpy:numpy.ndarray`
         (see :mod:`wradlib.georef` for documentation)
     site : sequence
-        sequence of floats
+        A sequence of floats
         (see :mod:`wradlib.georef` for documentation)
-    crs : :py:class:`gdal:osgeo.osr.SpatialReference`
-        GDAL OSR Spatial Reference Object describing projection
+    crs : :py:class:`pyproj:pyproj.CRS`, :py:class:`cartopy:cartopy.crs.CRS`, :py:class:`gdal:osgeo.osr.SpatialReference`, str or int
+        Any of the given projection objects, anything which can be consumed by pyproj.CRS.from_user_input or None
         (see :mod:`wradlib.georef` for documentation)
     x : :class:`numpy:numpy.ndarray`
         array of x coordinates of the points in map projection

--- a/wradlib/vpr.py
+++ b/wradlib/vpr.py
@@ -411,8 +411,14 @@ def volcoords_from_polar(site, elevs, azimuths, ranges, *, crs=None):
         sequence of azimuth angles
     ranges : sequence
         sequence of ranges
-    crs : :py:class:`gdal:osgeo.osr.SpatialReference`
-        GDAL OSR Spatial Reference Object describing projection
+    crs
+        Coordinate Reference System (CRS). Can be one of:
+
+        - A :py:class:`pyproj:pyproj.CRS` instance
+        - A :py:class:`cartopy:cartopy.crs.CRS` instance
+        - A :py:class:`gdal:osgeo.osr.SpatialReference` instance
+        - A type accepted by :py:meth:`pyproj.CRS.from_user_input` (e.g., EPSG code,
+          PROJ string, dictionary, WKT, or any object with a `to_wkt()` method)
 
     Returns
     -------
@@ -451,8 +457,14 @@ def volcoords_from_polar_irregular(site, elevs, azimuths, ranges, *, crs=None):
         sequence of azimuth angles
     ranges : sequence
         sequence of ranges
-    crs : :py:class:`gdal:osgeo.osr.SpatialReference`
-        GDAL OSR Spatial Reference Object describing projection
+    crs
+        Coordinate Reference System (CRS). Can be one of:
+
+        - A :py:class:`pyproj:pyproj.CRS` instance
+        - A :py:class:`cartopy:cartopy.crs.CRS` instance
+        - A :py:class:`gdal:osgeo.osr.SpatialReference` instance
+        - A type accepted by :py:meth:`pyproj.CRS.from_user_input` (e.g., EPSG code,
+          PROJ string, dictionary, WKT, or any object with a `to_wkt()` method)
 
     Returns
     -------
@@ -525,8 +537,14 @@ def make_3d_grid(site, crs, maxrange, maxalt, horiz_res, vert_res, *, minalt=0.0
     ----------
     site : tuple
         Radar location coordinates in lon, lat
-    crs : :py:class:`gdal:osgeo.osr.SpatialReference`
-        GDAL OSR SRS describing projection
+    crs
+        Coordinate Reference System (CRS). Can be one of:
+
+        - A :py:class:`pyproj:pyproj.CRS` instance
+        - A :py:class:`cartopy:cartopy.crs.CRS` instance
+        - A :py:class:`gdal:osgeo.osr.SpatialReference` instance
+        - A type accepted by :py:meth:`pyproj.CRS.from_user_input` (e.g., EPSG code,
+          PROJ string, dictionary, WKT, or any object with a `to_wkt()` method)
     maxrange : float
         maximum radar range (same unit as CRS defined by ``crs``,
         typically meters)

--- a/wradlib/zonalstats.py
+++ b/wradlib/zonalstats.py
@@ -117,8 +117,15 @@ class ZonalDataBase:
         (same unit as coordinates)
         Points/Polygons  will be considered inside the target if they are
         contained in the buffer.
-    crs : :py:class:`gdal:osgeo.osr.SpatialReference`
-        OGR.SpatialReference will be used for DataSource object.
+    crs
+        Coordinate Reference System (CRS) of src and trg data. Can be one of:
+
+        - A :py:class:`pyproj:pyproj.CRS` instance
+        - A :py:class:`cartopy:cartopy.crs.CRS` instance
+        - A :py:class:`gdal:osgeo.osr.SpatialReference` instance
+        - A type accepted by :py:meth:`pyproj.CRS.from_user_input` (e.g., EPSG code,
+          PROJ string, dictionary, WKT, or any object with a `to_wkt()` method)
+
         src and trg data have to be in the same crs-format
     silent : bool
         If True no ProgressBar is shown. Defaults to False.
@@ -131,6 +138,7 @@ class ZonalDataBase:
 
     def __init__(self, src, *, trg=None, buf=0.0, crs=None, **kwargs):
         self._buffer = buf
+        crs = georef.ensure_crs(crs, trg="osr")
         self._crs = crs
         silent = kwargs.pop("silent", False)
 
@@ -376,8 +384,15 @@ class ZonalDataPoly(ZonalDataBase):
         Polygons will be considered inside the target if they are contained
         in the buffer.
 
-    crs : :py:class:`gdal:osgeo.osr.SpatialReference`
-        OGR.SpatialReference will be used for DataSource object.
+    crs
+        Coordinate Reference System (CRS) of src and trg data. Can be one of:
+
+        - A :py:class:`pyproj:pyproj.CRS` instance
+        - A :py:class:`cartopy:cartopy.crs.CRS` instance
+        - A :py:class:`gdal:osgeo.osr.SpatialReference` instance
+        - A type accepted by :py:meth:`pyproj.CRS.from_user_input` (e.g., EPSG code,
+          PROJ string, dictionary, WKT, or any object with a `to_wkt()` method)
+
         src and trg data have to be in the same crs-format
 
     Examples
@@ -427,8 +442,15 @@ class ZonalDataPoint(ZonalDataBase):
         Points will be considered inside the target if they are contained
         in the buffer.
 
-    crs : :py:class:`gdal:osgeo.osr.SpatialReference`
-        OGR.SpatialReference will be used for DataSource object.
+    crs
+        Coordinate Reference System (CRS) of src and trg data. Can be one of:
+
+        - A :py:class:`pyproj:pyproj.CRS` instance
+        - A :py:class:`cartopy:cartopy.crs.CRS` instance
+        - A :py:class:`gdal:osgeo.osr.SpatialReference` instance
+        - A type accepted by :py:meth:`pyproj.CRS.from_user_input` (e.g., EPSG code,
+          PROJ string, dictionary, WKT, or any object with a `to_wkt()` method)
+
         src and trg data have to be in the same crs-format
 
     Examples
@@ -867,8 +889,14 @@ def get_clip_mask(coords, clippoly, *, crs=None):
     clippoly : :class:`numpy:numpy.ndarray`
         array of xy coords with shape (N,2) representing closed
         polygon coordinates
-    crs : :py:class:`gdal:osgeo.osr.SpatialReference`
-        osr.SpatialReference
+    crs
+        Coordinate Reference System (CRS) of coordinates. Can be one of:
+
+        - A :py:class:`pyproj:pyproj.CRS` instance
+        - A :py:class:`cartopy:cartopy.crs.CRS` instance
+        - A :py:class:`gdal:osgeo.osr.SpatialReference` instance
+        - A type accepted by :py:meth:`pyproj.CRS.from_user_input` (e.g., EPSG code,
+          PROJ string, dictionary, WKT, or any object with a `to_wkt()` method)
 
     Returns
     -------


### PR DESCRIPTION
1. use pyproj for all user facing returns
2. only keep osgeo.osr internally (gdal-based processing)
3. fix docstrings
4. deprecate osr functions
5. make most input functions projection agnostic using `ensure_crs` function
6. add test

cc @egouden Would be nice, if you can have a look here.

This would be a breaking change (1.) and therefore needs major version bump. So I'm thinking to remove the deprecated osr functions (4.) since we do not have a deprecation cycle. 

