### PR TITLE
Add ZPHI-Method and companions

### DIFF
--- a/docs/notebooks/attenuation/attenuation.md
+++ b/docs/notebooks/attenuation/attenuation.md
@@ -21,4 +21,5 @@ This section provides a collection of example code snippets to make users famili
 :maxdepth: 2
 
 pia
+zphi
 ```

--- a/docs/notebooks/attenuation/zphi.md
+++ b/docs/notebooks/attenuation/zphi.md
@@ -1,0 +1,101 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.18.1
+  main_language: python
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+# Specific Attenuation via ZPHI method
+
+Weather radar reflectivity measurements are affected by propagation effects, most importantly attenuation due to hydrometeors along the radar beam. In X-band and C-band radar applications, this can lead to significant underestimation of reflectivity at long range and in heavy precipitation.
+
+The ZPHI method provides a physically constrained approach to estimate specific attenuation from the joint evolution of reflectivity ({math}`Z_H`) and differential phase shift ({math}`\Phi_{DP}`). It exploits the fact that {math}`\Phi_{DP}` is a path-integrated quantity that is not directly affected by attenuation and can therefore be used as a robust constraint.
+
+In this notebook, we demonstrate a complete ZPHI processing chain including:
+
+- estimation of total differential phase shift ({math}`\Delta \Phi_{DP}`)
+- reconstruction of {math}`\Phi_{DP}^{cal}` from {math}`K_{DP}` (when needed)
+- retrieval of specific attenuation ({math}`A_H` / {math}`A_V`)
+
+The workflow follows established formulations from {cite}`Testud2000`, {cite}`Ryzhkov2014`, and {cite}`Diederich2015`.
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+import wradlib as wrl
+import wradlib_data
+import warnings
+import xarray as xr
+import cmweather
+
+warnings.filterwarnings("ignore")
+try:
+    get_ipython().run_line_magic("matplotlib inline")
+except:
+    plt.ion()
+```
+
+## Read BoXPol data
+
+```{code-cell} ipython3
+fname = wradlib_data.DATASETS.fetch("hdf5/2014-08-10--182000.ppi.mvol")
+with xr.open_dataset(fname, engine="gamic", group="sweep_0") as swp:
+    swp = swp.set_coords("sweep_mode").wrl.georef.georeference()
+    mask = swp.RHOHV > 0.9
+    phidp = swp.PHIDP.where(mask)
+    dbz = swp.DBZH.where(mask)
+```
+
+## Overview Plot
+
+```{code-cell} ipython3
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(16, 8))
+dbz.wrl.vis.plot(vmin=0, vmax=60, ax=ax1)
+phidp.wrl.vis.plot(vmin=-100, vmax=20, ax=ax2)
+plt.title("Raw Reflectivity (dBZ)")
+```
+
+## Calculate specific attenuation AH
+
+```{code-cell} ipython3
+alpha = 0.28
+ah = wrl.atten.specific_attenuation_zphi(phidp, dbz, alpha=alpha, b=0.78, rng=2000.)
+```
+
+## Plot specific attenuation AH
+
+```{code-cell} ipython3
+ah.wrl.vis.plot(vmax=2)
+```
+
+## Derive {math}`K_{DP}`
+
+```{code-cell} ipython3
+kdp_ah = ah.fillna(0) / alpha
+kdp_ah.attrs = swp.KDP.attrs
+```
+
+```{code-cell} ipython3
+kdp_ah.wrl.vis.plot(vmax=2)
+```
+
+## Recalculate {math}`\Phi_{DP}^{cal}`
+
+```{code-cell} ipython3
+phical = kdp_ah.wrl.dp.phidp_from_kdp()
+phical = phical.rename("PHIDP_AH")
+phical.attrs = swp.PHIDP.attrs
+display(phical)
+```
+
+## Plot {math}`\PHI_{DP}^{cal}`
+
+```{code-cell} ipython3
+phical.wrl.vis.plot()
+```

--- a/docs/notebooks/attenuation/zphi.md
+++ b/docs/notebooks/attenuation/zphi.md
@@ -19,7 +19,7 @@ The ZPHI method provides a physically constrained approach to estimate specific 
 
 In this notebook, we demonstrate a complete ZPHI processing chain including:
 
-- estimation of total differential phase shift ({math}`\Delta \Phi_{DP}`)
+- estimation of total differential phase shift ({math}`\Delta \Phi_{DP}^{tot}`)
 - reconstruction of {math}`\Phi_{DP}^{cal}` from {math}`K_{DP}` (when needed)
 - retrieval of specific attenuation ({math}`A_H` / {math}`A_V`)
 
@@ -82,7 +82,7 @@ kdp_ah.attrs = swp.KDP.attrs
 ```
 
 ```{code-cell} ipython3
-kdp_ah.wrl.vis.plot(vmax=2)
+kdp_ah.wrl.vis.plot(vmax=5)
 ```
 
 ## Recalculate {math}`\Phi_{DP}^{cal}`
@@ -94,7 +94,7 @@ phical.attrs = swp.PHIDP.attrs
 display(phical)
 ```
 
-## Plot {math}`\PHI_{DP}^{cal}`
+## Plot {math}`\Phi_{DP}^{cal}`
 
 ```{code-cell} ipython3
 phical.wrl.vis.plot()

--- a/docs/notebooks/attenuation/zphi.md
+++ b/docs/notebooks/attenuation/zphi.md
@@ -11,6 +11,7 @@ kernelspec:
   name: python3
 ---
 
+(zphi_main_header)=
 # Specific Attenuation via ZPHI method
 
 Weather radar reflectivity measurements are affected by propagation effects, most importantly attenuation due to hydrometeors along the radar beam. In X-band and C-band radar applications, this can lead to significant underestimation of reflectivity at long range and in heavy precipitation.
@@ -62,6 +63,10 @@ plt.title("Raw Reflectivity (dBZ)")
 ```
 
 ## Calculate specific attenuation AH
