### PR TITLE
FIX: specify compat option in xarray.merge

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -15,6 +15,7 @@ You can install the latest {{wradlib}} release from PyPI via ``$ python -m pip i
 
 **Bugfixes**
 
+* specify compat option in xarray.merge ({pull}`767`) by {at}`egouden`
 * align with xradar/xarray datatree coordinate inheritance, update dependency pinnings ({pull}`762`) by {at}`kmuehlbauer`
 * correct earthdata srtm download endpoint, use data.lpdaac.earthdatacloud.nasa.gov ({pull}`763`) by {at}`kmuehlbauer`
 

--- a/wradlib/classify.py
+++ b/wradlib/classify.py
@@ -1104,7 +1104,7 @@ def _filter_window_distance_xarray(obj, **kwargs):
         dask_gufunc_kwargs=dict(allow_rechunk=True),
     )
     if isinstance(obj, xr.Dataset):
-        out = xr.merge([out, keep])
+        out = xr.merge([out, keep], compat="no_conflicts")
     else:
         out.name = "filter_window_distance"
 
@@ -1414,7 +1414,7 @@ def create_gpm_observations(ds):
     tind = ds.airTemperature - 273.15
     tind.name = "TEMP"
 
-    ds2 = xr.merge([zkum, dfrm, rt, tind])
+    ds2 = xr.merge([zkum, dfrm, rt, tind], compat="no_conflicts")
 
     # combine into one variable
     obs = ["ZKUM", "DFRM", "RT", "TEMP"]

--- a/wradlib/comp.py
+++ b/wradlib/comp.py
@@ -184,7 +184,7 @@ def _togrid_xarray(obj, trg, *args, **kwargs):
     )
     out = out.unstack("npoints_cart")
     if isinstance(obj, xr.Dataset):
-        out = xr.merge([out, keep])
+        out = xr.merge([out, keep], compat="no_conflicts")
     else:
         out.attrs = obj.attrs
         out.name = f"{obj.name}.togrid"

--- a/wradlib/ipol.py
+++ b/wradlib/ipol.py
@@ -409,7 +409,7 @@ def _interpolate_mapping(src, trg, **kwargs):
 
     # restore attributes and merge with kept variables if Dataset
     if isinstance(src, xr.Dataset):
-        out = xr.merge([out, keep])
+        out = xr.merge([out, keep], compat="no_conflicts")
     else:
         out.attrs = src.attrs
         out.name = src.name

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -1734,7 +1734,7 @@ def _texture_xarray(obj):
         out.attrs = attrs
         out.name = obj.name + "_TEXTURE"
     else:
-        out = xr.merge([out, keep])
+        out = xr.merge([out, keep], compat="no_conflicts")
     return out
 
 


### PR DESCRIPTION
All merge functions have been adapted to avoid warnings. This was silent in the tests.