### PR TITLE
FIX: set z coordinate units to meters in georeference

### DIFF
--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -7,6 +7,12 @@ Please note that {{wradlib}} releases follow [semantic versioning](https://semve
 
 You can install the latest {{wradlib}} release from PyPI via ``$ python -m pip install wradlib`` or specific version via ``$ pip install wradlib==x.y.z``. The recommended installation process is described in {doc}`installation`.
 
+## Version 2.9.6
+
+**Bugfixes**
+
+* set units of the `z` coordinate to meters in {func}`wradlib.georef.georeference` instead of inheriting the units of `x`, and use meters for `gr` on geographic CRS ({issue}`791`) reported by {at}`aladinor`, ({pull}`XXX`) by {at}`aladinor`
+
 ## Version 2.9.5
 
 **Bugfixes**

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -11,7 +11,7 @@ You can install the latest {{wradlib}} release from PyPI via ``$ python -m pip i
 
 **Bugfixes**
 
-* set units of the `z` coordinate to meters in {func}`wradlib.georef.georeference` instead of inheriting the units of `x`, and use meters for `gr` on geographic CRS ({issue}`791`) reported by {at}`aladinor`, ({pull}`XXX`) by {at}`aladinor`
+* set units of the `z` coordinate to meters in {func}`wradlib.georef.georeference` instead of inheriting the units of `x`, and use meters for `gr` on geographic CRS ({issue}`791`) reported by {at}`aladinor`, ({pull}`792`) by {at}`aladinor`
 
 ## Version 2.9.5
 

--- a/wradlib/georef/polar.py
+++ b/wradlib/georef/polar.py
@@ -1136,9 +1136,9 @@ def georeference(obj, **kwargs):
     cf_by_axis = {c["axis"]: c for c in cf_coords}
     x_attrs = cf_by_axis.get("X")
     y_attrs = cf_by_axis.get("Y")
-    unit = x_attrs["units"]
-    z_attrs = {"standard_name": "height_above_ground", "units": unit}
-    gr_attrs = {"standard_name": "distance_from_radar", "units": unit}
+    gr_unit = "meters" if trg_crs.is_geographic else x_attrs["units"]
+    z_attrs = {"standard_name": "height_above_ground", "units": "meters"}
+    gr_attrs = {"standard_name": "distance_from_radar", "units": gr_unit}
     obj.coords["x"] = (dimlist, xyz[..., 0], x_attrs)
     obj.coords["y"] = (dimlist, xyz[..., 1], y_attrs)
     obj.coords["z"] = (dimlist, xyz[..., 2], z_attrs)

--- a/wradlib/tests/test_georef.py
+++ b/wradlib/tests/test_georef.py
@@ -1606,6 +1606,31 @@ def test_georeference_dataset(xr_data):
     xr.testing.assert_equal(xr_data, da)
 
 
+@pytest.mark.parametrize(
+    "crs,gr_follows_x",
+    [(None, True), (4979, False), (3433, True)],
+    ids=["aeqd", "geographic", "projected_feet"],
+)
+def test_georeference_z_gr_units(crs, gr_follows_x):
+    # z is a beam height in meters whatever the target CRS is, so it must not
+    # inherit the units of x as it did before GH791. gr keeps the CRS units,
+    # which ground_range only computes in meters for a geographic CRS.
+    da = georef.create_xarray_dataarray(
+        np.random.rand(360, 100),
+        r=np.arange(500.0, 100000.0, 1000.0),
+        phi=np.arange(0.5, 360.0),
+        theta=np.ones(360) * 0.5,
+        site=(-92.0, 35.0, 100.0),
+        sweep_mode="azimuth_surveillance",
+    )
+    da = georef.georeference(da, crs=crs)
+
+    assert da.z.attrs["units"] == "meters"
+    assert da.gr.attrs["units"] == (da.x.attrs["units"] if gr_follows_x else "meters")
+    # z really is in meters, it would be O(1) if it had been left in degrees
+    assert da.z.max() > 1000.0
+
+
 @requires_gdal
 def test_ensure_crs_pyproj():
     crs_pyproj = pyproj.CRS.from_epsg(4326)


### PR DESCRIPTION
 - [x] Closes #791
 - [x] Tests added
 - [x] Passes `black . && ruff check .`
 - [x] Fully documented (e.g. docstrings)

`georeference()` derived a single `unit` from the x-axis of the target CRS and applied it to both `z` and `gr`. Under a geographic CRS that labels `z` — a beam height in meters — as `degrees_east`, as reported in #791.

`z` is now always `meters`. It never depends on the target CRS: `spherical_to_xyz` always builds a 2-axis AEQD source, so PROJ passes `z` through untouched even for a compound CRS whose vertical axis is in feet (verified against EPSG:8712).

`gr` needed a different treatment rather than the same hardcoding. `misc.ground_range` computes a geodesic distance in meters for a geographic CRS, but a euclidean distance in *CRS units* for a projected one, so `gr` now follows the CRS except when geographic.

Same sweep through six CRSs, after the change:

| target CRS | `x` units | `gr` units | `gr.max` | `z.max` |
| --- | --- | --- | ---: | ---: |
| `None` (native AEQD) | `metre` | `metre` | 99480.3 | 1550.9 |
| EPSG:4326 (geographic 2D) | `degrees_east` | `meters` | 99480.3 | 1550.9 |
| EPSG:4979 (geographic 3D) | `degrees_east` | `meters` | 99480.3 | 1550.9 |
| EPSG:3857 (projected, m) | `metre` | `metre` | 122526.3 | 1550.9 |
| EPSG:3433 (projected, ftUS) | `0.3048006... metre` | `0.3048006... metre` | 326413.3 | 1550.9 |
| EPSG:8712 (compound, ftUS) | `0.3048006... metre` | `0.3048006... metre` | 326413.3 | 1550.9 |

Only the numeric metadata changes; no coordinate values are touched.

### Notes for reviewers

`meters` is used rather than pyproj's `metre` to match `xradar.model.get_altitude_attrs()` / `get_range_attrs()`, which `georef/misc.py` already uses for `bin_altitude` / `bin_distance`. This does change the AEQD default path for `z` from `metre` to `meters`. Happy to switch if you would rather keep the pyproj spelling, though it then disagrees with the neighbouring functions.

Two pre-existing issues in `misc.ground_range` surfaced while working on this, both left alone as out of scope — happy to open a separate issue:

1. The projected branch is a bare `sqrt(dx**2 + dy**2)` in CRS units, with the comment *"Assume CRS units are meters"*, while the docstring promises meters. That is why `gr` has to inherit the CRS units here instead of the function guaranteeing them.
2. For conformal projections that distance is not a ground range at all. The EPSG:3857 row above reads 122526 against 99480 everywhere else — Web Mercator's `sec(35°)` inflation — so the value is unit-correct but semantically wrong for a coordinate carrying `standard_name="distance_from_radar"`.

### Tests

`test_georeference_z_gr_units` is parametrized over AEQD, geographic and a US-survey-foot projected CRS. It fails on all three params against the current `main`.