+
+```{seealso}
+{func}`wradlib.atten.specific_attenuation_zphi`
+```
 
 ```{code-cell} ipython3
 alpha = 0.28

--- a/docs/notebooks/dualpol/delta_phidp.md
+++ b/docs/notebooks/dualpol/delta_phidp.md
@@ -81,7 +81,7 @@ Before computing {math}`\Delta \Phi_{DP}`, a physically meaningful segment of th
 
 - invalid or missing observations are masked
 - a sliding window is used to estimate local data density
-- the “densest” contiguous region of valid Φ_{DP} is selected
+- the “densest” contiguous region of valid {math}`\Phi_{DP}` is selected
 
 This ensures that {math}`\Delta \Phi_{DP}^{tot}` is computed only where phase information is reliable.
 
@@ -98,6 +98,10 @@ dbzmask = swp.DBZH.where(mask)
 ## Estimate ray-based location and values of start and stop window
 
 We choose 2000m window for estimation of start and stop values.
+
+```{seealso}
+{func}`wradlib.dp.delta_phidp`
+```
 
 ```{code-cell} ipython3
 dphi = phimask.wrl.dp.delta_phidp(rng=2000.)

--- a/docs/notebooks/dualpol/delta_phidp.md
+++ b/docs/notebooks/dualpol/delta_phidp.md
@@ -22,23 +22,23 @@ from IPython.display import display
 warnings.filterwarnings("ignore")
 ```
 
-The total differential phase shift, denoted as {math}`\Delta Phi_{DP}^{tot}`, is a path-integrated radar variable that represents the accumulated change in differential phase ({math}`\Phi_{DP}`) along a radar ray between two range locations.
+The total differential phase shift, denoted as {math}`\Delta \Phi_{DP}^{tot}`, is a path-integrated radar variable that represents the accumulated change in differential phase ({math}`\Phi_{DP}`) along a radar ray between two range locations.
 
 Unlike reflectivity,{math}`\Phi_{DP}` is a propagation phase quantity that increases monotonically with range in precipitation and is largely unaffected by attenuation and calibration biases. This makes it a robust constraint for attenuation and rainfall microphysics retrievals.
 
-In the ZPHI framework, {math}`\Delta Phi_{DP}^{tot}` serves as the key normalization quantity linking local reflectivity structure to integrated propagation effects.
+In the ZPHI framework, {math}`\Delta \Phi_{DP}^{tot}` serves as the key normalization quantity linking local reflectivity structure to integrated propagation effects.
 
-{math}`\Delta Phi_{DP}` represents the net phase shift induced by hydrometeors along a selected radar path segment:
+{math}`\Delta \Phi_{DP}` represents the net phase shift induced by hydrometeors along a selected radar path segment:
 
 $\begin{equation}
-f\Delta\Phi_{DP} = \Phi_{DP}(r_2) - \Phi_{DP}(r_1)
+\Delta\Phi_{DP} = \Phi_{DP}(r_2) - \Phi_{DP}(r_1)
 \tag{1}
 \end{equation}$
 
 where:
 
 - {math}`r_1` - start of the selected valid radar interval
-- {math}`r_1` - end of the selected valid radar interval
+- {math}`r_2` - end of the selected valid radar interval
 
 This interval is not fixed a priori, but is determined dynamically based on data quality and spatial continuity.
 
@@ -77,13 +77,13 @@ swp.PHIDP.wrl.vis.plot(vmin=-100, vmax=50)
 
 This algorithm is described in detail in {cite}`Testud2000`, {cite}`Ryzhkov2014`, and {cite}`Diederich2015`.
 
-Before computing {math}`\Delta Phi_{DP}`, a physically meaningful segment of the radar ray is identified:
+Before computing {math}`\Delta \Phi_{DP}`, a physically meaningful segment of the radar ray is identified:
 
 - invalid or missing observations are masked
 - a sliding window is used to estimate local data density
 - the “densest” contiguous region of valid Φ_{DP} is selected
 
-This ensures that {math}`\Delta Phi_{DP}^{tot}` is computed only where phase information is reliable.
+This ensures that {math}`\Delta \Phi_{DP}^{tot}` is computed only where phase information is reliable.
 
 ## Mask source data
 

--- a/docs/notebooks/dualpol/delta_phidp.md
+++ b/docs/notebooks/dualpol/delta_phidp.md
@@ -1,0 +1,165 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.18.1
+  main_language: python
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+(delta_phidp_main_header)=
+# Total Differential Phase Shift {math}`\Delta \Phi_{DP}`
+
+```{code-cell} ipython3
+import warnings
+
+from IPython.display import display
+
+warnings.filterwarnings("ignore")
+```
+
+The total differential phase shift, denoted as {math}`\Delta Phi_{DP}^{tot}`, is a path-integrated radar variable that represents the accumulated change in differential phase ({math}`\Phi_{DP}`) along a radar ray between two range locations.
+
+Unlike reflectivity,{math}`\Phi_{DP}` is a propagation phase quantity that increases monotonically with range in precipitation and is largely unaffected by attenuation and calibration biases. This makes it a robust constraint for attenuation and rainfall microphysics retrievals.
+
+In the ZPHI framework, {math}`\Delta Phi_{DP}^{tot}` serves as the key normalization quantity linking local reflectivity structure to integrated propagation effects.
+
+{math}`\Delta Phi_{DP}` represents the net phase shift induced by hydrometeors along a selected radar path segment:
+
+$\begin{equation}
+f\Delta\Phi_{DP} = \Phi_{DP}(r_2) - \Phi_{DP}(r_1)
+\tag{1}
+\end{equation}$
+
+where:
+
+- {math}`r_1` - start of the selected valid radar interval
+- {math}`r_1` - end of the selected valid radar interval
+
+This interval is not fixed a priori, but is determined dynamically based on data quality and spatial continuity.
+
+# Import Section
+
+```{code-cell} ipython3
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+import wradlib as wrl
+import wradlib_data
+import open_radar_data
+```
+
+# Open Dataset
+
+We use a dataset from BoXPol, Germany.
+
+```{code-cell} ipython3
+fname = wradlib_data.DATASETS.fetch("hdf5/2014-08-10--182000.ppi.mvol")
+with xr.open_dataset(fname, engine="gamic", group="sweep_0") as swp:
+    swp = swp.set_coords("sweep_mode").wrl.georef.georeference()
+```
+
+# Inspect Dataset
+
+```{code-cell} ipython3
+display(swp)
+```
+
+```{code-cell} ipython3
+swp.PHIDP.wrl.vis.plot(vmin=-100, vmax=50)
+```
+
+# Total Differential Phase Shift {math}`\Delta \Phi_{DP}^{tot}`
+
+This algorithm is described in detail in {cite}`Testud2000`, {cite}`Ryzhkov2014`, and {cite}`Diederich2015`.
+
+Before computing {math}`\Delta Phi_{DP}`, a physically meaningful segment of the radar ray is identified:
+
+- invalid or missing observations are masked
+- a sliding window is used to estimate local data density
+- the “densest” contiguous region of valid Φ_{DP} is selected
+
+This ensures that {math}`\Delta Phi_{DP}^{tot}` is computed only where phase information is reliable.
+
+## Mask source data
+
+Essential pre-step masking unwanted signal.
+
+```{code-cell} ipython3
+mask = swp.RHOHV >= 0.9
+phimask = swp.PHIDP.where(mask)
+dbzmask = swp.DBZH.where(mask)
+```
+
+## Estimate ray-based location and values of start and stop window
+
+We choose 2000m window for estimation of start and stop values.
+
+```{code-cell} ipython3
+dphi = phimask.wrl.dp.delta_phidp(rng=2000.)
+```
+
+### Overview in Cartesian Domain
+
+```{code-cell} ipython3
+fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(16, 8))
+dphi.first.plot(label="first", ax=ax1)
+dphi.last.plot(label="last", ax=ax1)
+ax1.grid()
+ax1.legend()
+dphi.dphi.plot(ls="-", marker=".", label="delta", ax=ax2)
+ax2.grid()
+ax2.legend()
+plt.tight_layout()
+```
+
+### Overview in Polar Domain
+
+```{code-cell} ipython3
+fig = plt.figure(figsize=(20, 14))
+ax1 = plt.subplot(231, projection="polar")
+ax2 = plt.subplot(232, projection="polar")
+ax3 = plt.subplot(233, projection="polar")
+# set the lable go clockwise and start from the top
+ax1.set_theta_zero_location("N")
+ax2.set_theta_zero_location("N")
+ax3.set_theta_zero_location("N")
+# clockwise
+ax1.set_theta_direction(-1)
+ax2.set_theta_direction(-1)
+ax3.set_theta_direction(-1)
+
+theta = np.linspace(0, 2 * np.pi, num=360, endpoint=False)
+ax1.plot(theta, dphi.first_idx, color="b", linewidth=3)
+_ = ax1.set_title(r"$\Delta \Phi_{DP}$ - First Index")
+ax2.plot(theta, dphi.last_idx, color="r", linewidth=3)
+_ = ax2.set_title(r"$\Delta \Phi_{DP}$ - Last Index")
+ax3.plot(theta, dphi.dphi, color="g", linewidth=3)
+_ = ax3.set_title(r"$\Delta \Phi_{DP}^{tot}$")
+```
+
+## Overview of first and last segments
+
+```{code-cell} ipython3
+fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 10), sharex=True)
+dphi.start_range.plot(ax=ax1, lw=0.8, c="k")
+(dphi.start_range + dphi.center_span).plot(ax=ax1, lw=0.8, c="r", ls=":")
+dphi.stop_range.plot(ax=ax1, lw=0.8, c="k")
+(dphi.stop_range - dphi.center_span).plot(ax=ax1, lw=0.8, c="r", ls=":")
+phimask.plot(ax=ax1, x="azimuth", y="range", cmap="turbo", vmin=-100, vmax=50)
+ax1.set_title(r"$\Phi_{DP}$ - start/stop")
+
+phimask2 = phimask.where(((phimask.range >= dphi.start_range) & (phimask.range <= dphi.start_range + dphi.center_span)) |
+                         ((phimask.range >= dphi.stop_range - dphi.center_span) & (phimask.range <= dphi.stop_range)))
+phimask2.plot(ax=ax2, x="azimuth", y="range", cmap="turbo", vmin=-100, vmax=50)
+dphi.start_range.plot(ax=ax2, lw=0.8, c="k", ls=":")
+(dphi.start_range + dphi.center_span).plot(ax=ax2, lw=0.8, c="k", ls=":")
+dphi.stop_range.plot(ax=ax2, lw=0.8, c="k", ls=":")
+(dphi.stop_range - dphi.center_span).plot(ax=ax2, lw=0.8, c="k", ls=":")
+ax2.set_title(r"$\Phi_{DP}$ - start/stop - masked")
+fig.tight_layout()
+```

--- a/docs/notebooks/dualpol/dualpol.md
+++ b/docs/notebooks/dualpol/dualpol.md
@@ -20,5 +20,6 @@ This section provides a collection of example code snippets to process polarimet
 :maxdepth: 2
 Differential Phase <phidp>
 System Differential Phase <system_phidp>
+Total Differential Phase Shift <delta_phidp>
 Depolarization <depolarization>
 ```

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -476,3 +476,58 @@ issn    = {1976-7951},
   year         = {2021},
   note         = {Latest revision varies; use current ITU-R publication year in formal work}
 }
