### PR TITLE
FIX: srtm download location

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -16,6 +16,7 @@ You can install the latest {{wradlib}} release from PyPI via ``$ python -m pip i
 **Bugfixes**
 
 * align with xradar/xarray datatree coordinate inheritance, update dependency pinnings ({pull}`762`) by {at}`kmuehlbauer`
+* correct earthdata srtm download endpoint, use data.lpdaac.earthdatacloud.nasa.gov ({pull}`763`) by {at}`kmuehlbauer`
 
 ## Version 2.8.0
 

--- a/wradlib/io/dem.py
+++ b/wradlib/io/dem.py
@@ -83,13 +83,13 @@ def download_srtm(filename, destination, *, resolution=3, session=None):
         session object to use
     """
 
-    website = "https://e4ftl01.cr.usgs.gov/MEASURES"
+    website = "https://data.lpdaac.earthdatacloud.nasa.gov/lp-prod-protected"
     subres = 3
     if resolution == 30:
         subres = 2
     resolution = f"SRTMGL{resolution}.00{subres}"
-    source = "/".join([website, resolution, "2000.02.11"])
-    url = "/".join([source, filename])
+    source = "/".join([website, resolution])
+    url = "/".join([source, filename[:-4], filename])
 
     if session is None:
         session = init_header_redirect_session()


### PR DESCRIPTION
Set's new location of SRTM Download endpoint: `data.lpdaac.earthdatacloud.nasa.gov`

Tested locally with EARTHDATA bearer token.