### PR TITLE
ENH: interpolate xarray

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "wradlib"
-copyright = "2011-2025, wradlib developers"
+copyright = "2011-2026, wradlib developers"
 author = "Wradlib Community"
 url = "https://github.com/wradlib"
 
@@ -165,7 +165,7 @@ autodoc_default_options = {
 }
 
 myst_substitutions = {
-    "today": dt.datetime.utcnow().strftime("%Y-%m-%d"),
+    "today": dt.datetime.now(dt.UTC).strftime("%Y-%m-%d"),
     "release": release,
     "wradlib": "$\\omega radlib$",
     "xradar": "[xradar](https://xradar.rtfd.io)",
@@ -188,9 +188,6 @@ exclude_patterns = [
     ".DS_Store",
     "links.rst",
     "**.ipynb_checkpoints",
-    # "examples/notebooks/**/*.md",
-    # "examples/notebooks/*.md",
-    #    "generated/*",
 ]
 
 # -- myst_nb specifics --

--- a/docs/notebooks/interpolation/cartesian_to_polar.md
+++ b/docs/notebooks/interpolation/cartesian_to_polar.md
@@ -1,0 +1,134 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.18.1
+  main_language: python
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+# Interpolate data on cartesian coordinates to polar coordinates
+
+```{code-cell} python
+import numpy as np
+import matplotlib.pyplot as plt
+import wradlib as wrl
+import wradlib_data
+import warnings
+import xarray as xr
+import cmweather
+
+warnings.filterwarnings("ignore")
+try:
+    get_ipython().run_line_magic("matplotlib inline")
+except:
+    plt.ion()
+```
+
+## Read a cartesian data set
+
+```{code-cell} python
+filename = wradlib_data.DATASETS.fetch("geo/bonn_new.tif")
+print(filename)
+```
+
+```{code-cell} python
+dem_bonn = xr.open_dataset(filename, engine="rasterio")
+```
+
+Inspect the data set a little
+
+```{code-cell} python
+display(dem_bonn)
+```
+
+Extract dem_bonn band and coarsen grid. We do this here to prevent memory issues when running this on CI. When applying this to your workflows, just use your normal grid resolution.
+
+```{code-cell} python
+ band = dem_bonn.coarsen(x=10, y=10, boundary="trim").mean()["band_data"].isel(band=0)
+ display(band)
+```
+
+## Read a polar data set
+
+In order to be on the same coordinates, we georeference our radar sweep accordingly.
+
+```{code-cell} python
+fname = wradlib_data.DATASETS.fetch("hdf5/2014-08-10--182000.ppi.mvol")
+swp = xr.open_dataset(fname, engine="gamic", group="sweep_0")
+swp = swp.wrl.georef.georeference(crs=dem_bonn.spatial_ref)
+swp = swp.set_coords("sweep_mode")
+display(swp)
+```
+
+## griddata
+
+For details see {{wradlib}}'s central interpolation API entrypoint {meth}`wradlib.ipol.IpolMethods.interpolate`.
+This is slow for large input arrays. Please check with {func}`scipy.interpolate.griddata` for kwarg distribution.
+
+```{code-cell} python
+band_xy = band.chunk()
+swp = swp.isel(range=slice(0, 100))
+band_polar_nearest = band_xy.wrl.ipol.interpolate(swp, method="griddata_nearest")
+band_polar_linear = band_xy.wrl.ipol.interpolate(swp, method="griddata_linear")
+band_polar_cubic = band_xy.wrl.ipol.interpolate(swp, method="griddata_cubic")
+```
+
+```{code-cell} python
+fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, figsize=(12, 10))
+cmap = "terrain"
+vmin, vmax = 0.0, 250.0
+
+band_crop = band_xy.wrl.util.crop(swp)
+pm = band_crop.plot(ax=ax1, cmap=cmap, vmin=vmin, vmax=vmax)
+ax1.set_aspect(band_crop.wrl.util.aspect())
+ax1.set_title("Original DEM")
+
+pm = band_polar_nearest.wrl.vis.plot(ax=ax2, cmap=cmap, vmin=vmin, vmax=vmax)
+ax2.set_title("Nearest")
+pm = band_polar_linear.wrl.vis.plot(ax=ax3, cmap=cmap, vmin=vmin, vmax=vmax)
+ax3.set_title("Linear")
+pm = band_polar_cubic.wrl.vis.plot(ax=ax4, cmap=cmap, vmin=vmin, vmax=vmax)
+ax4.set_title("Cubic")
+
+plt.tight_layout()
+```
+
+## map_coordinates
+
+For details see {{wradlib}}'s central interpolation API entrypoint {meth}`wradlib.ipol.IpolMethods.interpolate`.
+Please check with {func}`scipy.ndimage.map_coordinates` for kwarg distribution.
+
+```{code-cell} python
+band_xy = band.chunk()
+swp = swp.isel(range=slice(0,100))
+band_polar_nearest = band_xy.wrl.ipol.interpolate(swp, method="map_coordinates", order=0)
+band_polar_linear = band_xy.wrl.ipol.interpolate(swp, method="map_coordinates", order=1)
+band_polar_quadratic = band_xy.wrl.ipol.interpolate(swp, method="map_coordinates", order=2)
+band_polar_cubic = band_xy.wrl.ipol.interpolate(swp, method="map_coordinates", order=3)
+band_polar_quartic = band_xy.wrl.ipol.interpolate(swp, method="map_coordinates", order=4)
+band_polar_quintic = band_xy.wrl.ipol.interpolate(swp, method="map_coordinates", order=5)
+```
+
+```{code-cell} python
+fig, ((ax1, ax2), (ax3, ax4), (ax5, ax6)) = plt.subplots(3, 2, figsize=(12, 15))
+
+pm = band_polar_nearest.wrl.vis.plot(ax=ax1, cmap=cmap, vmin=vmin, vmax=vmax)
+ax1.set_title("Nearest")
+pm = band_polar_linear.wrl.vis.plot(ax=ax2, cmap=cmap, vmin=vmin, vmax=vmax)
+ax2.set_title("Linear")
+pm = band_polar_quadratic.wrl.vis.plot(ax=ax3, cmap=cmap, vmin=vmin, vmax=vmax)
+ax3.set_title("Quadratic")
+pm = band_polar_cubic.wrl.vis.plot(ax=ax4, cmap=cmap, vmin=vmin, vmax=vmax)
+ax4.set_title("Cubic")
+pm = band_polar_quartic.wrl.vis.plot(ax=ax5, cmap=cmap, vmin=vmin, vmax=vmax)
+ax5.set_title("Quartic")
+pm = band_polar_quintic.wrl.vis.plot(ax=ax6, cmap=cmap, vmin=vmin, vmax=vmax)
+ax6.set_title("Quintic")
+
+plt.tight_layout()
+```

--- a/docs/notebooks/interpolation/interpolation.md
+++ b/docs/notebooks/interpolation/interpolation.md
@@ -1,0 +1,25 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.18.1
+  main_language: python
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+# Interpolation with wradlib
+
+This section provides a collection of example code snippets to make users familiar with $\omega radlib$'s interpolation capabilities.
+
+From version 2.7.0 {{wradlib}} has unified the interpolation API facilitating the single API entrypoint {meth}`wradlib.ipol.IpolMethods.interpolate`.
+
+```{toctree}
+:hidden:
+:maxdepth: 2
+Polar to Cartesian <polar_to_cartesian>
+Cartesian to Polar <cartesian_to_polar>
+```

--- a/docs/notebooks/interpolation/polar_to_cartesian.md
+++ b/docs/notebooks/interpolation/polar_to_cartesian.md
@@ -1,0 +1,151 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.18.1
+  main_language: python
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+# Interpolate data from polar to cartesian coordinates
+
+The {{wradlib}} {mod}`wradlib.ipol` module implements several interpolator schemes, many of them based on {class}`scipy:scipy.spatial.cKDTree` class. In this notebook its shown how they are applied to {class}`xarray:xarray.Dataset` or {class}`xarray:xarray.DataArray`.
+
+```{code-cell} python
+import numpy as np
+import matplotlib.pyplot as plt
+import wradlib as wrl
+import wradlib_data
+import warnings
+import xarray as xr
+import cmweather
+
+warnings.filterwarnings("ignore")
+```
+
+## Import polar and cartesian data
+
+```{code-cell} python
+filename1 = wradlib_data.DATASETS.fetch("geo/bonn_new.tif")
+dem_bonn = xr.open_dataset(filename1, engine="rasterio")
+
+filename2 = wradlib_data.DATASETS.fetch("hdf5/2014-08-10--182000.ppi.mvol")
+swp = xr.open_dataset(filename2, engine="gamic", group="sweep_0")
+```
+## Preprocess polar data
+
+In order to be on the same coordinates, we georeference the radar sweep coordinates accordingly.
+
+```{code-cell} python
+swp = swp.wrl.georef.georeference(crs=dem_bonn.spatial_ref)
+swp = swp.set_coords("sweep_mode")
+swp = swp.isel(range=slice(0, 100))
+display(swp)
+```
+## Preprocess cartesian data
+
+First, inspect the data set a little.
+
+```{code-cell} python
+display(dem_bonn)
+```
+
+Extract dem_bonn band and crop grid.
+
+```{code-cell} python
+band = (
+    dem_bonn
+    .wrl.util.crop(swp, pad=0)
+    .isel(band=0)["band_data"]
+)
+display(band)
+```
+
+## Nearest neighbour interpolation
+
+For details see {{wradlib}}'s central interpolation API entrypoint {meth}`wradlib.ipol.IpolMethods.interpolate`.
+Please check with {class}`scipy:scipy.spatial.cKDTree` for kwargs for tree initialization and {meth}`scipy:scipy.spatial.cKDTree.query` for kwargs for querying the tree.
+
+```{code-cell} python
+band_xy = band.chunk()
+nearest = swp.wrl.ipol.interpolate(band_xy, method="nearest")
+display(nearest)
+```
+
+```{code-cell} python
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
+cmap = "HomeyerRainbow"
+vmin, vmax = 0.0, 60.0
+
+pm = swp.DBZH.wrl.vis.plot(ax=ax1, cmap=cmap, vmin=vmin, vmax=vmax)
+ax1.set_title("Original PPI")
+
+pm = nearest.DBZH.plot(ax=ax2, cmap=cmap, vmin=vmin, vmax=vmax)
+ax2.set_aspect(nearest.wrl.util.aspect())
+ax2.set_title("Nearest")
+plt.tight_layout()
+```
+
+## Inverse distance
+
+For details see {{wradlib}}'s central interpolation API entrypoint {meth}`wradlib.ipol.IpolMethods.interpolate`.
+Please check with {class}`scipy:scipy.spatial.cKDTree` for kwargs for tree initialization and {meth}`scipy:scipy.spatial.cKDTree.query` for kwargs for querying the tree.
+
+```{code-cell} python
+band_xy = band.chunk()
+inverse_distance = swp.wrl.ipol.interpolate(band_xy, method="inverse_distance", k=4, idw_p=2)
+display(inverse_distance)
+```
+
+```{code-cell} python
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
+cmap = "HomeyerRainbow"
+vmin, vmax = 0.0, 60.0
+
+pm = swp.DBZH.wrl.vis.plot(ax=ax1, cmap=cmap, vmin=vmin, vmax=vmax)
+ax1.set_title("Original PPI")
+
+pm = inverse_distance.DBZH.plot(ax=ax2, cmap=cmap, vmin=vmin, vmax=vmax)
+ax2.set_aspect(inverse_distance.wrl.util.aspect())
+ax2.set_title("Inverse Distance")
+
+plt.tight_layout()
+```
+
+## Precompute KDTree dataset
+
+In the above examples the KDTree is computed and queried within the function. If your geometry is fixed you can precompute the KDTree and use it in subsequent computations.
+Please check with {class}`scipy:scipy.spatial.cKDTree` for kwargs for tree initialization and {meth}`scipy:scipy.spatial.cKDTree.query` for kwargs for querying the tree.
+
+
+```{code-cell} python
+band_xy = band.chunk()
+mapping = swp.wrl.ipol.get_mapping(band_xy, k=4)
+display(mapping)
+```
+
+```{code-cell} python
+band_xy = band.chunk()
+nearest = swp.wrl.ipol.interpolate(mapping, method="nearest")
+inverse_distance = swp.wrl.ipol.interpolate(mapping, method="inverse_distance", idw_p=2)
+```
+
+```{code-cell} python
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
+cmap = "HomeyerRainbow"
+vmin, vmax = 0.0, 60.0
+
+pm = nearest.DBZH.plot(ax=ax1, cmap=cmap, vmin=vmin, vmax=vmax)
+ax1.set_aspect(nearest.wrl.util.aspect())
+ax1.set_title("Nearest")
+
+pm = inverse_distance.DBZH.plot(ax=ax2, cmap=cmap, vmin=vmin, vmax=vmax)
+ax2.set_aspect(inverse_distance.wrl.util.aspect())
+ax2.set_title("Inverse Distance")
+
+plt.tight_layout()
+```

--- a/docs/notebooks/overview.md
+++ b/docs/notebooks/overview.md
@@ -18,6 +18,8 @@ This section provides a collection of example code snippets to make users famili
 ```{toctree}
 :hidden:
 :maxdepth: 3
+
 Visualization <visualisation/plotting>
+Interpolation <interpolation/interpolation>
 Composition <composition/max_reflectivity>
 ```

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -9,6 +9,10 @@ You can install the latest {{wradlib}} release from PyPI via ``$ python -m pip i
 
 ## Development Version (unreleased)
 
+**New features**
+
+* add xarray based {meth}`wradlib.ipol.IpolMethods.interpolate` API entrypoint ({pull}`742`) by {at}`kmuehlbauer`
+
 **Maintenance**
 
 * update pre-commit and lint ({pull}`741`) by {at}`kmuehlbauer`

--- a/wradlib/georef/projection.py
+++ b/wradlib/georef/projection.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
-# Copyright (c) 2011-2025, wradlib developers.
+# Copyright (c) 2011-2026, wradlib developers.
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 """
@@ -78,6 +78,7 @@ def ensure_crs(crs, trg="pyproj"):
         Coordinate Reference System (CRS) of the coordinates. Must be given and
         can be one of:
 
+        - A :py:class:`xarray:xarray.DataArray` instance containing spatial reference
         - A :py:class:`pyproj:pyproj.crs.CoordinateSystem` instance
         - A :py:class:`cartopy:cartopy.crs.CRS` instance
         - A :py:class:`gdal:osgeo.osr.SpatialReference` instance
@@ -97,7 +98,9 @@ def ensure_crs(crs, trg="pyproj"):
     # first move everything into pyproj.CRS/WKT or return early
     if crs is None:
         return crs
-    if isinstance(crs, pyproj.CRS) and type(crs) is pyproj.CRS:
+    if hasattr(crs, "attrs"):
+        return pyproj.CRS.from_cf(crs.attrs)
+    elif isinstance(crs, pyproj.CRS) and type(crs) is pyproj.CRS:
         if trg == "pyproj":
             return crs
     elif has_import(cartopy) and isinstance(crs, cartopy.crs.CRS):

--- a/wradlib/tests/conftest.py
+++ b/wradlib/tests/conftest.py
@@ -3,6 +3,11 @@
 # Distributed under the MIT License. See LICENSE.txt for more info.
 
 import pytest
+import xarray as xr
+
+from wradlib import georef, io, util
+
+wradlib_data = util.import_optional("wradlib_data", dep="devel")
 
 
 @pytest.fixture(params=["file", "filelike"])
@@ -14,3 +19,30 @@ def file_or_filelike(request):
 def mock_wradlib_data_env(monkeypatch, tmpdir):
     wradlib_path = tmpdir.mkdir("wradlib-data")
     monkeypatch.setenv("WRADLIB_DATA", wradlib_path)
+
+
+@pytest.fixture(scope="session")
+def dx_swp():
+    fname = wradlib_data.DATASETS.fetch("dx/raa00-dx_10908-0806021655-fbg---bin.gz")
+    data, attrs = io.read_dx(fname)
+    return georef.create_xarray_dataarray(data)
+
+
+@pytest.fixture(scope="session")
+def dwd_swp():
+    fname = wradlib_data.DATASETS.fetch("dx/raa00-dx_10908-0806021655-fbg---bin.gz")
+    data, attrs = io.read_dx(fname)
+    return georef.create_xarray_dataarray(data)
+
+
+@pytest.fixture(scope="session")
+def gamic_swp():
+    fname = wradlib_data.DATASETS.fetch("hdf5/2014-08-10--182000.ppi.mvol")
+    swp = xr.open_dataset(fname, engine="gamic", group="sweep_0")
+    return swp
+
+
+@pytest.fixture(scope="session")
+def dem_bonn():
+    fname = wradlib_data.DATASETS.fetch("geo/bonn_new.tif")
+    return xr.open_dataset(fname, engine="rasterio")

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -18,6 +18,7 @@ attributable to the other modules
 """
 
 __all__ = [
+    "aspect",
     "from_to",
     "filter_window_polar",
     "filter_window_cartesian",
@@ -1484,6 +1485,41 @@ def crop(src, trg, pad=0):
     return src.sel(x=slice_vals(src.x, trg.x, pad), y=slice_vals(src.y, trg.y, pad))
 
 
+def aspect(obj):
+    """
+    Compute an aspect ratio that equalizes physical axis lengths.
+
+    The returned value can be passed to plotting functions (e.g. xarray or
+    matplotlib) to scale the x and y axes such that one unit in x has the
+    same physical length as one unit in y, independent of the array shape
+    or data resolution.
+
+    Parameters
+    ----------
+    obj : xarray.DataArray or xarray.Dataset
+        Object with ``x`` and ``y`` coordinates defining the spatial extent.
+
+    Returns
+    -------
+    float
+        Aspect ratio defined as ``(x_max - x_min) / (y_max - y_min)``.
+
+    Notes
+    -----
+    This function uses coordinate ranges rather than array dimensions.
+    It is therefore suitable for plots where the axes should reflect
+    physical distances (e.g., meters, degrees) rather than pixel counts.
+
+    Examples
+    --------
+    >>> ax = plt.gca() #doctest: +SKIP
+    >>> da.plot(ax=ax, aspect=aspect(da)) #doctest: +SKIP
+    """
+    return (float(obj.x.max()) - float(obj.x.min())) / (
+        float(obj.y.max()) - float(obj.y.min())
+    )
+
+
 class XarrayMethods:
     """BaseClass to bind xarray methods to wradlib SubAccessor
 
@@ -1565,6 +1601,13 @@ class UtilMethods(XarrayMethods):
             return crop(self, *args, **kwargs)
         else:
             return crop(self._obj, *args, **kwargs)
+
+    @docstring(aspect)
+    def aspect(self, *args, **kwargs):
+        if not isinstance(self, UtilMethods):
+            return aspect(self, *args, **kwargs)
+        else:
+            return aspect(self._obj, *args, **kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds xarray-based `interpolate` API to wradlib.ipol module plus some examples.

The idea is to have a single interpolate entrypoint where you can do:

```python
# accessor-based
nearest = swp.wrl.ipol.interpolate(band_xy, method="nearest")
# normal API
nearest = wrl.ipol.interpolate(swp, band_xy, method="nearest")
```