+
+@article{Testud2000,
+  author = "Jacques  Testud and Erwan  Le Bouar and Estelle  Obligis and Mustapha  Ali-Mehenni",
+  title = "The Rain Profiling Algorithm Applied to Polarimetric Weather Radar",
+  journal = "Journal of Atmospheric and Oceanic Technology",
+  year = "2000",
+  publisher = "American Meteorological Society",
+  address = "Boston MA, USA",
+  volume = "17",
+  number = "3",
+  doi = "10.1175/1520-0426(2000)017<0332:TRPAAT>2.0.CO;2",
+  pages=      "332 - 356",
+  url = "https://journals.ametsoc.org/view/journals/atot/17/3/1520-0426_2000_017_0332_trpaat_2_0_co_2.xml"
+}
+
+@article{Ryzhkov2014,
+  author = "Alexander  Ryzhkov and Malte  Diederich and Pengfei  Zhang and Clemens  Simmer",
+  title = "Potential Utilization of Specific Attenuation for Rainfall Estimation, Mitigation of Partial Beam Blockage, and Radar Networking",
+  journal = "Journal of Atmospheric and Oceanic Technology",
+  year = "2014",
+  publisher = "American Meteorological Society",
+  address = "Boston MA, USA",
+  volume = "31",
+  number = "3",
+  doi = "10.1175/JTECH-D-13-00038.1",
+  pages = "599 - 619",
+  url = "https://journals.ametsoc.org/view/journals/atot/31/3/jtech-d-13-00038_1.xml"
+}
+
+@article{Diederich2015,
+ ISSN = {1525755X, 15257541},
+ URL = {http://www.jstor.org/stable/24914953},
+ author = {Malte Diederich and Alexander Ryzhkov and Clemens Simmer and Pengfei Zhang and Silke Trömel},
+ journal = {Journal of Hydrometeorology},
+ number = {2},
+ pages = {487--502},
+ publisher = {American Meteorological Society},
+ title = {Use of Specific Attenuation for Rainfall Measurement at X-Band Radar Wavelengths.: Part I: Radar Calibration and Partial Beam Blockage Estimation},
+ volume = {16},
+ year = {2015}
+}
+
+@article{Bringi1990,
+  author = "V. N.  Bringi and V.  Chandrasekar and N.  Balakrishnan and D. S.  Zrnić",
+  title = "An Examination of Propagation Effects in Rainfall on Radar Measurements at Microwave Frequencies",
+  journal = "Journal of Atmospheric and Oceanic Technology",
+  year = "1990",
+  publisher = "American Meteorological Society",
+  address = "Boston MA, USA",
+  volume = "7",
+  number = "6",
+  doi = "10.1175/1520-0426(1990)007<0829:AEOPEI>2.0.CO;2",
+  pages = "829 - 840",
+  url = "https://journals.ametsoc.org/view/journals/atot/7/6/1520-0426_1990_007_0829_aeopei_2_0_co_2.xml"
+}

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -14,6 +14,7 @@ You can install the latest {{wradlib}} release from PyPI via ``$ python -m pip i
 * parameterise thresholds in unfold_phi and improve implementation ({pull}`770`) by {at}`enchilaDaSzen`
 * add algorithms to estimate system differential phase ({pull}`775`) by {at}`kmuehlbauer`
 * add algorithms to estimate SNR and correct RHOHV for noise ({pull}`776`) by {at}`kmuehlbauer`
+* add ZPHI-Method related algorithms, tests and example notebooks ({pull}`777`) by {at}`kmuehlbauer`
 
 **Bugfixes**
 

--- a/wradlib/atten.py
+++ b/wradlib/atten.py
@@ -794,7 +794,7 @@ def specific_attenuation_zphi(phidp, dbz, alpha, b, rng=2000.0):
 
     Notes
     -----
-    - Uses `delta_phidp` to estimate total differential phase shift.
+    - Uses :func:`~wradlib.dp.delta_phidp` to estimate total differential phase shift.
     - Negative phase shifts are clamped to a small positive value for stability.
     - Reflectivity is converted from dBZ to linear units before integration.
     - Assumes identical range coordinate system for `phidp` and `dbz`.

--- a/wradlib/atten.py
+++ b/wradlib/atten.py
@@ -22,6 +22,7 @@ __all__ = [
     "correct_attenuation_constrained",
     "correct_radome_attenuation_empirical",
     "pia_from_kdp",
+    "specific_attenuation_zphi",
     "AttenMethods",
 ]
 __doc__ = __doc__.format("\n   ".join(__all__))
@@ -31,10 +32,10 @@ from functools import singledispatch
 
 import numpy as np
 from scipy import interpolate, ndimage
-from xarray import DataArray, apply_ufunc
+from xarray import DataArray, apply_ufunc, broadcast
 
-from wradlib import trafo, zr
-from wradlib.util import XarrayMethods, docstring
+from wradlib import dp, trafo, zr
+from wradlib.util import XarrayMethods, cumtrapz_xarray, docstring
 
 logger = logging.getLogger("attcorr")
 
@@ -749,6 +750,95 @@ def _pia_from_kdp_xarray(obj, **kwargs):
     out.name = "PIA"
 
 
+def _get_specific_attenuation_attrs(pol="h"):
+    return dict(
+        units="dB/km",
+        standard_name=f"specific_attenuation_{pol.lower()}",
+        long_name=f"Specific attenuation {pol.upper()}",
+        short_name=f"A{pol.upper()}",
+    )
+
+
+def specific_attenuation_zphi(phidp, dbz, alpha, b, rng=2000.0):
+    r"""
+    Estimate specific attenuation (:math:`A_H` or :math:`A_V`) using the ZPHI method.
+
+    This implementation follows the ZPHI approach (:cite:`Testud2000`,
+    :cite:`Ryzhkov2014`, :cite:`Diederich2015`), where the total differential phase
+    shift (:math:`\Delta \Phi_{DP}`) is first estimated from a representative range
+    interval, and then used to constrain the attenuation–reflectivity relationship.
+
+    Parameters
+    ----------
+    phidp : xarray.DataArray
+        Differential phase field with a ``range`` dimension.
+    dbz : xarray.DataArray
+        Reflectivity field in decibels (dBZ), same ``range`` dimension as ``phidp``.
+    alpha : float or array-like
+        ZPHI coefficient(s) controlling the relationship between phase shift and attenuation.
+    b : float
+        Exponent in the ZPHI power-law formulation.
+    rng : float, optional
+        Physical range (m) used for estimating total differential phase shift.
+        Default is 2000 m.
+
+    Returns
+    -------
+    xarray.DataArray
+        Specific attenuation field with metadata attributes:
+
+        - units: dB/km
+        - standard_name: specific_attenuation_h or v
+        - long_name: human-readable description
+        - short_name: AH or AV
+
+    Notes
+    -----
+    - Uses `delta_phidp` to estimate total differential phase shift.
+    - Negative phase shifts are clamped to a small positive value for stability.
+    - Reflectivity is converted from dBZ to linear units before integration.
+    - Assumes identical range coordinate system for `phidp` and `dbz`.
+    """
+
+    # retrieve delta phidp
+    delta_phidp = dp.delta_phidp(phidp, rng=rng)
+    dphi = delta_phidp.dphi.where(delta_phidp.dphi >= 0, 1e-4)
+
+    # handle alpha
+    alpha = np.asarray(alpha)
+    if alpha.ndim == 0:
+        alpha = DataArray(alpha)
+    else:
+        alpha = DataArray(alpha, dims="alpha", coords={"alpha": alpha})
+    alpha, dphi = broadcast(alpha, dphi)
+
+    # need to expand alpha to dphi-shape
+    fdphi = 10 ** (0.1 * b * alpha * dphi) - 1
+
+    # select start and stop range according delta_phidp output
+    zhraw = dbz.where(
+        (dbz.range >= delta_phidp.start_range) & (dbz.range <= delta_phidp.stop_range)
+    )
+    zax = zhraw.wrl.trafo.idecibel().fillna(1e-4)
+    za = zax**b
+    # set masked to zero for integration
+    za_zero = za.fillna(0)
+
+    # integrate
+    iza_x = 0.46 * b * za_zero.pipe(cumtrapz_xarray)
+    iza = iza_x.max("range") - iza_x
+    iza_fdphi = iza / fdphi
+
+    # integral from r1 to r2
+    iza_first = iza_fdphi.sel(range=delta_phidp.start_range)
+
+    ah = za / (iza_first + iza)
+    pol = "V" if "V" in dbz.name.upper() else "H"
+    ah.attrs = _get_specific_attenuation_attrs(pol=pol)
+
+    return ah
+
+
 class AttenMethods(XarrayMethods):
     """wradlib xarray SubAccessor methods for Atten Methods."""
 
@@ -779,6 +869,13 @@ class AttenMethods(XarrayMethods):
             return pia_from_kdp(self, *args, **kwargs)
         else:
             return pia_from_kdp(self._obj, *args, **kwargs)
+
+    @docstring(specific_attenuation_zphi)
+    def specific_attenuation_zphi(self, *args, **kwargs):
+        if not isinstance(self, AttenMethods):
+            return specific_attenuation_zphi(self, *args, **kwargs)
+        else:
+            return specific_attenuation_zphi(self._obj, *args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/wradlib/atten.py
+++ b/wradlib/atten.py
@@ -798,6 +798,10 @@ def specific_attenuation_zphi(phidp, dbz, alpha, b, rng=2000.0):
     - Negative phase shifts are clamped to a small positive value for stability.
     - Reflectivity is converted from dBZ to linear units before integration.
     - Assumes identical range coordinate system for `phidp` and `dbz`.
+
+    Examples
+    --------
+    See :ref:`Core Features - Attenuation - Specific Attenuation via ZPHI method <zphi_main_header>`.
     """
 
     # retrieve delta phidp

--- a/wradlib/dp.py
+++ b/wradlib/dp.py
@@ -48,6 +48,7 @@ _AUTOSUMMARY = r"""
 """
 
 __all__ = [
+    "delta_phidp",
     "depolarization",
     "kdp_from_phidp",
     "phidp_kdp_vulpiani",
@@ -933,7 +934,8 @@ def _get_range_step(obj):
 
 
 def _get_bins_from_range(obj, rng):
-    return int(rng / _get_range_step(obj))
+    dr = _get_range_step(obj)
+    return max(1, int(np.ceil(rng / dr)))
 
 
 def _aggregate_sysphi(phi, n_lowest_rays):
@@ -985,24 +987,26 @@ def system_phidp_block(phidp, rng, n_lowest_rays=30):
     See :ref:`Core Features - Dual-Pol - System Differential Phase <system_phidp_main_header>`.
     """
 
+    rstep = _get_range_step(phidp)
+
     # binary mask of valid PHIDP bins
     phib = phidp.notnull().astype(np.int8)
 
     # required number of consecutive bins
     N = phidp.pipe(_get_bins_from_range, rng)
+    center_span = (N - 1) * rstep
 
     # count valid bins in rolling window
-    phib_sum = phib.rolling(range=N, center=True).sum(skipna=True)
+    phib_sum = phib.rolling(range=N, center=False).sum(skipna=True)
 
     # maximum number of valid bins per ray
     smax = phib_sum.max(dim="range", skipna=True)
+    # only windows that are fully valid
+    valid_mask = smax == N
 
     # derive selected range interval
-    rstep = _get_range_step(phib_sum)
-    center_range = phib_sum.idxmax(dim="range").where(smax == N)
-
-    start_range = center_range - (N // 2) * rstep
-    stop_range = start_range + N * rstep
+    stop_range = phib_sum.where(valid_mask).idxmax(dim="range")
+    start_range = stop_range - center_span
 
     start_range.name = "start_range"
     stop_range.name = "stop_range"
@@ -1078,26 +1082,25 @@ def system_phidp_window(phidp, rng, n_lowest_rays=30):
     --------
     See :ref:`Core Features - Dual-Pol - System Differential Phase <system_phidp_main_header>`.
     """
+    rstep = _get_range_step(phidp)
 
     # binary mask of valid PHIDP bins
     phib = phidp.notnull().astype(np.int8)
 
     # window length in bins
     N = phidp.pipe(_get_bins_from_range, rng)
+    center_span = (N - 1) * rstep
 
     # count valid bins in rolling window
-    phib_sum = phib.rolling(range=N, center=True).sum(skipna=True)
+    phib_sum = phib.rolling(range=N, center=False).sum(skipna=True)
 
     # maximum valid-bin count per ray
     valid_bins = phib_sum.max(dim="range", skipna=True)
     valid_bins.name = "valid_bins"
 
     # derive selected interval
-    rstep = _get_range_step(phib_sum)
-    center_range = phib_sum.idxmax(dim="range")
-
-    start_range = center_range - (N // 2) * rstep
-    stop_range = start_range + N * rstep
+    stop_range = phib_sum.idxmax(dim="range")
+    start_range = stop_range - center_span
 
     start_range.name = "start_range"
     stop_range.name = "stop_range"
@@ -1287,8 +1290,137 @@ def system_phidp_hist(
     )
 
 
+def delta_phidp(phidp, rng, **kwargs):
+    r"""
+    Estimate :math:`\Phi_{DP}` statistics from the first and last densest range windows.
+
+    This function analyzes an xarray DataArray `phidp` defined along a coordinate
+    named ``range`` and identifies:
+
+    - the first range window spanning at least ``rng`` that contains the
+      maximum number of valid (non-NaN) observations, and
+    - the last such window when scanning from the far end of the ray.
+
+    For each window, the median phase value is computed. The phase difference
+    between the last and first window is returned together with diagnostic
+    information.
+
+    Parameters
+    ----------
+    phidp : xarray.DataArray
+        Input phase-like data indexed by a coordinate named ``range``.
+        NaN values are treated as missing data.
+    rng : float
+        Desired window width in the same units as ``phidp.range``.
+        The actual width used is the smallest whole-gate window that spans at
+        least ``rng``.
+
+    Keyword Arguments
+    -----------------
+    min_periods : int
+        Minimum number of valid samples required within a rolling window.
+        Defaults to the full window size.
+
+    Returns
+    -------
+    xarray.Dataset
+        Dataset containing:
+
+        phib : xarray.DataArray
+            Rolling count of valid observations.
+        start_range : xarray.DataArray
+            Left edge of the first densest window.
+        stop_range : xarray.DataArray
+            Right edge of the last densest window.
+        first : xarray.DataArray
+            Median phase within the first densest window.
+        first_idx : xarray.DataArray
+            Index of the left edge of the first densest window.
+        last : xarray.DataArray
+            Median phase within the last densest window.
+        last_idx : xarray.DataArray
+            Index of the right edge of the last densest window.
+        dphi : xarray.DataArray
+            Difference between ``last`` and ``first``. Total :math:`\Delta \Phi_{DP}`.
+        center_span : float
+            center-to-center span of selected bins
+
+    Notes
+    -----
+    - Assumes uniform spacing along ``phi.range``.
+    - The rolling count is computed using ``center=False``.
+    - If multiple windows contain the same maximum number of valid
+      observations, the first occurrence is selected.
+    - ``start_range`` refers to the left edge of the first densest window.
+    - ``stop_range`` refers to the right edge of the last densest window.
+    - The actual window width may be slightly larger than ``rng`` because
+      whole range bins are used.
+    """
+
+    rstep = _get_range_step(phidp)
+
+    # smallest whole-gate window spanning at least rng
+    N = _get_bins_from_range(phidp, rng)
+
+    # distance between first and last gate centers
+    center_span = (N - 1) * rstep
+
+    # binary mask of valid data
+    phib = phidp.notnull().astype(np.int8)
+
+    min_periods = kwargs.get("min_periods", N)
+
+    # count valid bins in rolling window
+    # coordinate is anchored at the right edge of the window
+    phib_sum = phib.rolling(range=N, center=False, min_periods=min_periods).sum(
+        skipna=True
+    )
+
+    # first densest window
+    window_end = phib_sum.idxmax(dim="range")
+    window_end_idx = phib_sum.argmax(dim="range")
+
+    start_range = window_end - center_span
+    start_range_idx = window_end_idx - (N - 1)
+
+    first = phidp.where(
+        (phidp.range >= start_range) & (phidp.range <= window_end)
+    ).median("range", skipna=True)
+
+    # last densest window
+    rev = phib_sum[..., ::-1]
+
+    stop_range = rev.idxmax(dim="range")
+    stop_range_idx = phib_sum.sizes["range"] - rev.argmax(dim="range") - 1
+
+    last = phidp.where(
+        (phidp.range >= stop_range - center_span) & (phidp.range <= stop_range)
+    ).median("range", skipna=True)
+
+    return xr.Dataset(
+        dict(
+            phib=phib_sum,
+            start_range=start_range,
+            stop_range=stop_range,
+            first=first,
+            first_idx=start_range_idx,
+            last=last,
+            last_idx=stop_range_idx,
+            dphi=last - first,
+            center_span=center_span,
+        )
+    )
+
+
 class DpMethods(util.XarrayMethods):
     """wradlib xarray SubAccessor methods for DualPol."""
+
+    @util.docstring(delta_phidp)
+    def delta_phidp(self, *args, **kwargs):
+        if not isinstance(self, DpMethods):
+            return delta_phidp(self, *args, **kwargs)
+        else:
+            return delta_phidp(self._obj, *args, **kwargs)
 
     @util.docstring(_depolarization_xarray)
     def depolarization(self, *args, **kwargs):

--- a/wradlib/dp.py
+++ b/wradlib/dp.py
@@ -1355,6 +1355,10 @@ def delta_phidp(phidp, rng, **kwargs):
     - ``stop_range`` refers to the right edge of the last densest window.
     - The actual window width may be slightly larger than ``rng`` because
       whole range bins are used.
+
+    Examples
+    --------
+    See :ref:`Core Features - Dual-Pol - Total Differential Phase Shift <delta_phidp_main_header>`.
     """
 
     rstep = _get_range_step(phidp)

--- a/wradlib/qual.py
+++ b/wradlib/qual.py
@@ -384,13 +384,10 @@ def estimate_snr(dbz, rng, noise_level, gas_att):
     ----------
     dbz : array_like
         Equivalent radar reflectivity factor in dBZ.
-
     rng : array_like
         Range from radar in meters (m).
-
     noise_level : float or array_like
         Receiver noise level expressed in dB (consistent with dbz scaling).
-
     gas_att : float
         Effective gaseous attenuation coefficient in dB/km.
         This parameter represents a *two-way radar-path attenuation*
@@ -403,11 +400,12 @@ def estimate_snr(dbz, rng, noise_level, gas_att):
 
     Notes
     -----
-    The SNR is computed as:
+    The SNR is computed as::
 
         SNR = dbz - 20 * log10(rng_km) - noise_level - gas_att * rng_km
 
     where:
+
     - 20 * log10(rng) represents two-way geometric spreading loss
     - gas_att is an effective attenuation coefficient (dB/km),
       typically including round-trip propagation effects

--- a/wradlib/tests/test_atten.py
+++ b/wradlib/tests/test_atten.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 
 import numpy as np
 import pytest
+import wradlib_data
+import xarray as xr
 
 from wradlib import atten, io
 
@@ -192,3 +194,147 @@ def test_bisect_reference_attenuation(att_data):
     assert np.allclose(result, goodresult)
     assert np.allclose(amid, goodamid)
     assert np.allclose(b, goodb)
+
+
+@pytest.fixture
+def simple_phidp_dbz():
+    r = np.arange(200) * 100.0
+
+    phidp = xr.DataArray(
+        np.linspace(0, 30, 200),
+        coords={"range": r},
+        dims="range",
+    )
+
+    phidp[60:120] += 10.0
+    phidp[150] = np.nan
+
+    dbz = xr.DataArray(
+        40 - 0.05 * np.arange(200),
+        coords={"range": r},
+        dims="range",
+        name="DBZH",
+    )
+
+    return phidp, dbz
+
+
+def test_specific_attenuation_output_structure(simple_phidp_dbz):
+    phidp, dbz = simple_phidp_dbz
+
+    out = atten.specific_attenuation_zphi(phidp, dbz, alpha=0.3, b=0.6, rng=2000.0)
+
+    assert isinstance(out, xr.DataArray)
+    assert out.dims == ("range",)
+
+    assert "units" in out.attrs
+    assert out.attrs["units"] == "dB/km"
+    assert "standard_name" in out.attrs
+    assert "long_name" in out.attrs
+    assert "short_name" in out.attrs
+
+
+def test_specific_attenuation_finite(simple_phidp_dbz):
+    phidp, dbz = simple_phidp_dbz
+
+    out = atten.specific_attenuation_zphi(phidp, dbz, alpha=0.3, b=0.6, rng=2000.0)
+
+    assert np.all(np.isfinite(out.values))
+    assert np.nanmin(out.values) >= 0
+
+
+def test_specific_attenuation_alpha_broadcast(simple_phidp_dbz):
+    phidp, dbz = simple_phidp_dbz
+
+    out_scalar = atten.specific_attenuation_zphi(
+        phidp, dbz, alpha=0.3, b=0.6, rng=2000.0
+    )
+
+    out_vector = atten.specific_attenuation_zphi(
+        phidp, dbz, alpha=[0.2, 0.3], b=0.6, rng=2000.0
+    )
+
+    assert "alpha" in out_vector.dims
+    assert out_vector.sizes["alpha"] == 2
+    assert out_vector.sizes["range"] == out_scalar.sizes["range"]
+
+
+def test_specific_attenuation_depends_on_phidp(simple_phidp_dbz):
+    phidp, dbz = simple_phidp_dbz
+
+    out1 = atten.specific_attenuation_zphi(phidp, dbz, alpha=0.3, b=0.6, rng=2000.0)
+
+    phidp2 = phidp + 5.0  # perturb phase
+    out2 = atten.specific_attenuation_zphi(phidp2, dbz, alpha=0.3, b=0.6, rng=2000.0)
+
+    assert np.allclose(out1.values, out2.values)
+
+
+def test_specific_attenuation_data():
+    fname = wradlib_data.DATASETS.fetch("hdf5/2014-08-10--182000.ppi.mvol")
+    with xr.open_dataset(fname, engine="gamic", group="sweep_0") as swp:
+        mask = swp.RHOHV > 0.9
+        phidp = swp.PHIDP.where(mask)
+        dbz = swp.DBZH.where(mask)
+
+    out1 = atten.specific_attenuation_zphi(phidp, dbz, 0.28, 0.78, rng=2000.0)
+    out2 = phidp.wrl.atten.specific_attenuation_zphi(dbz, 0.28, 0.78, rng=2000.0)
+
+    out1 = out1.max("range").sel(azimuth=slice(100, 150))
+    out2 = out2.max("range").sel(azimuth=slice(100, 150))
+    wanted = np.array(
+        [
+            1.07407273,
+            0.50883621,
+            0.5075296,
+            0.70262613,
+            1.17170939,
+            1.04093076,
+            0.6277884,
+            0.40821078,
+            0.87730694,
+            1.09753143,
+            1.15603688,
+            0.9731284,
+            3.14065076,
+            1.39616165,
+            1.28489366,
+            1.62729008,
+            1.65306511,
+            1.10869691,
+            1.77924222,
+            2.24248579,
+            0.58178274,
+            2.52007878,
+            1.71641173,
+            1.13451356,
+            0.36279973,
+            0.54705892,
+            0.5706312,
+            0.75613272,
+            0.82019211,
+            1.41853458,
+            1.36950221,
+            1.31224489,
+            1.57759488,
+            1.61514931,
+            2.13054111,
+            1.25734168,
+            1.26039325,
+            1.00678335,
+            0.96663833,
+            0.48267999,
+            0.69075709,
+            1.28177211,
+            1.21027243,
+            1.45197661,
+            1.90574993,
+            2.31374573,
+            2.82394853,
+            1.99345444,
+            1.50467872,
+            1.16656558,
+        ]
+    )
+    np.testing.assert_allclose(out1.values, wanted)
+    np.testing.assert_allclose(out2.values, wanted)

--- a/wradlib/tests/test_atten.py
+++ b/wradlib/tests/test_atten.py
@@ -336,5 +336,5 @@ def test_specific_attenuation_data():
             1.16656558,
         ]
     )
-    np.testing.assert_allclose(out1.values, wanted)
-    np.testing.assert_allclose(out2.values, wanted)
+    np.testing.assert_allclose(out1.values, wanted, atol=1e-6)
+    np.testing.assert_allclose(out2.values, wanted, atol=1e-6)

--- a/wradlib/tests/test_dp.py
+++ b/wradlib/tests/test_dp.py
@@ -335,11 +335,12 @@ def test_system_phidp():
             133.5,
             134.0,
             134.5,
+            135.0,
             np.nan,
             np.nan,
         ],
         dims=["range"],
