### PR TITLE
fix usage of Path and str

### DIFF
--- a/wradlib/tests/test_util.py
+++ b/wradlib/tests/test_util.py
@@ -58,7 +58,7 @@ def test_get_wradlib_data():
     data_path = util._get_wradlib_data_path()
     filename = "dx/raa00-dx_10908-0806021655-fbg---bin.gz"
     util._get_wradlib_data_file(filename)
-    os.environ["WRADLIB_DATA"] = data_path
+    os.environ["WRADLIB_DATA"] = str(data_path)
     assert util._get_wradlib_data_path() == data_path
     util._get_wradlib_data_file(filename)
 

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -36,6 +36,7 @@ import datetime as dt
 import importlib
 import inspect
 import os
+import pathlib
 import warnings
 from functools import singledispatch
 
@@ -599,7 +600,7 @@ def _get_wradlib_data_path():
             wrl_data_path = wradlib_data.DATASETS.abspath
     if not os.path.isdir(wrl_data_path):
         raise OSError(f"`WRADLIB_DATA` path {wrl_data_path!r} does not exist.")
-    return wrl_data_path
+    return pathlib.Path(wrl_data_path)
 
 
 def get_wradlib_data_path():


### PR DESCRIPTION
This is a fix for the following issues:
- assigning Windows Path to `os.environ["WRADLIB_DATA"]` fails
- `util._get_wradlib_data_path()` does not always return a pathlib.Path