-        coords={"range": np.arange(19) * 250.0},
+        coords={"range": np.arange(20) * 250.0},
         name="PHIDP",
     ).expand_dims(azimuth=[0])
 
@@ -387,8 +388,8 @@ def test_system_phidp_xarray():
     res_first = phase.wrl.dp.system_phidp_first()
     res_hist = phase.wrl.dp.system_phidp_hist()
 
-    assert res_block["sysphi"].item() == pytest.approx(-80.128479)
-    assert res_window["sysphi"].item() == pytest.approx(-80.315254)
+    assert res_block["sysphi"].item() == pytest.approx(-80.149078)
+    assert res_window["sysphi"].item() == pytest.approx(-80.348213)
     assert res_first["sysphi"].item() == pytest.approx(-80.651726)
     assert res_hist["sysphi_peak"].item() == pytest.approx(-80.55)
     assert res_hist["sysphi_first"].item() == pytest.approx(-81.6)
@@ -433,3 +434,85 @@ def test_rhohv_noise_correction_xarray():
     xr.testing.assert_allclose(result, expected)
 
     assert result.name.endswith("_NC")
+
+
+def make_phi():
+    r = np.arange(20)
+
+    data = np.full(20, np.nan)
+    data[6:14] = np.arange(8)
+
+    return xr.DataArray(
+        data,
+        coords={"range": r},
+        dims="range",
+    )
+
+
+def test_delta_phidp_basic_properties():
+    phi = make_phi()
+
+    out = dp.delta_phidp(phi, rng=5.0)
+
+    assert isinstance(out, xr.Dataset)
+
+    for key in [
+        "phib",
+        "start_range",
+        "stop_range",
+        "first",
+        "first_idx",
+        "last",
+        "last_idx",
+        "dphi",
+        "center_span",
+    ]:
+        assert key in out
+
+    assert np.isfinite(out["start_range"].item())
+    assert np.isfinite(out["stop_range"].item())
+
+    np.testing.assert_allclose(
+        out["dphi"],
+        out["last"] - out["first"],
+    )
+
+
+def test_delta_phidp_finds_first_and_last_densest_windows():
+    phi = make_phi()
+
+    out = dp.delta_phidp(phi, rng=5.0)
+
+    assert out["start_range"].item() == 6
+    assert out["first_idx"].item() == 6
+
+    assert out["stop_range"].item() == 13
+    assert out["last_idx"].item() == 13
+
+    assert out["center_span"].item() == 4
+
+
+def test_delta_phidp():
+    fname = wradlib_data.DATASETS.fetch("hdf5/2014-08-10--182000.ppi.mvol")
+    with xr.open_dataset(fname, engine="gamic", group="sweep_0") as swp:
+        phase = swp.PHIDP.where(swp.RHOHV > 0.9)
+
+    out = dp.delta_phidp(phase, rng=2000.0)
+    np.testing.assert_allclose(out["first"][0].values, -78.62331)
+    np.testing.assert_allclose(out["first_idx"][0].values, 44)
+    np.testing.assert_allclose(out["last"][0].values, -78.203064)
+    np.testing.assert_allclose(out["last_idx"][0].values, 569)
+    np.testing.assert_allclose(out["dphi"][0].values, 0.420242, rtol=1e-6)
+
+
+def test_delta_phidp_xarray():
+    fname = wradlib_data.DATASETS.fetch("hdf5/2014-08-10--182000.ppi.mvol")
+    with xr.open_dataset(fname, engine="gamic", group="sweep_0") as swp:
+        phase = swp.PHIDP.where(swp.RHOHV > 0.9)
+
+    out = phase.wrl.dp.delta_phidp(rng=2000.0)
+    np.testing.assert_allclose(out["first"][0].values, -78.62331)
+    np.testing.assert_allclose(out["first_idx"][0].values, 44)
+    np.testing.assert_allclose(out["last"][0].values, -78.203064)
+    np.testing.assert_allclose(out["last_idx"][0].values, 569)
+    np.testing.assert_allclose(out["dphi"][0].values, 0.420242, rtol=1e-6)

--- a/wradlib/util.py
+++ b/wradlib/util.py
@@ -47,7 +47,7 @@ from functools import singledispatch
 
 import numpy as np
 import xarray as xr
-from scipy import ndimage, signal
+from scipy import integrate, ndimage, signal
 from scipy.spatial import KDTree
 
 from wradlib import georef, version
@@ -1774,6 +1774,19 @@ def bbox(*args):
             min(mins_y),
             max(maxs_y),
         ]
+    )
+
+
+def cumtrapz_xarray(da):
+    """xarray wrapper for scipy.cumtrapz"""
+    dr = da.range.diff("range").median("range").values / 1000.0
+    return xr.apply_ufunc(
+        integrate.cumulative_trapezoid,
+        da,
+        input_core_dims=[["range"]],
+        output_core_dims=[["range"]],
+        dask="parallelized",
+        kwargs=dict(dx=dr, initial=0.0, axis=-1),
     )
 
 


### PR DESCRIPTION
This moves the existing ZPHI code used by radar group Bonn into wradlib. Code has been cleaned and adapted. Added example notebooks, too.

- estimation of total differential phaseshift including start and stop locations
- calculation of specific attenuation via ZPHI method
- aligned with estimation code for system phidp (still some refactoring possible)